### PR TITLE
Explicitly setting the version of beberlie/assert to a stable tag.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-curl": "*",
         "guzzle/http": "3.5.*",
         "guzzle/plugin-backoff": "3.5.*",
-        "beberlei/assert": "dev-master",
+        "beberlei/assert": "1.*",
         "symfony/yaml": "2.*"
     },
 


### PR DESCRIPTION
This is to resolve the issue of installing a dev stable package in an dependency.  This will prevent users having to explicitly define a lower minimum-stability in their root composer.json file, or having to explicitly set the dev stability for beberlei/assert.

I've confirmed tests still pass with this change, but as the package version 1.2 (the current latest) for beberlei/assert is from fall 2012, if there's any recent changes you need this fix might not work.
