### PR TITLE
Fix for body request matcher

### DIFF
--- a/src/VCR/Request.php
+++ b/src/VCR/Request.php
@@ -155,6 +155,10 @@ class Request extends EntityEnclosingRequest
             }
         }
 
+        if (!empty($request['body'])) {
+            $requestObject->setBody((string) $request['body']);
+        }
+
         return $requestObject;
     }
 }

--- a/tests/VCR/RequestTest.php
+++ b/tests/VCR/RequestTest.php
@@ -178,4 +178,51 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             $restoredRequest->toArray()
         );
     }
+
+    public function testRestoreBody()
+    {
+        $this->request->setBody('sometest');
+        $restoredRequest = Request::fromArray($this->request->toArray());
+        $this->assertEquals(
+            array(
+                'method'      => 'GET',
+                'url'         => 'http://example.com',
+                'headers'     => array(
+                    'User-Agent' => 'Unit-Test',
+                    'Host' => 'example.com',
+                    'Content-Length' => '8'
+                ),
+                'body' => 'sometest',
+            ),
+            $restoredRequest->toArray()
+        );
+    }
+
+    public function testMatchesBody()
+    {
+        $this->request->setBody('sometest');
+        $request = new Request('POST', 'http://example.com');
+        $request->setBody('sometest');
+
+        $this->assertTrue(
+            $this->request->matches(
+                Request::fromArray($request->toArray()),
+                array(array('VCR\RequestMatcher', 'matchBody'))
+            )
+        );
+    }
+
+    public function testDoesntMatchBody()
+    {
+        $this->request->setBody('sometest');
+        $request = new Request('POST', 'http://example.com');
+        $request->setBody('not match');
+
+        $this->assertFalse(
+            $this->request->matches(
+                Request::fromArray($request->toArray()),
+                array(array('VCR\RequestMatcher', 'matchBody'))
+            )
+        );
+    }
 }


### PR DESCRIPTION
The submitted pull request fixes an issue with the body matcher. The request recreated from the storage forget to populate the body. 
