### PR TITLE
Fixed: error when transforming curl method names to local mehtod name

### DIFF
--- a/src/VCR/LibraryHooks/CurlRewrite.php
+++ b/src/VCR/LibraryHooks/CurlRewrite.php
@@ -225,7 +225,7 @@ class CurlRewrite implements LibraryHookInterface
         $localMethod = preg_replace_callback(
             '/_(.?)/',
             function($matches) {
-                return strtoupper($matches[0]);
+                return strtoupper($matches[1]);
             },
             $localMethod
         );

--- a/tests/VCR/LibraryHooks/CurlRewriteTest.php
+++ b/tests/VCR/LibraryHooks/CurlRewriteTest.php
@@ -175,6 +175,23 @@ class CurlRewriteTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider curlMethodsProvider
+     */
+    public function testBuildLocalMethodName($expected, $method)
+    {
+        $this->assertEquals($expected, CurlRewriteProxy::buildLocalMethodName($method));
+    }
+    public function curlMethodsProvider()
+    {
+        return array(
+            'curl_multi_add_handler' => array('multiAddHandler', 'curl_multi_add_handler'),
+            'curl_add_handler' => array('addHandler', 'curl_add_handler'),
+            'not a curl function' => array('exec', 'curl_exec'),
+        );
+    }
+
+
+    /**
      * @return \callable
      */
     protected function getTestCallback($handleRequestCallback = null)
@@ -185,3 +202,12 @@ class CurlRewriteTest extends \PHPUnit_Framework_TestCase
         };
     }
 }
+
+
+ class CurlRewriteProxy extends CurlRewrite
+ {
+     public static function buildLocalMethodName($method)
+    {
+        return parent::buildLocalMethodName($method);
+    }
+ }


### PR DESCRIPTION
the PR verifies that the name of the intended 'local' method to be invoked is transformed correctly.
