### PR TITLE
Reset request on curl_reset

### DIFF
--- a/src/VCR/CodeTransform/CurlCodeTransform.php
+++ b/src/VCR/CodeTransform/CurlCodeTransform.php
@@ -15,7 +15,8 @@ class CurlCodeTransform extends AbstractCodeTransform
         '/(?<!::|->|\w_)\\\?curl_multi_add_handle\s*\(/i'    => '\VCR\LibraryHooks\CurlHook::curl_multi_add_handle(',
         '/(?<!::|->|\w_)\\\?curl_multi_remove_handle\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_multi_remove_handle(',
         '/(?<!::|->|\w_)\\\?curl_multi_exec\s*\(/i'          => '\VCR\LibraryHooks\CurlHook::curl_multi_exec(',
-        '/(?<!::|->|\w_)\\\?curl_multi_info_read\s*\(/i'     => '\VCR\LibraryHooks\CurlHook::curl_multi_info_read('
+        '/(?<!::|->|\w_)\\\?curl_multi_info_read\s*\(/i'     => '\VCR\LibraryHooks\CurlHook::curl_multi_info_read(',
+        '/(?<!::|->|\w_)\\\?curl_reset\s*\(/i'               => '\VCR\LibraryHooks\CurlHook::curl_reset('
     );
 
     /**

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -154,13 +154,6 @@ class CurlHook implements LibraryHook
         return \call_user_func_array(array(__CLASS__, $localMethod), $args);
     }
 
-    public static function curlReset($curlHandle)
-    {
-        \curl_reset($curlHandle);
-        self::$requests[(int) $curlHandle] = new Request('GET', null);
-        self::$curlOptions[(int) $curlHandle] = array();
-    }
-
     /**
      * Initialize a cURL session.
      *
@@ -179,6 +172,21 @@ class CurlHook implements LibraryHook
     }
 
     /**
+     * Reset a cURL session.
+     *
+     * @link http://www.php.net/manual/en/function.curl-reset.php
+     * @param resource $curlHandle A cURL handle returned by curl_init().
+     *
+     * @return void
+     */
+    public static function curlReset($curlHandle)
+    {
+        \curl_reset($curlHandle);
+        self::$requests[(int) $curlHandle] = new Request('GET', null);
+        self::$curlOptions[(int) $curlHandle] = array();
+    }
+
+    /**
      * Perform a cURL session.
      *
      * @link http://www.php.net/manual/en/function.curl-exec.php
@@ -192,7 +200,7 @@ class CurlHook implements LibraryHook
     {
         $request = self::$requests[(int) $curlHandle];
         CurlHelper::validateCurlPOSTBody($request, $curlHandle);
-        
+
         $requestCallback = self::$requestCallback;
         self::$responses[(int) $curlHandle] = $requestCallback($request);
 
@@ -210,7 +218,7 @@ class CurlHook implements LibraryHook
      * @param resource $multiHandle A cURL multi handle returned by curl_multi_init().
      * @param resource $curlHandle  A cURL handle returned by curl_init().
      *
-     * @return integer Returns 0 on success, or one of the CURLM_XXX errors code.
+     * @return void
      */
     public static function curlMultiAddHandle($multiHandle, $curlHandle)
     {
@@ -228,7 +236,7 @@ class CurlHook implements LibraryHook
      * @param resource $multiHandle A cURL multi handle returned by curl_multi_init().
      * @param resource $curlHandle A cURL handle returned by curl_init().
      *
-     * @return integer  Returns 0 on success, or one of the CURLM_XXX error codes.
+     * @return void
      */
     public static function curlMultiRemoveHandle($multiHandle, $curlHandle)
     {
@@ -326,7 +334,7 @@ class CurlHook implements LibraryHook
      * @param resource $curlHandle A cURL handle returned by curl_init().
      * @param array    $options    An array specifying which options to set and their values.
      *
-     * @return boolean|null              Returns TRUE if all options were successfully set.
+     * @return void
      */
     public static function curlSetoptArray($curlHandle, $options)
     {

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -176,8 +176,6 @@ class CurlHook implements LibraryHook
      *
      * @link http://www.php.net/manual/en/function.curl-reset.php
      * @param resource $curlHandle A cURL handle returned by curl_init().
-     *
-     * @return void
      */
     public static function curlReset($curlHandle)
     {
@@ -217,8 +215,6 @@ class CurlHook implements LibraryHook
      * @link http://www.php.net/manual/en/function.curl-multi-add-handle.php
      * @param resource $multiHandle A cURL multi handle returned by curl_multi_init().
      * @param resource $curlHandle  A cURL handle returned by curl_init().
-     *
-     * @return void
      */
     public static function curlMultiAddHandle($multiHandle, $curlHandle)
     {
@@ -235,8 +231,6 @@ class CurlHook implements LibraryHook
      * @link http://www.php.net/manual/en/function.curl-multi-remove-handle.php
      * @param resource $multiHandle A cURL multi handle returned by curl_multi_init().
      * @param resource $curlHandle A cURL handle returned by curl_init().
-     *
-     * @return void
      */
     public static function curlMultiRemoveHandle($multiHandle, $curlHandle)
     {
@@ -333,8 +327,6 @@ class CurlHook implements LibraryHook
      * @link http://www.php.net/manual/en/function.curl-setopt-array.php
      * @param resource $curlHandle A cURL handle returned by curl_init().
      * @param array    $options    An array specifying which options to set and their values.
-     *
-     * @return void
      */
     public static function curlSetoptArray($curlHandle, $options)
     {

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -154,6 +154,13 @@ class CurlHook implements LibraryHook
         return \call_user_func_array(array(__CLASS__, $localMethod), $args);
     }
 
+    public static function curlReset($curlHandle)
+    {
+        \curl_reset($curlHandle);
+        self::$requests[(int) $curlHandle] = new Request('GET', null);
+        self::$curlOptions[(int) $curlHandle] = array();
+    }
+
     /**
      * Initialize a cURL session.
      *

--- a/tests/VCR/CodeTransform/CurlCodeTransformTest.php
+++ b/tests/VCR/CodeTransform/CurlCodeTransformTest.php
@@ -30,6 +30,7 @@ class CurlCodeTransformTest extends \PHPUnit_Framework_TestCase
             array('\VCR\LibraryHooks\CurlHook::curl_multi_remove_handle(', 'curl_multi_remove_handle('),
             array('\VCR\LibraryHooks\CurlHook::curl_multi_exec(', 'curl_multi_exec('),
             array('\VCR\LibraryHooks\CurlHook::curl_multi_info_read(', 'curl_multi_info_read('),
+            array('\VCR\LibraryHooks\CurlHook::curl_reset(', 'curl_reset('),
 
             array('\VCR\LibraryHooks\CurlHook::curl_init(', '\\CURL_INIT ('),
             array('\VCR\LibraryHooks\CurlHook::curl_exec(', '\\curl_exec('),
@@ -39,6 +40,7 @@ class CurlCodeTransformTest extends \PHPUnit_Framework_TestCase
             array('\VCR\LibraryHooks\CurlHook::curl_multi_remove_handle(', '\\curl_multi_remove_handle('),
             array('\VCR\LibraryHooks\CurlHook::curl_multi_exec(', '\\curl_multi_exec('),
             array('\VCR\LibraryHooks\CurlHook::curl_multi_info_read(', '\\curl_multi_info_read('),
+            array('\VCR\LibraryHooks\CurlHook::curl_reset(', '\\curl_reset('),
 
             array('SomeClass::CURL_INIT (', 'SomeClass::CURL_INIT ('),
             array('SomeClass::curl_exec(', 'SomeClass::curl_exec('),
@@ -48,6 +50,7 @@ class CurlCodeTransformTest extends \PHPUnit_Framework_TestCase
             array('SomeClass::curl_multi_remove_handle(', 'SomeClass::curl_multi_remove_handle('),
             array('SomeClass::curl_multi_exec(', 'SomeClass::curl_multi_exec('),
             array('SomeClass::curl_multi_info_read(', 'SomeClass::curl_multi_info_read('),
+            array('SomeClass::curl_reset(', 'SomeClass::curl_reset('),
 
             array('$object->CURL_INIT (', '$object->CURL_INIT ('),
             array('$object->curl_exec(', '$object->curl_exec('),
@@ -57,6 +60,7 @@ class CurlCodeTransformTest extends \PHPUnit_Framework_TestCase
             array('$object->curl_multi_remove_handle(', '$object->curl_multi_remove_handle('),
             array('$object->curl_multi_exec(', '$object->curl_multi_exec('),
             array('$object->curl_multi_info_read(', '$object->curl_multi_info_read('),
+            array('$object->curl_reset(', '$object->curl_reset('),
 
             array('function send_http_asynchronous_curl_exec(', 'function send_http_asynchronous_curl_exec(')
         );

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -303,19 +303,22 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         curl_multi_close($curlMultiHandle);
     }
 
+    /**
+     * @requires PHP 5.5.0
+     */
     public function testShouldResetRequest()
     {
-      $testClass = $this;
-      $this->curlHook->enable(
-          function (Request $request) use ($testClass) {
-              $testClass->assertEquals(
-                  'GET',
-                  $request->getMethod(),
-                  ''
-              );
-              return new Response(200);
-          }
-      );
+        $testClass = $this;
+        $this->curlHook->enable(
+            function (Request $request) use ($testClass) {
+                $testClass->assertEquals(
+                    'GET',
+                    $request->getMethod(),
+                    ''
+                );
+                return new Response(200);
+            }
+        );
 
         $curlHandle = curl_init("http://example.com");
         curl_setopt($curlHandle, CURLOPT_CUSTOMREQUEST, "DELETE");

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -303,6 +303,28 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         curl_multi_close($curlMultiHandle);
     }
 
+    public function testShouldResetRequest()
+    {
+      $testClass = $this;
+      $this->curlHook->enable(
+          function (Request $request) use ($testClass) {
+              $testClass->assertEquals(
+                  'GET',
+                  $request->getMethod(),
+                  ''
+              );
+              return new Response(200);
+          }
+      );
+
+        $curlHandle = curl_init("http://example.com");
+        curl_setopt($curlHandle, CURLOPT_CUSTOMREQUEST, "DELETE");
+        curl_reset($curlHandle);
+        curl_exec($curlHandle);
+
+        $this->curlHook->disable();
+    }
+
     /**
      * @return \callable
      */


### PR DESCRIPTION
Guzzle reuses curl handles in which case it does not curl_init a new handle.

In this scenario requests are not reset in php-vcr causing attributes to leak into subsequent requests. 

This change implements curl_reset to create a new request object against the curl handle.