### PR TITLE
Fix for request matcher missing query string differences

### DIFF
--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -28,12 +28,13 @@ class Configuration
     // All are enabled by default
     private $enabledRequestMatchers;
     private $availableRequestMatchers = array(
-        'method'      => array('VCR\RequestMatcher', 'matchMethod'),
-        'url'         => array('VCR\RequestMatcher', 'matchUrl'),
-        'host'        => array('VCR\RequestMatcher', 'matchHost'),
-        'headers'     => array('VCR\RequestMatcher', 'matchHeaders'),
-        'body'        => array('VCR\RequestMatcher', 'matchBody'),
-        'post_fields' => array('VCR\RequestMatcher', 'matchPostFields'),
+        'method'       => array('VCR\RequestMatcher', 'matchMethod'),
+        'url'          => array('VCR\RequestMatcher', 'matchUrl'),
+        'host'         => array('VCR\RequestMatcher', 'matchHost'),
+        'headers'      => array('VCR\RequestMatcher', 'matchHeaders'),
+        'body'         => array('VCR\RequestMatcher', 'matchBody'),
+        'post_fields'  => array('VCR\RequestMatcher', 'matchPostFields'),
+        'query_string' => array('VCR\RequestMatcher', 'matchQueryString'),
     );
     private $whiteList = array();
     private $blackList = array('src/VCR/LibraryHooks/', 'src/VCR/Util/Soap/SoapClient');

--- a/src/VCR/RequestMatcher.php
+++ b/src/VCR/RequestMatcher.php
@@ -61,4 +61,11 @@ class RequestMatcher
         return true;
     }
 
+    public static function matchQueryString(Request $first, Request $second)
+    {
+        if (null !== $first->getQuery(true) && $first->getQuery(true) != $second->getQuery(true)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/tests/VCR/RequestMatcherTest.php
+++ b/tests/VCR/RequestMatcherTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace VCR;
+
+class RequestMatcherTest extends \PHPUnit_Framework_TestCase
+{
+    public function testMatchingMethod()
+    {
+        $first = new Request('GET', 'http://example.com', array());
+        $second = new Request('GET', 'http://example.com', array());
+
+        $this->assertTrue(RequestMatcher::matchMethod($first, $second));
+
+        $first = new Request('GET', 'http://example.com', array());
+        $second = new Request('POST', 'http://example.com', array());
+
+        $this->assertFalse(RequestMatcher::matchMethod($first, $second));
+    }
+
+    public function testMatchingUrl()
+    {
+        $first = new Request('GET', 'http://example.com/common/path', array());
+        $second = new Request('GET', 'http://example.com/common/path', array());
+
+        $this->assertTrue(RequestMatcher::matchUrl($first, $second));
+
+        $first = new Request('GET', 'http://example.com/first/path', array());
+        $second = new Request('GET', 'http://example.com/second/path', array());
+
+        $this->assertFalse(RequestMatcher::matchUrl($first, $second));
+    }
+
+    public function testMatchingHost()
+    {
+        $first = new Request('GET', 'http://example.com/common/path', array());
+        $second = new Request('GET', 'http://example.com/common/path', array());
+
+        $this->assertTrue(RequestMatcher::matchHost($first, $second));
+
+        $first = new Request('GET', 'http://example.com/first/path', array());
+        $second = new Request('GET', 'http://elpmaxe.com/second/path', array());
+
+        $this->assertFalse(RequestMatcher::matchHost($first, $second));
+    }
+
+    public function testMatchingHeaders()
+    {
+        $first = new Request('GET', 'http://example.com', array(
+            'Accept' => 'Everything',
+        ));
+        $second = new Request('GET', 'http://example.com', array(
+            'Accept' => 'Everything',
+        ));
+
+        $this->assertTrue(RequestMatcher::matchHeaders($first, $second));
+
+        $first = new Request('GET', 'http://example.com', array(
+            'Accept' => 'Everything',
+        ));
+        $second = new Request('GET', 'http://example.com', array(
+            'Accept' => 'Nothing',
+        ));
+
+        $this->assertFalse(RequestMatcher::matchHeaders($first, $second));
+    }
+
+    public function testMatchingPostFields()
+    {
+        $mock = array(
+            'method' => 'POST',
+            'url' => 'http://example.com',
+            'headers' => array(),
+            'post_fields' => array(
+                'field1' => 'value1',
+                'field2' => 'value2',
+            )
+        );
+
+        $first = Request::fromArray($mock);
+        $second = Request::fromArray($mock);
+
+        $this->assertTrue(RequestMatcher::matchPostFields($first, $second));
+
+        $mock['post_fields']['field2'] = 'changedvalue2';
+        $third = Request::fromArray($mock);
+
+        $this->assertFalse(RequestMatcher::matchPostFields($first, $third));
+    }
+
+    public function testMatchingQueryString()
+    {
+        $first = new Request('GET', 'http://example.com/search?query=test', array());
+        $second = new Request('GET', 'http://example.com/search?query=test', array());
+
+        $this->assertTrue(RequestMatcher::matchQueryString($first, $second));
+
+        $first = new Request('GET', 'http://example.com/search?query=first', array());
+        $second = new Request('GET', 'http://example.com/search?query=second', array());
+
+        $this->assertFalse(RequestMatcher::matchQueryString($first, $second));
+    }
+}


### PR DESCRIPTION
The submitted pull request fixes an issue where the request matcher doesn't take into account the query string of the request being made.

If a fixture exists that covers "http://example.com/search?query=first", the same fixture response would be used for "http://example.com/search?query=second", "http://example.com/search?query=third", etc.
