### PR TITLE
Avoid writeable check when in mode 'none' to run on readonly filesystems

### DIFF
--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -121,16 +121,11 @@ class Configuration
     private $blackList = array('src/VCR/LibraryHooks/', 'src/VCR/Util/SoapClient', 'tests/VCR/Filter');
 
     /**
-     * The mode which determines how requests are handled
-     *
-     * Currently supported modes:
-     *      - new_episodes (Always allows new HTTP requests)
-     *      - once (Will allow new HTTP requests the first time the cassette is created then throw an exception after that)
-     *      - none (Will never allow new HTTP requests)
+     * The mode which determines how requests are handled. One of the MODE constants.
      *
      * @var string Current mode
      */
-    private $mode = 'new_episodes';
+    private $mode = VCR::MODE_NEW_EPISODES;
 
     /**
      * List of available modes.
@@ -143,9 +138,9 @@ class Configuration
      * @var array List of available modes.
      */
     private $availableModes = array(
-        'new_episodes',
-        'once',
-        'none'
+        VCR::MODE_NEW_EPISODES,
+        VCR::MODE_ONCE,
+        VCR::MODE_NONE,
     );
 
     /**
@@ -358,7 +353,7 @@ class Configuration
     /**
      * Sets the current mode.
      *
-     * @param string The mode to set VCR to
+     * @param string $mode The mode to set VCR to
      *
      * @return Configuration
      */

--- a/src/VCR/Storage/AbstractStorage.php
+++ b/src/VCR/Storage/AbstractStorage.php
@@ -54,30 +54,29 @@ abstract class AbstractStorage implements Storage
      * If the cassetteName contains PATH_SEPARATORs, subfolders of the
      * cassettePath are autocreated when not existing.
      *
-     * @param string $cassettePath Path to the cassette directory.
-     * @param string $cassetteName Path to the cassette file, relative to the path.
+     * @param string  $cassettePath   Path to the cassette directory.
+     * @param string  $cassetteName   Path to the cassette file, relative to the path.
+     * @param string  $defaultContent Default data for this cassette if its not existing
      */
     public function __construct($cassettePath, $cassetteName, $defaultContent = '[]')
     {
         Assertion::directory($cassettePath, "Cassette path '{$cassettePath}' is not existing or not a directory");
 
-        $file = rtrim($cassettePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $cassetteName;
+        $this->filePath = rtrim($cassettePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $cassetteName;
 
-        if (!is_dir(dirname($file))) {
-            mkdir(dirname($file), 0777, true);
+        if (!is_dir(dirname($this->filePath))) {
+            mkdir(dirname($this->filePath), 0777, true);
         }
 
-        if (!file_exists($file) || 0 === filesize($file)) {
-            file_put_contents($file, $defaultContent);
-
+        if (!file_exists($this->filePath) || 0 === filesize($this->filePath)) {
+            file_put_contents($this->filePath, $defaultContent);
             $this->isNew = true;
+        } else {
+            Assertion::file($this->filePath, "Specified path '{$this->filePath}' is not a file.");
+            Assertion::readable($this->filePath, "Specified file '{$this->filePath}' must be readable.");
         }
 
-        Assertion::file($file, "Specified path '{$file}' is not a file.");
-        Assertion::readable($file, "Specified file '{$file}' must be readable.");
-        Assertion::writeable($file, "Specified path '{$file}' must be writeable.");
-
-        $this->handle = fopen($file, 'r+');
+        $this->handle = fopen($this->filePath, 'r+');
     }
 
     /**

--- a/src/VCR/Storage/Json.php
+++ b/src/VCR/Storage/Json.php
@@ -2,6 +2,8 @@
 
 namespace VCR\Storage;
 
+use VCR\Util\Assertion;
+
 /**
  * Json based storage for records.
  *
@@ -15,6 +17,8 @@ class Json extends AbstractStorage
      */
     public function storeRecording(array $recording)
     {
+        Assertion::writeable($this->filePath, "Specified path '{$this->filePath}' must be writeable.");
+
         fseek($this->handle, -1, SEEK_END);
         if (ftell($this->handle) > 2) {
             fwrite($this->handle, ',');

--- a/src/VCR/Storage/Yaml.php
+++ b/src/VCR/Storage/Yaml.php
@@ -4,6 +4,7 @@ namespace VCR\Storage;
 
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Dumper;
+use VCR\Util\Assertion;
 
 /**
  * Yaml based storage for records.
@@ -44,6 +45,8 @@ class Yaml extends AbstractStorage
      */
     public function storeRecording(array $recording)
     {
+        Assertion::writeable($this->filePath, "Specified path '{$this->filePath}' must be writeable.");
+
         fseek($this->handle, -1, SEEK_END);
         fwrite($this->handle, "\n" . $this->yamlDumper->dump(array($recording), 4));
         fflush($this->handle);

--- a/src/VCR/VCR.php
+++ b/src/VCR/VCR.php
@@ -13,6 +13,21 @@ namespace VCR;
  */
 class VCR
 {
+    /**
+     * Always allow to do HTTP requests and add to the cassette. Default mode.
+     */
+    const MODE_NEW_EPISODES = 'new_episodes';
+
+    /**
+     * Only allow new HTTP requests when the cassette is newly created.
+     */
+    const MODE_ONCE = 'once';
+
+    /**
+     * Treat the fixtures as read only and never allow new HTTP requests.
+     */
+    const MODE_NONE = 'none';
+
     public static function __callStatic($method, $parameters)
     {
         $instance = VCRFactory::get('VCR\Videorecorder');

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -223,7 +223,7 @@ class Videorecorder
             return $response;
         }
 
-        if ($this->config->getMode() == 'none' || $this->config->getMode() == 'once' && $this->cassette->isNew() === false) {
+        if (VCR::MODE_NONE === $this->config->getMode() || VCR::MODE_ONCE === $this->config->getMode() && $this->cassette->isNew() === false) {
             throw new \LogicException(
                 "The request does not match a previously recorded request and the 'mode' is set to '{$this->config->getMode()}'. "
                 . "If you want to send the request anyway, make sure your 'mode' is set to 'new_episodes'. "

--- a/tests/VCR/Storage/AbstractStorageTest.php
+++ b/tests/VCR/Storage/AbstractStorageTest.php
@@ -30,9 +30,8 @@ class AbstractStorageTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\VCR\VCRException', "Cassette path 'vfs://test/foo' is not existing or not a directory");
 
         vfsStream::setup('test');
-        $this->storage = new TestStorage(vfsStream::url('test/foo'), 'file');
+        new TestStorage(vfsStream::url('test/foo'), 'file');
     }
-
 }
 
 class TestStorage extends AbstractStorage

--- a/tests/VCR/VideorecorderTest.php
+++ b/tests/VCR/VideorecorderTest.php
@@ -143,7 +143,7 @@ class VideorecorderTest extends \PHPUnit_Framework_TestCase
         return $client;
     }
 
-    protected function getCassetteMock($request, $response, $mode = 'new_episodes', $isNew = false)
+    protected function getCassetteMock($request, $response, $mode = VCR::MODE_NEW_EPISODES, $isNew = false)
     {
         $cassette = $this->getMockBuilder('\VCR\Cassette')
             ->disableOriginalConstructor()
@@ -155,7 +155,7 @@ class VideorecorderTest extends \PHPUnit_Framework_TestCase
             ->with($request)
             ->will($this->returnValue(false));
 
-        if ($mode == 'new_episodes' || $mode == 'once' && $isNew === true) {
+        if (VCR::MODE_NEW_EPISODES === $mode || VCR::MODE_ONCE === $mode && $isNew === true) {
             $cassette
                 ->expects($this->once())
                 ->method('record')


### PR DESCRIPTION
On our CI, symfony sources are on a read-only filesystem and we certainly don't want php-vcr to update any fixtures. We switch to mode "none" based on an environment variable that is only present on CI. However, we would need this fix to avoid the writeable check (which makes no sense in "none" mode anyways).

/cc @thormeier