### PR TITLE
Fix problem with CURLOPT_HEADERFUNCTION

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -56,8 +56,10 @@ class CurlHelper
     public static function handleOutput(Response $response, array $curlOptions, $ch)
     {
         if (isset($curlOptions[CURLOPT_HEADERFUNCTION])) {
-            $headers = $response->getRawHeaders();
-            call_user_func($curlOptions[CURLOPT_HEADERFUNCTION], $ch, $headers);
+            $headers = explode("\n", $response->getRawHeaders());
+            foreach($headers as $header) {
+                call_user_func($curlOptions[CURLOPT_HEADERFUNCTION], $ch, $header);
+            }
         }
 
         $body = (string) $response->getBody(true);


### PR DESCRIPTION
Is my solution to fix #65.

After some digging it seems that CURLOPT_HEADERFUNCTION loads a single line of header so I iterates over the raw headers as suggested in the issue.
