### PR TITLE
Various fixes

### DIFF
--- a/src/VCR/Request.php
+++ b/src/VCR/Request.php
@@ -197,7 +197,13 @@ class Request
      */
     public function getHost()
     {
-        return parse_url($this->getUrl(), PHP_URL_HOST);
+        $host = parse_url($this->getUrl(), PHP_URL_HOST);
+
+        if ($port = parse_url($this->getUrl(), PHP_URL_PORT)) {
+          $host .= ':' . $port;
+        }
+
+        return $host;
     }
 
     /**

--- a/src/VCR/RequestMatcher.php
+++ b/src/VCR/RequestMatcher.php
@@ -71,7 +71,7 @@ class RequestMatcher
     {
         $firstHeaders = $first->getHeaders();
         foreach ($second->getHeaders() as $key => $pattern) {
-            if (!isset($firstHeaders[$key])
+            if (!array_key_exists($key, $firstHeaders)
                 || $pattern !== $firstHeaders[$key]) {
                 return false;
             }

--- a/tests/VCR/RequestMatcherTest.php
+++ b/tests/VCR/RequestMatcherTest.php
@@ -56,6 +56,14 @@ class RequestMatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(RequestMatcher::matchHeaders($first, $second));
     }
 
+    public function testHeaderMatchingAllowsEmptyVals()
+    {
+        $first = new Request('GET', 'http://example.com', array('Accept' => null, 'Content-Type' => 'application/json'));
+        $second = new Request('GET', 'http://example.com', array('Accept' => null, 'Content-Type' => 'application/json'));
+
+        $this->assertTrue(RequestMatcher::matchHeaders($first, $second));
+    }
+
     public function testMatchingPostFields()
     {
         $mock = array(

--- a/tests/VCR/RequestTest.php
+++ b/tests/VCR/RequestTest.php
@@ -210,4 +210,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
+
+    public function testGetHostReturnsBothHostAndPort()
+    {
+        $request = new Request('GET', 'http://example.com:5000/foo?param=key');
+        $this->assertEquals('example.com:5000', $request->getHost());
+    }
 }


### PR DESCRIPTION
This PR introduces two modifications/fixes:

1. `Request::getHost` does not include the port, which means that request matching fails for various cassettes that contain hostnames with an explicit port. See the [RFC](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23)

2. `RequestMatcher::matchHeaders` fails to match requests which have the same null headers. But IMO if two requests have `Accept: null` that denotes equality. This is also causing cassette matching problems