### PR TITLE
Fix: Using VCR with Guzzle results in duplicated Host headers.

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -116,11 +116,16 @@ class CurlHelper
                 $headers = array();
                 foreach ($value as $header) {
                     $headerParts = explode(': ', $header, 2);
+
                     if (isset($headerParts[1])) {
-                        $headers[$headerParts[0]] = $headerParts[1];
+                        if (strtolower($headerParts[0]) == 'host') {
+                            $request->setHeader($headerParts[0], $headerParts[1]);
+                        } else {
+                            $request->addHeader($headerParts[0], $headerParts[1]);
+                        }
                     }
                 }
-                $request->addHeaders($headers);
+
                 break;
             case CURLOPT_WRITEFUNCTION:
             case CURLOPT_HEADERFUNCTION:


### PR DESCRIPTION
Using php-vcr in conjunction with Guzzle results in php-vcr duplicating the host header. `\VCR\Util\CurlHelper::setCurlOptionOnRequest`  sets it during the `CURLOPT_URL` and `CURLOPT_HTTPHEADER` cases.  

Example:

```
\VCR\VCR::configure()->enableLibraryHooks(array('curl_rewrite'));
\VCR\VCR::turnOn();
\VCR\VCR::insertCassette('Demo');

$client = new Guzzle\Http\Client();
$request = $client->get('http://www.google.com');
$response = $request->send();
```

The host header that gets sent over the wire in the above example is:
`Host: www.google.com, www.google.com\r\n`
