### PR TITLE
Improve reporting when cassette does not contain response

### DIFF
--- a/tests/VCR/VideorecorderTest.php
+++ b/tests/VCR/VideorecorderTest.php
@@ -155,7 +155,7 @@ class VideorecorderTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('playback')
             ->with($request)
-            ->will($this->returnValue(null));
+            ->will($this->throwException(new \OutOfBoundsException()));
 
         if (VCR::MODE_NEW_EPISODES === $mode || VCR::MODE_ONCE === $mode && $isNew === true) {
             $cassette


### PR DESCRIPTION
It may be tricky to determine why a recorded response is not used as no
information about how the actual request compares to the recorded once.

This change changes the behaviour of the playback method to throw an 
exception is a match is not found. The message contains information 
about the involved requests.

If PHP-VCR is also configured not to allow recording of new requests 
then the new exception is chained to the existing one.

Additional information related to request matching is added to the new
root exception.

This relates to the original problem in #94.

The resulting output will look something like this:

![4 bash 2016-05-24 11-43-49](https://cloud.githubusercontent.com/assets/73966/15499502/da3e54da-21a4-11e6-9332-cb2eb7934a2b.png)
