### PR TITLE
Fix parallel cURL requests

### DIFF
--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -46,9 +46,9 @@ class CurlHook implements LibraryHook
     protected static $multiHandles = array();
 
     /**
-     * @var resource Last active curl_multi_exec() handle.
+     * @var array Last active curl_multi_exec() handles.
      */
-    protected static $multiExecLastCh;
+    protected static $multiExecLastChs = array();
 
     /**
      * @var AbstractCodeTransform
@@ -253,7 +253,7 @@ class CurlHook implements LibraryHook
         if (isset(self::$multiHandles[(int) $multiHandle])) {
             foreach (self::$multiHandles[(int) $multiHandle] as $curlHandle) {
                 if (!isset(self::$responses[(int) $curlHandle])) {
-                    self::$multiExecLastCh = $curlHandle;
+                    self::$multiExecLastChs[] = $curlHandle;
                     self::curlExec($curlHandle);
                 }
             }
@@ -271,13 +271,12 @@ class CurlHook implements LibraryHook
      */
     public static function curlMultiInfoRead()
     {
-        if (self::$multiExecLastCh) {
+        if (!empty(self::$multiExecLastChs)) {
             $info = array(
                 'msg' => CURLMSG_DONE,
-                'handle' => self::$multiExecLastCh,
+                'handle' => array_pop(self::$multiExecLastChs),
                 'result' => CURLE_OK
             );
-            self::$multiExecLastCh = null;
 
             return $info;
         }

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -266,8 +266,10 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         curl_multi_add_handle($curlMultiHandle, $curlHandle2);
 
         $mh = curl_multi_exec($curlMultiHandle);
-        $lastInfo = curl_multi_info_read($mh);
-        $afterLastInfo = curl_multi_info_read($mh);
+
+        $lastInfo       = curl_multi_info_read($mh);
+        $secondLastInfo = curl_multi_info_read($mh);
+        $afterLastInfo  = curl_multi_info_read($mh);
 
         curl_multi_remove_handle($curlMultiHandle, $curlHandle1);
         curl_multi_remove_handle($curlMultiHandle, $curlHandle2);
@@ -281,6 +283,13 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
             $lastInfo,
             'When called the first time curl_multi_info_read should return last curl info.'
         );
+
+        $this->assertEquals(
+            array('msg' => 1, 'result' => 0, 'handle' => $curlHandle1),
+            $secondLastInfo,
+            'When called the second time curl_multi_info_read should return second to last curl info.'
+        );
+
         $this->assertFalse($afterLastInfo, 'Multi info called the last time should return false.');
     }
 


### PR DESCRIPTION
- Make sure all handles are inside an array so they can be removed
  properly when done
- Remove handle as soon as done

Makes the VCR working with Guzzle6 parallel requests based on promises. Using Guzzle6 parallel requests caused the application to hang because handles have never been removed.
