### PR TITLE
Fix the yaml parser bug when running in windows

### DIFF
--- a/src/VCR/Storage/Yaml.php
+++ b/src/VCR/Storage/Yaml.php
@@ -48,6 +48,13 @@ class Yaml implements Storage
      * @var  Dumper Yaml writer.
      */
     protected $yamlDumper;
+	
+	/**
+	 * Keep the tracking of the character before last character
+	 *
+	 * @var type 
+	 */
+	private $_charBuffer;
 
     /**
      * Creates a new YAML based file store.
@@ -129,7 +136,7 @@ class Yaml implements Storage
         $lastChar = null;
 
         while (false !== ($char = fgetc($this->handle))) {
-            $isNewArrayStart = ($char === '-') && ($lastChar === PHP_EOL || $lastChar === null);
+            $isNewArrayStart = ($this->_isEOL($lastChar) || $lastChar === null) && ($char === '-');
             $lastChar = $char;
 
             if ($isInRecord && $isNewArrayStart) {
@@ -179,6 +186,26 @@ class Yaml implements Storage
 
         return ! is_null($this->current) && $this->valid;
     }
+	
+	/**
+	 * A proper function to detect the end of line
+	 * 
+	 */
+	private function _isEOL($char)
+	{
+		if ($char == PHP_EOL)
+		{
+			return true;
+		}
+		elseif ($char == chr(10))
+		{
+			// check if this char is '\r' and the previous character is '\n'
+			return ($this->_charBuffer == chr(13));
+		}
+		// replace this char into buffer
+		$this->_charBuffer = $char;
+		return false;
+	}
 
     /**
      * Closes file handle.


### PR DESCRIPTION
I have used **php-vcr** in my project. When unit testing, the PHPUnit failed silently if I using Yaml storage. The problem is solved when I change the storage method from Yaml into Json.

After looking into the **php-vcr** source code. I believe that the bug comes from  [this line of code](https://github.com/php-vcr/php-vcr/blob/master/src/VCR/Storage/Yaml.php#L132). In windows, the `PHP_EOL` consists of two character, which make the condition `$lastChar === PHP_EOL` never true.
