### PR TITLE
Prevent inherit from itself SoapClient.

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -102,6 +102,8 @@ class StreamProcessor
             return true;
         }
 
+        $uri = $this->normalizePath($uri);
+
         foreach ($whiteList as $path) {
             if (strpos($uri, $path) !== false) {
                 return true;
@@ -120,6 +122,8 @@ class StreamProcessor
      */
     protected function isBlacklisted($uri)
     {
+        $uri = $this->normalizePath($uri);
+
         foreach (static::$configuration->getBlackList() as $path) {
             if (strpos($uri, $path) !== false) {
                 return true;
@@ -616,5 +620,21 @@ class StreamProcessor
         foreach (static::$codeTransformers as $codeTransformer) {
             stream_filter_append($stream, $codeTransformer::NAME, STREAM_FILTER_READ);
         }
+    }
+
+    /**
+     * Normalizes the path, to always use the slash as directory separator.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    private function normalizePath($path)
+    {
+        if (DIRECTORY_SEPARATOR !== '/') {
+            return str_replace(DIRECTORY_SEPARATOR, '/', $path);
+        }
+
+        return $path;
     }
 }

--- a/tests/VCR/Util/StreamProcessorTest.php
+++ b/tests/VCR/Util/StreamProcessorTest.php
@@ -78,10 +78,7 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
     {
         $test = $this;
         set_error_handler(function($errno, $errstr, $errfile, $errline) use ($test) {
-            $test->assertEquals(
-                'opendir(not_found): failed to open dir: No such file or directory',
-                $errstr
-            );
+            $test->assertContains('opendir(not_found', $errstr);
         });
 
         $processor = new StreamProcessor();
@@ -115,6 +112,10 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
     {
         if (version_compare(PHP_VERSION, '5.4.0', '<')) {
             $this->markTestSkipped('Behavior is only applicable and testable for PHP 5.4+');
+        }
+
+        if (!function_exists('posix_getuid')) {
+            $this->markTestSkipped('Requires "posix_getuid" function.');
         }
 
         $mock = $this->getStreamProcessorMock();


### PR DESCRIPTION
The original code not working on Windows OS, occurs an error:

    PHP Fatal error:  Class 'VCR\Util\SoapClient' not found ...

This is happens due to code transformation (see `SoapCodeTransform`), after which `VCR\Util\SoapClient` inherit from itself. Like this:

```php
<?php

namespace VCR\Util;

use VCR\LibraryHooks\SoapHook;
use VCR\VCRFactory;

class SoapClient extends \VCR\Util\SoapClient
{
    ...
```

PR solves issue #67.

Tests' result before the patch:

```
> .\vendor\bin\phpunit
PHPUnit 3.7.38 by Sebastian Bergmann.

Configuration read from D:\Projects\php-vcr\phpunit.xml

...............................................................  63 / 248 ( 25%)
..........................PHP Fatal error:  Class 'VCR\Util\SoapClient' not found in D:\Projects\php-vcr\src\VCR\Util\SoapClient.php on line 13
```

Tests' result before fix `StreamProcessorTest::testDirOpendirNotFound`:

```
> .\vendor\bin\phpunit
PHPUnit 3.7.38 by Sebastian Bergmann.

Configuration read from D:\Projects\php-vcr\phpunit.xml

...............................................................  63 / 248 ( 25%)
............................................................... 126 / 248 ( 50%)
.....S......................................................... 189 / 248 ( 76%)
.........................F..S..............................

Time: 2.2 seconds, Memory: 11.25Mb

There was 1 failure:

1) VCR\Util\StreamProcessorTest::testDirOpendirNotFound
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'opendir(not_found): failed to open dir: No such file or directory'
+'opendir(not_found,not_found): ═х єфрхЄё  эрщЄш єърчрээ√щ Їрщы. (code: 2)'

D:\Projects\php-vcr\tests\VCR\Util\StreamProcessorTest.php:84
D:\Projects\php-vcr\src\VCR\Util\StreamProcessor.php:334
D:\Projects\php-vcr\tests\VCR\Util\StreamProcessorTest.php:88
```

Tests' result after the patch:

```
> .\vendor\bin\phpunit
PHPUnit 3.7.38 by Sebastian Bergmann.

Configuration read from D:\Projects\php-vcr\phpunit.xml

...............................................................  63 / 248 ( 25%)
............................................................... 126 / 248 ( 50%)
.....S......................................................... 189 / 248 ( 76%)
............................S..............................

Time: 2.23 seconds, Memory: 11.25Mb

OK, but incomplete or skipped tests!
Tests: 248, Assertions: 343, Skipped: 2.
```