### PR TITLE
Fixed: Suppressed ErrorExceptions when running PHPUnit with `processIsolation="true"`

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -192,8 +192,13 @@ class StreamProcessor
         $this->restore();
         try {
             $result = @stat($path);
-        } catch (Exception $e) {
-            $result = false;
+        } catch (\ErrorException $e) {
+            // PHPUnit running in process isolation (processIsolation="true")
+            // throws an \ErrorException for any PHP warning.
+
+            // In this case we surpress errors.
+            // See https://github.com/php-vcr/php-vcr/pull/35 for more information.
+            return;
         }
         $this->intercept();
         return $result;


### PR DESCRIPTION
In #33 it was discovered that when running PHPUnit with `processIsolation="true"` an [error handler is set](https://github.com/sebastianbergmann/phpunit/blob/master/src/Util/PHP.php#L138-L140) which throws `\ErrorException`s for any userland warnings/errors.

In this case errors should be suppressed. 
