### PR TITLE
support path separators in cassette names

### DIFF
--- a/tests/VCR/Storage/AbstractStorageTest.php
+++ b/tests/VCR/Storage/AbstractStorageTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace VCR\Storage;
+
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * Test integration of PHPVCR with PHPUnit.
+ */
+class AbstractStorageTest extends \PHPUnit_Framework_TestCase
+{
+    protected $handle;
+    protected $filePath;
+    protected $storage;
+
+    public function testFilePathCreated()
+    {
+        $fs = vfsStream::setup('test');
+
+        $this->storage = new TestStorage(vfsStream::url('test/'), 'file');
+        $this->assertTrue($fs->hasChild('file'));
+
+        $this->storage = new TestStorage(vfsStream::url('test/'), 'folder/file');
+        $this->assertTrue($fs->hasChild('folder'));
+        $this->assertTrue($fs->getChild('folder')->hasChild('file'));
+    }
+
+    /**
+     * @expectedException \VCR\VCRException
+     */
+    public function testRootNotExisting()
+    {
+        vfsStream::setup('test');
+        $this->storage = new TestStorage(vfsStream::url('test/foo'), 'file');
+    }
+
+}
+
+class TestStorage extends AbstractStorage
+{
+    private $recording;
+
+    public function storeRecording(array $recording)
+    {
+        $this->recording = $recording;
+    }
+
+    public function next()
+    {
+        list ($this->position, $this->current) = each ($this->recording);
+
+        return $this->current;
+    }
+
+    public function valid()
+    {
+        return (boolean) $this->position;
+    }
+
+    public function rewind()
+    {
+        reset($this->recording);
+    }
+}


### PR DESCRIPTION
This change makes it possible to group fixtures by folder names.

To work correctly on windows systems, you need to use PATH_SEPARATOR rather than hardcode `/`.