### PR TITLE
Add support for HTTP Continue headers

### DIFF
--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -61,7 +61,12 @@ class HttpUtil
      */
     public static function parseResponse($response)
     {
-        list($rawHeader, $rawBody) = explode("\r\n\r\n", $response, 2);
+        if (strpos($response, 'HTTP/1.1 100 Continue') === 0) {
+            list($continueHeader, $rawHeader, $rawBody) = explode("\r\n\r\n", $response, 3);
+        }
+        else {
+            list($rawHeader, $rawBody) = explode("\r\n\r\n", $response, 2);
+        }
 
         // Parse headers and status.
         $headers = self::parseRawHeader($rawHeader);

--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -61,12 +61,9 @@ class HttpUtil
      */
     public static function parseResponse($response)
     {
-        if (strpos($response, 'HTTP/1.1 100 Continue') === 0) {
-            list($continueHeader, $rawHeader, $rawBody) = explode("\r\n\r\n", $response, 3);
-        }
-        else {
-            list($rawHeader, $rawBody) = explode("\r\n\r\n", $response, 2);
-        }
+        $response = str_replace("HTTP/1.1 100 Continue\r\n\r\n", '', $response);
+            
+        list($rawHeader, $rawBody) = explode("\r\n\r\n", $response, 2);
 
         // Parse headers and status.
         $headers = self::parseRawHeader($rawHeader);

--- a/tests/VCR/Util/HttpUtilTest.php
+++ b/tests/VCR/Util/HttpUtilTest.php
@@ -39,6 +39,41 @@ class HttpUtilTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedHeaders, $headers);
     }
     
+    public function testParseContinuePlusResponse()
+    {
+        $raw = "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";
+        list($status, $headers, $body) = HttpUtil::parseResponse($raw);
+
+        $expectedHeaders = array(
+            'Content-Type: text/html',
+            'Date: Fri, 19 Jun 2015 16:05:18 GMT',
+            'Vary: Accept-Encoding',
+            'Content-Length: 0'
+        );
+        
+        $this->assertEquals('HTTP/1.1 201 Created', $status);
+        $this->assertEquals(null, $body);
+        $this->assertEquals($expectedHeaders, $headers);
+    }
+
+    public function testParseContinuePlusResponseMultipleHeaders()
+    {
+        $raw = "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept, Accept-Language, Expect\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";
+        list($status, $headers, $body) = HttpUtil::parseResponse($raw);
+        
+        $expectedHeaders = array(
+            'Content-Type: text/html',
+            'Date: Fri, 19 Jun 2015 16:05:18 GMT',
+            'Vary: Accept, Accept-Language, Expect',
+            'Vary: Accept-Encoding',
+            'Content-Length: 0'
+        );
+        
+        $this->assertEquals('HTTP/1.1 201 Created', $status);
+        $this->assertEquals(null, $body);
+        $this->assertEquals($expectedHeaders, $headers);
+    }
+
     public function testParseHeadersBasic()
     {
         $inputArray = array(

--- a/tests/VCR/Util/HttpUtilTest.php
+++ b/tests/VCR/Util/HttpUtilTest.php
@@ -55,6 +55,24 @@ class HttpUtilTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $body);
         $this->assertEquals($expectedHeaders, $headers);
     }
+    
+    public function testParseiMultipleContinuePlusResponse()
+    {
+        $raw = "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";
+        list($status, $headers, $body) = HttpUtil::parseResponse($raw);
+
+        $expectedHeaders = array(
+            'Content-Type: text/html',
+            'Date: Fri, 19 Jun 2015 16:05:18 GMT',
+            'Vary: Accept-Encoding',
+            'Content-Length: 0'
+        );
+        
+        $this->assertEquals('HTTP/1.1 201 Created', $status);
+        $this->assertEquals(null, $body);
+        $this->assertEquals($expectedHeaders, $headers);
+    }
+
 
     public function testParseContinuePlusResponseMultipleHeaders()
     {


### PR DESCRIPTION
Requests that return an HTTP 100 Continue header before returning the remainder of the response are currently not processed properly in `src/VCR/Util/HttpUtil.php`. A typical response header looks like:
```
HTTP/1.1 200 OK
Date: Thu, 02 Jul 2015 22:32:22 GMT
Server: ***
...

<content>
```

When a continue header is encountered, the response header looks like: 
```
HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Date: Thu, 02 Jul 2015 22:32:22 GMT
Server: ***
...

<content>
```
This PR adds support for parsing that additional Continue header.

Thoughts / Comments ?