### PR TITLE
Fixed #50: Always use unix line endings for YAML

### DIFF
--- a/src/VCR/Storage/Yaml.php
+++ b/src/VCR/Storage/Yaml.php
@@ -77,7 +77,7 @@ class Yaml implements Storage
     public function storeRecording(array $recording)
     {
         fseek($this->handle, -1, SEEK_END);
-        fwrite($this->handle, PHP_EOL . $this->yamlDumper->dump(array($recording), 4));
+        fwrite($this->handle, "\n" . $this->yamlDumper->dump(array($recording), 4));
         fflush($this->handle);
     }
 
@@ -129,7 +129,7 @@ class Yaml implements Storage
         $lastChar = null;
 
         while (false !== ($char = fgetc($this->handle))) {
-            $isNewArrayStart = ($char === '-') && ($lastChar === PHP_EOL || $lastChar === null);
+            $isNewArrayStart = ($char === '-') && ($lastChar === "\n" || $lastChar === null);
             $lastChar = $char;
 
             if ($isInRecord && $isNewArrayStart) {

--- a/tests/VCR/Storage/YamlTest.php
+++ b/tests/VCR/Storage/YamlTest.php
@@ -19,7 +19,7 @@ class YamlTest extends \PHPUnit_Framework_TestCase
     public function testIterateOneObject()
     {
         $this->iterateAndTest(
-            "-". PHP_EOL
+            "-". "\n"
             . "    para1: val1",
             array(
                 array('para1' => 'val1'),
@@ -31,9 +31,9 @@ class YamlTest extends \PHPUnit_Framework_TestCase
     public function testIterateTwoObjects()
     {
         $this->iterateAndTest(
-            "-". PHP_EOL
-            . "    para1: val1" . PHP_EOL
-            . "-". PHP_EOL
+            "-". "\n"
+            . "    para1: val1" . "\n"
+            . "-". "\n"
             . "   para2: val2",
             array(
                 array('para1' => 'val1'),
@@ -46,10 +46,10 @@ class YamlTest extends \PHPUnit_Framework_TestCase
     public function testIterateFirstNestedObject()
     {
         $this->iterateAndTest(
-            "-". PHP_EOL
-            . "    para1:" . PHP_EOL
-            . "        para2: val2" . PHP_EOL
-            . "-". PHP_EOL
+            "-". "\n"
+            . "    para1:" . "\n"
+            . "        para2: val2" . "\n"
+            . "-". "\n"
             . "    para3: val3",
             array(
                 array('para1' => array('para2' => 'val2')),
@@ -62,11 +62,11 @@ class YamlTest extends \PHPUnit_Framework_TestCase
     public function testIterateSecondNestedObject()
     {
         $this->iterateAndTest(
-            "-". PHP_EOL
-            . "    para1: val1" . PHP_EOL
-            . "-" . PHP_EOL
-            . "    para2:" . PHP_EOL
-            . "        para3: val3" . PHP_EOL,
+            "-". "\n"
+            . "    para1: val1" . "\n"
+            . "-" . "\n"
+            . "    para2:" . "\n"
+            . "        para3: val3" . "\n",
             array(
                 array('para1' => 'val1'),
                 array('para2' => array('para3' => 'val3')),


### PR DESCRIPTION
Fixes #50 Running PHP-VCR on Windows generates fixtures with Windows line endings.
To keep fixtures generated on different systems comparable, use UNIX line endings no matter what system is used. 

Editors on Windows should be able handle Unix file endings.
