### PR TITLE
[SoapClient] Fixes __getLastRequest and __getLastResponse

### DIFF
--- a/src/VCR/Util/SoapClient.php
+++ b/src/VCR/Util/SoapClient.php
@@ -17,8 +17,14 @@ class SoapClient extends \SoapClient
 
     protected $options = array();
 
+    /**
+     * @var string
+     */
     protected $response;
 
+    /**
+     * @var string
+     */
     protected $request;
 
     public function __construct($wsdl, $options = array()) {
@@ -56,11 +62,17 @@ class SoapClient extends \SoapClient
         return $one_way ? null : $response;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function __getLastRequest()
     {
         return $this->request;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function __getLastResponse()
     {
         return $this->response;

--- a/src/VCR/Util/SoapClient.php
+++ b/src/VCR/Util/SoapClient.php
@@ -17,6 +17,10 @@ class SoapClient extends \SoapClient
 
     protected $options = array();
 
+    protected $response;
+
+    protected $request;
+
     public function __construct($wsdl, $options = array()) {
        $this->options = $options;
        parent::__construct($wsdl, $options);
@@ -37,6 +41,8 @@ class SoapClient extends \SoapClient
      */
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
+        $this->request = $request;
+
         $soapHook = $this->getLibraryHook();
 
         if ($soapHook->isEnabled()) {
@@ -45,7 +51,19 @@ class SoapClient extends \SoapClient
             $response = $this->realDoRequest($request, $location, $action, $version, $one_way);
         }
 
+        $this->response = $response;
+
         return $one_way ? null : $response;
+    }
+
+    public function __getLastRequest()
+    {
+        return $this->request;
+    }
+
+    public function __getLastResponse()
+    {
+        return $this->response;
     }
 
     /**

--- a/tests/VCR/Util/SoapClientTest.php
+++ b/tests/VCR/Util/SoapClientTest.php
@@ -139,4 +139,29 @@ class SoapClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('\VCR\LibraryHooks\SoapHook', $client->getLibraryHook());
     }
+
+    public function testGetLastWhateverBeforeRequest()
+    {
+        $client = new SoapClient(self::WSDL);
+
+        $this->assertNull($client->__getLastRequest());
+        $this->assertNull($client->__getLastResponse());
+    }
+
+    public function testGetLastWhateverAfterRequest()
+    {
+        $request  = 'Knorx ist groß';
+        $response = 'some value';
+
+        $hook = $this->getLibraryHookMock(true);
+        $hook->expects($this->once())->method('doRequest')->will($this->returnValue($response));
+
+        $client = new SoapClient(self::WSDL);
+        $client->setLibraryHook($hook);
+
+        $client->__doRequest($request, self::WSDL, self::ACTION, SOAP_1_2, 0);
+
+        $this->assertEquals($request, $client->__getLastRequest());
+        $this->assertEquals($response, $client->__getLastResponse());
+    }
 }


### PR DESCRIPTION
This fixes ```VCR/Utils/SoapClient```'s ```__getLastRequest()``` and ```__getLastResponse()``` stuff, but i dont have a mind how to deal with __getLastRequestHeaders and __getLastResponseHeaders, and looks like i don't need it 'cause it just returns http headers but not SOAP headers. I can parse SOAP headers out of request/response body, so i give up on fixing __getLastRequestHeaders and __getLastResponseHeaders for now.