### PR TITLE
Fixed #58: Allows curl functions to be pretended with a \.

### DIFF
--- a/src/VCR/CodeTransform/CurlCodeTransform.php
+++ b/src/VCR/CodeTransform/CurlCodeTransform.php
@@ -7,15 +7,15 @@ class CurlCodeTransform extends AbstractCodeTransform
     const NAME = 'vcr_curl';
 
     private static $patterns = array(
-        '/(?<!::|->)curl_init\s*\(/i'                => '\VCR\LibraryHooks\CurlHook::curl_init(',
-        '/(?<!::|->)curl_exec\s*\(/i'                => '\VCR\LibraryHooks\CurlHook::curl_exec(',
-        '/(?<!::|->)curl_getinfo\s*\(/i'             => '\VCR\LibraryHooks\CurlHook::curl_getinfo(',
-        '/(?<!::|->)curl_setopt\s*\(/i'              => '\VCR\LibraryHooks\CurlHook::curl_setopt(',
-        '/(?<!::|->)curl_setopt_array\s*\(/i'        => '\VCR\LibraryHooks\CurlHook::curl_setopt_array(',
-        '/(?<!::|->)curl_multi_add_handle\s*\(/i'    => '\VCR\LibraryHooks\CurlHook::curl_multi_add_handle(',
-        '/(?<!::|->)curl_multi_remove_handle\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_multi_remove_handle(',
-        '/(?<!::|->)curl_multi_exec\s*\(/i'          => '\VCR\LibraryHooks\CurlHook::curl_multi_exec(',
-        '/(?<!::|->)curl_multi_info_read\s*\(/i'     => '\VCR\LibraryHooks\CurlHook::curl_multi_info_read('
+        '/(?<!::|->)\\\?curl_init\s*\(/i'                => '\VCR\LibraryHooks\CurlHook::curl_init(',
+        '/(?<!::|->)\\\?curl_exec\s*\(/i'                => '\VCR\LibraryHooks\CurlHook::curl_exec(',
+        '/(?<!::|->)\\\?curl_getinfo\s*\(/i'             => '\VCR\LibraryHooks\CurlHook::curl_getinfo(',
+        '/(?<!::|->)\\\?curl_setopt\s*\(/i'              => '\VCR\LibraryHooks\CurlHook::curl_setopt(',
+        '/(?<!::|->)\\\?curl_setopt_array\s*\(/i'        => '\VCR\LibraryHooks\CurlHook::curl_setopt_array(',
+        '/(?<!::|->)\\\?curl_multi_add_handle\s*\(/i'    => '\VCR\LibraryHooks\CurlHook::curl_multi_add_handle(',
+        '/(?<!::|->)\\\?curl_multi_remove_handle\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_multi_remove_handle(',
+        '/(?<!::|->)\\\?curl_multi_exec\s*\(/i'          => '\VCR\LibraryHooks\CurlHook::curl_multi_exec(',
+        '/(?<!::|->)\\\?curl_multi_info_read\s*\(/i'     => '\VCR\LibraryHooks\CurlHook::curl_multi_info_read('
     );
 
     /**

--- a/tests/VCR/CodeTransform/CurlCodeTransformTest.php
+++ b/tests/VCR/CodeTransform/CurlCodeTransformTest.php
@@ -31,6 +31,15 @@ class CurlCodeTransformTest extends \PHPUnit_Framework_TestCase
             array('\VCR\LibraryHooks\CurlHook::curl_multi_exec(', 'curl_multi_exec('),
             array('\VCR\LibraryHooks\CurlHook::curl_multi_info_read(', 'curl_multi_info_read('),
 
+            array('\VCR\LibraryHooks\CurlHook::curl_init(', '\\CURL_INIT ('),
+            array('\VCR\LibraryHooks\CurlHook::curl_exec(', '\\curl_exec('),
+            array('\VCR\LibraryHooks\CurlHook::curl_getinfo(', '\\curl_getinfo('),
+            array('\VCR\LibraryHooks\CurlHook::curl_setopt(', '\\curl_setopt('),
+            array('\VCR\LibraryHooks\CurlHook::curl_multi_add_handle(', '\\curl_multi_add_handle('),
+            array('\VCR\LibraryHooks\CurlHook::curl_multi_remove_handle(', '\\curl_multi_remove_handle('),
+            array('\VCR\LibraryHooks\CurlHook::curl_multi_exec(', '\\curl_multi_exec('),
+            array('\VCR\LibraryHooks\CurlHook::curl_multi_info_read(', '\\curl_multi_info_read('),
+
             array('SomeClass::CURL_INIT (', 'SomeClass::CURL_INIT ('),
             array('SomeClass::curl_exec(', 'SomeClass::curl_exec('),
             array('SomeClass::curl_getinfo(', 'SomeClass::curl_getinfo('),


### PR DESCRIPTION
See #58.
