### PR TITLE
Fix pattern for classes extending SoapClient.

### DIFF
--- a/src/VCR/LibraryHooks/Soap/Filter.php
+++ b/src/VCR/LibraryHooks/Soap/Filter.php
@@ -15,7 +15,7 @@ class Filter extends AbstractFilter
 
     private static $patterns = array(
         '@new\s+\\\?SoapClient\W*\(@i',
-        '@extends\s+SoapClient\W*@i',
+        '@extends\s+\\\?SoapClient@i',
     );
 
     /**


### PR DESCRIPTION
As I see it the current pattern has two problems:
- It does not match \SoapClient
- It matches any non-word characters after SoapClient. Thus line breaks and the beginning of docblocks are included and replaced.

One problem I have seen after this change is that `VCR\Util\Soap\SoapClient` is updated as well. I have fixed this locally by adding the path to the blacklist, but I am not sure whether this is the right way to go about this.
