### PR TITLE
Fixes search and replace across multiple buckets.

### DIFF
--- a/src/VCR/CodeTransform/AbstractCodeTransform.php
+++ b/src/VCR/CodeTransform/AbstractCodeTransform.php
@@ -57,6 +57,7 @@ abstract class AbstractCodeTransform extends \PHP_User_Filter
      *
      * @return int PSFS_PASS_ON | PSFS_FEED_ME
      *
+     * @link Implementation adapted from http://www.codediesel.com/php/creating-custom-stream-filters/
      * @link http://www.php.net/manual/en/php-user-filter.filter.php
      */
     public function filter($in, $out, &$consumed, $closing)

--- a/src/VCR/Storage/AbstractStorage.php
+++ b/src/VCR/Storage/AbstractStorage.php
@@ -75,7 +75,7 @@ abstract class AbstractStorage implements Storage
 
         Assertion::file($file, "Specified path '{$file}' is not a file.");
         Assertion::readable($file, "Specified file '{$file}' must be readable.");
-        Assertion::writeable($file, "Specified path '{$file}' must be writeable.");
+        Assertion::writeable($file, "Specified path '{$file}' must be writable.");
 
         $this->handle = fopen($file, 'r+');
     }

--- a/tests/VCR/CodeTransform/CurlCodeTransformTest.php
+++ b/tests/VCR/CodeTransform/CurlCodeTransformTest.php
@@ -6,6 +6,22 @@ use lapistano\ProxyObject\ProxyBuilder;
 
 class CurlCodeTransformTest extends \PHPUnit_Framework_TestCase
 {
+    public function testTransformOverBucketSizeBorder() {
+        $transformer = new \VCR\CodeTransform\CurlCodeTransform();
+        $transformer->register();
+
+        $stream = fopen(__DIR__ .  '/../../fixtures/code_transform_large.php', 'r');
+        stream_filter_append($stream, $transformer::NAME);
+
+        $content = '';
+        while (!feof($stream)) {
+            $content .= fread($stream, 2024);
+            var_dump('hier', $content);
+        }
+        fclose($stream);
+        var_dump($content);
+    }
+
     /**
      * @dataProvider codeSnippetProvider
      */

--- a/tests/VCR/CodeTransform/CurlCodeTransformTest.php
+++ b/tests/VCR/CodeTransform/CurlCodeTransformTest.php
@@ -16,10 +16,8 @@ class CurlCodeTransformTest extends \PHPUnit_Framework_TestCase
         $content = '';
         while (!feof($stream)) {
             $content .= fread($stream, 2024);
-            var_dump('hier', $content);
         }
         fclose($stream);
-        var_dump($content);
     }
 
     /**


### PR DESCRIPTION
When reading a bucket it might happen that the search string
is split up between two buckets and then cannot be found.

The (easy) solution is to read in the whole file and then
search and replace.

Fixes #76.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/php-vcr/php-vcr/77)

<!-- Reviewable:end -->
