### PR TITLE
Fix url matcher

### DIFF
--- a/src/VCR/RequestMatcher.php
+++ b/src/VCR/RequestMatcher.php
@@ -30,15 +30,7 @@ class RequestMatcher
      */
     public static function matchUrl(Request $first, Request $second)
     {
-        if (null !== $first->getPath()) {
-            $path = str_replace('#', '\\#', $first->getPath());
-
-            if (!preg_match('#'.$path.'#', rawurldecode($second->getPath()))) {
-                return false;
-            }
-        }
-
-        return true;
+        return !((null !== $first->getPath()) and ((string) $first->getPath() != (string) $second->getPath()));
     }
 
     /**

--- a/tests/VCR/RequestMatcherTest.php
+++ b/tests/VCR/RequestMatcherTest.php
@@ -28,6 +28,11 @@ class RequestMatcherTest extends \PHPUnit_Framework_TestCase
         $second = new Request('GET', 'http://example.com/second/path', array());
 
         $this->assertFalse(RequestMatcher::matchUrl($first, $second));
+
+        $first = new Request('GET', 'http://example.com/second', array());
+        $second = new Request('GET', 'http://example.com/second/path', array());
+
+        $this->assertFalse(RequestMatcher::matchUrl($first, $second));
     }
 
     public function testMatchingHost()


### PR DESCRIPTION
Hello. There is a little problem with url matcher. For example this case brokes tests:
```
<?php

public function testMatchingUrl()
{
    $first = new Request('GET', 'http://example.com/common/path', array());
    $second = new Request('GET', 'http://example.com/common/path', array());
    $this->assertTrue(RequestMatcher::matchUrl($first, $second));  // work fine

    $first = new Request('GET', 'http://example.com/second', array());
    $second = new Request('GET', 'http://example.com/second/path', array());
    $this->assertFalse(RequestMatcher::matchUrl($first, $second)); // should not match
}
```
Phpunit output:
```

1) VCR\RequestMatcherTest::testMatchingUrl
Failed asserting that true is false.

/home/chizhik/php-vcr/tests/VCR/RequestMatcherTest.php:30
/usr/share/php/PHPUnit/TextUI/Command.php:176
/usr/share/php/PHPUnit/TextUI/Command.php:129
```
Could you answer, why php-vcr does not match urls strictly?