### PR TITLE
Dispatch before playback event for each http interaction in cassette

### DIFF
--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -79,13 +79,13 @@ class Cassette
      * @param Request $request Request to check if it was recorded.
      * @param boolean $dispatchEvents Whether to dispatch events or not. Default is false.
      *
-     * @return boolean True if a response was recorded for specified request.
+     * @return Response|null Response for specified request.
      */
     protected function getResponse(Request $request, $dispatchEvents = false) {
         foreach ($this->storage as $recording) {
             $storedRequest = Request::fromArray($recording['request']);
             if ($dispatchEvents) {
-                $this->config->dispatch(VCREvents::VCR_BEFORE_PLAYBACK, new BeforePlaybackEvent($request, $this));
+                $this->config->dispatch(VCREvents::VCR_BEFORE_PLAYBACK, new BeforePlaybackEvent($storedRequest, $this));
             }
             if ($storedRequest->matches($request, $this->getRequestMatchers())) {
                 return Response::fromArray($recording['response']);

--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -3,6 +3,9 @@
 namespace VCR;
 
 use VCR\Util\Assertion;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Configuration stores a Videorecorders configuration options.
@@ -142,6 +145,11 @@ class Configuration
         VCR::MODE_ONCE,
         VCR::MODE_NONE,
     );
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher;
 
     /**
      * Returns the current blacklist.
@@ -384,5 +392,36 @@ class Configuration
             . "create it or set a different cassette path using "
             . "\\VCR\\VCR::configure()->setCassettePath('directory')."
         );
+    }
+
+    /**
+     * @param EventDispatcherInterface $dispatcher
+     */
+    public function setEventDispatcher(EventDispatcherInterface $dispatcher)
+    {
+        $this->eventDispatcher = $dispatcher;
+    }
+
+    /**
+     * @return EventDispatcherInterface
+     */
+    public function getEventDispatcher()
+    {
+        if (!$this->eventDispatcher) {
+            $this->eventDispatcher = new EventDispatcher();
+        }
+        return $this->eventDispatcher;
+    }
+
+    /**
+     * Dispatches an event to all registered listeners.
+     *
+     * @param string $eventName The name of the event to dispatch.
+     * @param Event $event The event to pass to the event handlers/listeners.
+     * @return Event
+     */
+    public function dispatch($eventName, Event $event = null)
+    {
+        return $this->getEventDispatcher()->dispatch($eventName, $event);
     }
 }

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -7,11 +7,7 @@ use VCR\Util\HttpClient;
 use VCR\Event\AfterHttpRequestEvent;
 use VCR\Event\AfterPlaybackEvent;
 use VCR\Event\BeforeHttpRequestEvent;
-use VCR\Event\BeforePlaybackEvent;
 use VCR\Event\BeforeRecordEvent;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * A videorecorder records requests on a cassette.
@@ -55,11 +51,6 @@ class Videorecorder
     protected $isOn = false;
 
     /**
-     * @var EventDispatcherInterface
-     */
-    protected $eventDispatcher;
-
-    /**
      * Creates a videorecorder instance.
      *
      * @param Configuration $config  Config options like which library hooks to use.
@@ -71,37 +62,6 @@ class Videorecorder
         $this->config = $config;
         $this->client = $client;
         $this->factory = $factory;
-    }
-
-    /**
-     * @param EventDispatcherInterface $dispatcher
-     */
-    public function setEventDispatcher(EventDispatcherInterface $dispatcher)
-    {
-        $this->eventDispatcher = $dispatcher;
-    }
-
-    /**
-     * @return EventDispatcherInterface
-     */
-    public function getEventDispatcher()
-    {
-        if (!$this->eventDispatcher) {
-            $this->eventDispatcher = new EventDispatcher();
-        }
-        return $this->eventDispatcher;
-    }
-
-    /**
-     * Dispatches an event to all registered listeners.
-     *
-     * @param string $eventName The name of the event to dispatch.
-     * @param Event $event The event to pass to the event handlers/listeners.
-     * @return Event
-     */
-    private function dispatch($eventName, Event $event = null)
-    {
-        return $this->getEventDispatcher()->dispatch($eventName, $event);
     }
 
     /**
@@ -217,9 +177,8 @@ class Videorecorder
         }
 
         if ($this->cassette->hasResponse($request)) {
-            $this->dispatch(VCREvents::VCR_BEFORE_PLAYBACK, new BeforePlaybackEvent($request, $this->cassette));
             $response = $this->cassette->playback($request);
-            $this->dispatch(VCREvents::VCR_AFTER_PLAYBACK, new AfterPlaybackEvent($request, $response, $this->cassette));
+            $this->config->dispatch(VCREvents::VCR_AFTER_PLAYBACK, new AfterPlaybackEvent($request, $response, $this->cassette));
             return $response;
         }
 
@@ -232,11 +191,11 @@ class Videorecorder
 
         $this->disableLibraryHooks();
 
-        $this->dispatch(VCREvents::VCR_BEFORE_HTTP_REQUEST, new BeforeHttpRequestEvent($request));
+        $this->config->dispatch(VCREvents::VCR_BEFORE_HTTP_REQUEST, new BeforeHttpRequestEvent($request));
         $response = $this->client->send($request);
-        $this->dispatch(VCREvents::VCR_AFTER_HTTP_REQUEST, new AfterHttpRequestEvent($request, $response));
+        $this->config->dispatch(VCREvents::VCR_AFTER_HTTP_REQUEST, new AfterHttpRequestEvent($request, $response));
 
-        $this->dispatch(VCREvents::VCR_BEFORE_RECORD, new BeforeRecordEvent($request, $response, $this->cassette));
+        $this->config->dispatch(VCREvents::VCR_BEFORE_RECORD, new BeforeRecordEvent($request, $response, $this->cassette));
         $this->cassette->record($request, $response);
         $this->enableLibraryHooks();
 

--- a/tests/fixtures/unittest_event_test
+++ b/tests/fixtures/unittest_event_test
@@ -1,0 +1,41 @@
+
+-
+    request:
+        method: GET
+        url: 'http://google2.com/'
+        headers:
+            Host: google.com
+            Content-Length: 0
+    response:
+        status: 301
+        headers:
+            Location: 'http://www.google.com/'
+            Content-Type: 'text/html; charset=UTF-8'
+            Date: 'Mon, 13 May 2013 08:15:58 GMT'
+            Expires: 'Wed, 12 Jun 2013 08:15:58 GMT'
+            Cache-Control: 'public, max-age=2592000'
+            Server: gws
+            Content-Length: '219'
+            X-XSS-Protection: '1; mode=block'
+            X-Frame-Options: SAMEORIGIN
+        body: "This is a curl test dummy."
+-
+    request:
+        method: GET
+        url: 'http://google.com/'
+        headers:
+            Host: google.com
+            Content-Length: 0
+    response:
+        status: 301
+        headers:
+            Location: 'http://www.google.com/'
+            Content-Type: 'text/html; charset=UTF-8'
+            Date: 'Mon, 13 May 2013 08:15:58 GMT'
+            Expires: 'Wed, 12 Jun 2013 08:15:58 GMT'
+            Cache-Control: 'public, max-age=2592000'
+            Server: gws
+            Content-Length: '219'
+            X-XSS-Protection: '1; mode=block'
+            X-Frame-Options: SAMEORIGIN
+        body: "This is a curl test dummy."


### PR DESCRIPTION
Fix for #101.

As I mention [in this comment](https://github.com/php-vcr/php-vcr/issues/101#issuecomment-108513146), I followed Ruby VCR's lead (and aaa2000's suggestion) and dispatch the "before playback" event before each HTTP interaction in the cassette.

I did not do change the 'after playback' event, since there should be one anyway.

I did end up moving the dispatch into the configuration, a la Ruby's VCR. This means the `dispatch` method needs to be public.