### PR TITLE
Getting the testGetStorage test passing.

### DIFF
--- a/tests/VCR/ConfigurationTest.php
+++ b/tests/VCR/ConfigurationTest.php
@@ -55,10 +55,10 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->config->setStorage('Does not exist');
     }
 
-    public function testGetStorag()
+    public function testGetStorage()
     {
         $class = $this->config->getStorage();
-        $this->assertTrue(in_array("\VCR\Storage\StorageInterface", class_implements($class)));
+        $this->assertTrue(in_array("VCR\Storage\StorageInterface", class_implements($class)) || in_array("\VCR\Storage\StorageInterface", class_implements($class)));
     }
 
 }


### PR DESCRIPTION
The storage interface is present without the preceding slash in my environment.  I added an OR to the test logic in case this is just an environmental difference.
