### PR TITLE
Use of a virtual file system on tests to prevent having untracked files

### DIFF
--- a/tests/VCR/VCRTest.php
+++ b/tests/VCR/VCRTest.php
@@ -3,6 +3,7 @@
 namespace VCR;
 
 use Guzzle\Http\Client;
+use org\bovigo\vfs\vfsStream;
 
 /**
  * Test integration of PHPVCR with PHPUnit.
@@ -81,6 +82,8 @@ class VCRTest extends \PHPUnit_Framework_TestCase
 
     public function testInsertMultipleCassettes()
     {
+        $this->configureVirtualCassette();
+
         VCR::turnOn();
         VCR::insertCassette('unittest_cassette1');
         VCR::insertCassette('unittest_cassette2');
@@ -89,10 +92,18 @@ class VCRTest extends \PHPUnit_Framework_TestCase
 
     public function testDoesNotBlockThrowingExceptions()
     {
+        $this->configureVirtualCassette();
+
         VCR::turnOn();
         $this->setExpectedException('InvalidArgumentException');
         VCR::insertCassette('unittest_cassette1');
         throw new \InvalidArgumentException('test');
+    }
+
+    private function configureVirtualCassette()
+    {
+        vfsStream::setup('testDir');
+        VCR::configure()->setCassettePath(vfsStream::url('testDir'));
     }
 
     public function testShouldSetAConfiguration()

--- a/tests/VCR/VideorecorderTest.php
+++ b/tests/VCR/VideorecorderTest.php
@@ -3,6 +3,7 @@
 namespace VCR;
 
 use lapistano\ProxyObject\ProxyBuilder;
+use org\bovigo\vfs\vfsStream;
 
 /**
  * Test Videorecorder.
@@ -19,7 +20,10 @@ class VideorecorderTest extends \PHPUnit_Framework_TestCase
 
     public function testInsertCassetteEjectExisting()
     {
-        $configuration = new Configuration();
+        vfsStream::setup('testDir');
+        $factory = VCRFactory::getInstance();
+        $configuration = $factory->get('VCR\Configuration');
+        $configuration->setCassettePath(vfsStream::url('testDir'));
         $configuration->enableLibraryHooks(array());
         $videorecorder = $this->getMockBuilder('\VCR\Videorecorder')
             ->setConstructorArgs(array($configuration, new Util\HttpClient(), VCRFactory::getInstance()))


### PR DESCRIPTION
When the tests are executed, these files are created:

tests/cassette1
tests/cassette2
tests/fixtures/unittest_cassette1
tests/fixtures/unittest_cassette2
