### PR TITLE
Add flags parameter for url_stat call on stream wrapper

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -258,7 +258,11 @@ class StreamProcessor
      */
     public function stream_stat()
     {
-        return fstat($this->resource);
+        $this->restore();
+        $stat = fstat($this->resource);
+        $this->intercept();
+
+        return $stat;
     }
 
     /**
@@ -280,15 +284,16 @@ class StreamProcessor
      *
      * @link http://www.php.net/manual/en/streamwrapper.url-stat.php
      *
-     * @param  string $path The file path or URL to stat.
+     * @param string $path  The file path or URL to stat.
+     * @param int    $flags Holds additional flags set by the streams API.
      *
-     * @return integer      Should return as many elements as stat() does.
+     * @return integer Should return as many elements as stat() does.
      */
-    public function url_stat($path)
+    public function url_stat($path, $flags)
     {
         $this->restore();
         try {
-            $result = @stat($path);
+            $result = @stat($path, $flags);
         } catch (\ErrorException $e) {
             // PHPUnit running in process isolation (processIsolation="true")
             // throws an \ErrorException for any PHP warning.


### PR DESCRIPTION
according to http://php.net/manual/en/streamwrapper.url-stat.php url_stat has a second $flags parameter. if that is not passed through, checks like is_link fail