### PR TITLE
Allow function names that have keywords (e.g. raven/raven library)

### DIFF
--- a/src/VCR/CodeTransform/CurlCodeTransform.php
+++ b/src/VCR/CodeTransform/CurlCodeTransform.php
@@ -7,15 +7,15 @@ class CurlCodeTransform extends AbstractCodeTransform
     const NAME = 'vcr_curl';
 
     private static $patterns = array(
-        '/(?<!::|->)\\\?curl_init\s*\(/i'                => '\VCR\LibraryHooks\CurlHook::curl_init(',
-        '/(?<!::|->)\\\?curl_exec\s*\(/i'                => '\VCR\LibraryHooks\CurlHook::curl_exec(',
-        '/(?<!::|->)\\\?curl_getinfo\s*\(/i'             => '\VCR\LibraryHooks\CurlHook::curl_getinfo(',
-        '/(?<!::|->)\\\?curl_setopt\s*\(/i'              => '\VCR\LibraryHooks\CurlHook::curl_setopt(',
-        '/(?<!::|->)\\\?curl_setopt_array\s*\(/i'        => '\VCR\LibraryHooks\CurlHook::curl_setopt_array(',
-        '/(?<!::|->)\\\?curl_multi_add_handle\s*\(/i'    => '\VCR\LibraryHooks\CurlHook::curl_multi_add_handle(',
-        '/(?<!::|->)\\\?curl_multi_remove_handle\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_multi_remove_handle(',
-        '/(?<!::|->)\\\?curl_multi_exec\s*\(/i'          => '\VCR\LibraryHooks\CurlHook::curl_multi_exec(',
-        '/(?<!::|->)\\\?curl_multi_info_read\s*\(/i'     => '\VCR\LibraryHooks\CurlHook::curl_multi_info_read('
+        '/(?<!::|->|\w_)\\\?curl_init\s*\(/i'                => '\VCR\LibraryHooks\CurlHook::curl_init(',
+        '/(?<!::|->|\w_)\\\?curl_exec\s*\(/i'                => '\VCR\LibraryHooks\CurlHook::curl_exec(',
+        '/(?<!::|->|\w_)\\\?curl_getinfo\s*\(/i'             => '\VCR\LibraryHooks\CurlHook::curl_getinfo(',
+        '/(?<!::|->|\w_)\\\?curl_setopt\s*\(/i'              => '\VCR\LibraryHooks\CurlHook::curl_setopt(',
+        '/(?<!::|->|\w_)\\\?curl_setopt_array\s*\(/i'        => '\VCR\LibraryHooks\CurlHook::curl_setopt_array(',
+        '/(?<!::|->|\w_)\\\?curl_multi_add_handle\s*\(/i'    => '\VCR\LibraryHooks\CurlHook::curl_multi_add_handle(',
+        '/(?<!::|->|\w_)\\\?curl_multi_remove_handle\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_multi_remove_handle(',
+        '/(?<!::|->|\w_)\\\?curl_multi_exec\s*\(/i'          => '\VCR\LibraryHooks\CurlHook::curl_multi_exec(',
+        '/(?<!::|->|\w_)\\\?curl_multi_info_read\s*\(/i'     => '\VCR\LibraryHooks\CurlHook::curl_multi_info_read('
     );
 
     /**

--- a/tests/VCR/CodeTransform/CurlCodeTransformTest.php
+++ b/tests/VCR/CodeTransform/CurlCodeTransformTest.php
@@ -58,6 +58,8 @@ class CurlCodeTransformTest extends \PHPUnit_Framework_TestCase
             array('$object->curl_multi_exec(', '$object->curl_multi_exec('),
             array('$object->curl_multi_info_read(', '$object->curl_multi_info_read('),
 
+            array('function send_http_asynchronous_curl_exec(', 'function send_http_asynchronous_curl_exec(')
+
         );
     }
 }


### PR DESCRIPTION
This function from the raven/raven library...

```php
function send_http_asynchronous_curl_exec($url, $data, $headers) {
```

was getting rewritten as

```php
function send_http_asynchronous_\VCR\LibraryHooks\CurlHook::curl_exec($url, $data, $headers) {
```

resulting in...

```php
Parse error: syntax error, unexpected '\' (T_NS_SEPARATOR), expecting '(' in /Users/craigmorris/Sites/error-tracker-adapter/vendor/raven/raven/lib/Raven/Client.php on line 572
```