### PR TITLE
Switch content type depending on SOAP version.

### DIFF
--- a/src/VCR/LibraryHooks/Soap.php
+++ b/src/VCR/LibraryHooks/Soap.php
@@ -57,7 +57,8 @@ class Soap implements LibraryHookInterface
         }
 
         $vcrRequest = new Request('POST', $location);
-        $vcrRequest->addHeader('Content-Type', 'application/soap+xml; charset=utf-8; action="' . $action . '"');
+        $contentType = ($version == SOAP_1_2) ? 'application/soap+xml' : 'text/xml';
+        $vcrRequest->addHeader('Content-Type', $contentType . '; charset=utf-8; action="' . $action . '"');
         $vcrRequest->setBody($request);
 
         $handleRequestCallback = self::$handleRequestCallback;


### PR DESCRIPTION
[SOAP 1.1 uses a different content type than SOAP 1.2](http://www.herongyang.com/Web-Services/Perl-SOAP-1-2-Request-Differences-SOAP-1-1-and-1-2.html) so we should switch
accordingly. Current version assumes 1.2.
