### PR TITLE
Fixes before and after playback events

### DIFF
--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -176,7 +176,7 @@ class Videorecorder
 
         $storage = $this->factory->get('Storage', array($cassetteName));
 
-        $this->cassette = new Cassette($cassetteName, $this->config, $storage);
+        $this->cassette = new Cassette($cassetteName, $this->config, $storage, $this->getEventDispatcher());
         $this->enableLibraryHooks();
     }
 
@@ -216,10 +216,15 @@ class Videorecorder
             );
         }
 
-        if ($this->cassette->hasResponse($request)) {
-            $this->dispatch(VCREvents::VCR_BEFORE_PLAYBACK, new BeforePlaybackEvent($request, $this->cassette));
-            $response = $this->cassette->playback($request);
-            $this->dispatch(VCREvents::VCR_AFTER_PLAYBACK, new AfterPlaybackEvent($request, $response, $this->cassette));
+        $event = new BeforePlaybackEvent($request, $this->cassette);
+        $this->dispatch(VCREvents::VCR_BEFORE_PLAYBACK, $event);
+
+        $response = $this->cassette->playback($request);
+
+        // Playback succeeded and the recorded response can be returned.
+        if (!empty($response)) {
+            $event = new AfterPlaybackEvent($request, $response, $this->cassette);
+            $this->dispatch(VCREvents::VCR_AFTER_PLAYBACK, $event);
             return $response;
         }
 

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -176,7 +176,7 @@ class Videorecorder
 
         $storage = $this->factory->get('Storage', array($cassetteName));
 
-        $this->cassette = new Cassette($cassetteName, $this->config, $storage, $this->getEventDispatcher());
+        $this->cassette = new Cassette($cassetteName, $this->config, $storage);
         $this->enableLibraryHooks();
     }
 

--- a/tests/VCR/VCRTest.php
+++ b/tests/VCR/VCRTest.php
@@ -158,7 +158,12 @@ class VCRTest extends \PHPUnit_Framework_TestCase
         $this->doCurlGetRequest('http://google.com/');
 
         $this->assertEquals(
-            array(VCREvents::VCR_BEFORE_HTTP_REQUEST, VCREvents::VCR_AFTER_HTTP_REQUEST, VCREvents::VCR_BEFORE_RECORD),
+            array(
+                VCREvents::VCR_BEFORE_PLAYBACK,
+                VCREvents::VCR_BEFORE_HTTP_REQUEST,
+                VCREvents::VCR_AFTER_HTTP_REQUEST,
+                VCREvents::VCR_BEFORE_RECORD
+            ),
             $this->getRecordedEventNames()
         );
         VCR::eject();

--- a/tests/VCR/VideorecorderTest.php
+++ b/tests/VCR/VideorecorderTest.php
@@ -147,13 +147,13 @@ class VideorecorderTest extends \PHPUnit_Framework_TestCase
     {
         $cassette = $this->getMockBuilder('\VCR\Cassette')
             ->disableOriginalConstructor()
-            ->setMethods(array('hasResponse', 'record', 'playback', 'isNew'))
+            ->setMethods(array('record', 'playback', 'isNew'))
             ->getMock();
         $cassette
             ->expects($this->once())
-            ->method('hasResponse')
+            ->method('playback')
             ->with($request)
-            ->will($this->returnValue(false));
+            ->will($this->returnValue(null));
 
         if (VCR::MODE_NEW_EPISODES === $mode || VCR::MODE_ONCE === $mode && $isNew === true) {
             $cassette


### PR DESCRIPTION
This PR does:

 * Always send the before playback event as discussed in #101. 
 * Only fire the after playback event if a response was found (= playback happened)
 * Not calling `hasResponse` anymore increases performance with the current storage implementation.