### PR TITLE
add branch alias for master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
 
     "autoload": {
         "classmap": ["src/"]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.2.x-dev"
+        }
     }
 }


### PR DESCRIPTION
this would help people to depend on `1.2.*@dev` instead of `dev-master` when needing not yet released features.