### PR TITLE
provide more information when not in recording mode

### DIFF
--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -232,7 +232,10 @@ class Videorecorder
             throw new \LogicException(
                 "The request does not match a previously recorded request and the 'mode' is set to '{$this->config->getMode()}'. "
                 . "If you want to send the request anyway, make sure your 'mode' is set to 'new_episodes'. "
-                . "Please see http://php-vcr.github.io/documentation/configuration/#record-modes.");
+                . "Please see http://php-vcr.github.io/documentation/configuration/#record-modes."
+                ."\nCassette: ".$this->cassette->getName()
+                ."\nRequest: ".print_r($request->toArray(), true)
+            );
         }
 
         $this->disableLibraryHooks();


### PR DESCRIPTION
the Videorecorder should report more information to figure out what request was not found. the not-recording mode is usually on a ci server, so any debugging information will be helpful.