### PR TITLE
Fix exception namespaces.

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -192,7 +192,7 @@ class StreamProcessor
         $this->restore();
         try {
             $result = @stat($path);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $result = false;
         }
         $this->intercept();


### PR DESCRIPTION
All exceptions should be caught here. VCR\Util\Exception is not defined.
