### PR TITLE
Pretty print the JSON if available (5.4+)

### DIFF
--- a/src/VCR/Storage/Json.php
+++ b/src/VCR/Storage/Json.php
@@ -19,7 +19,12 @@ class Json extends AbstractStorage
         if (filesize($this->filePath) > 2) {
             fwrite($this->handle, ',');
         }
-        fwrite($this->handle, json_encode($recording) . ']');
+        if (defined('JSON_PRETTY_PRINT')) {
+            $json = json_encode($recording, JSON_PRETTY_PRINT);
+        } else {
+            $json = json_encode($recording);
+        }
+        fwrite($this->handle, $json . ']');
         fflush($this->handle);
     }
 


### PR DESCRIPTION
The YAML format is great because it shows the request in a readable form. This does the same for JSON where it's available, by pretty printing it before writing to disk.
