### PR TITLE
Enable recording of identical requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-curl": "*",
         "beberlei/assert": "2.*",
         "symfony/yaml": "2.*|3.*",
-        "symfony/event-dispatcher": "~2.1|3.*"
+        "symfony/event-dispatcher": "^2.4|^3.0|^4.0"
     },
 
     "require-dev": {

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -134,6 +134,11 @@ class Cassette
         return $this->storage->isNew();
     }
 
+    public function resetIndex()
+    {
+        $this->indexTable = [];
+    }
+
     /**
      * Returns a list of callbacks to configured request matchers.
      *

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -31,6 +31,13 @@ class Cassette
     protected $storage;
 
     /**
+     * Tracks the number of occurrence of a given request
+     *
+     * @var array
+     */
+    protected $indexTable = [];
+
+    /**
      * Creates a new cassette.
      *
      * @param  string           $name    Name of the cassette.
@@ -68,10 +75,15 @@ class Cassette
      */
     public function playback(Request $request)
     {
+        // Track how many times the same request occurs
+        $this->iterateIndex($request);
+
         foreach ($this->storage as $recording) {
             $storedRequest = Request::fromArray($recording['request']);
-            if ($storedRequest->matches($request, $this->getRequestMatchers())) {
-                return Response::fromArray($recording['response']);
+            if ($this->indexTable[$request->getHash()] === $recording['index']) {
+                if ($storedRequest->matches($request, $this->getRequestMatchers())) {
+                    return Response::fromArray($recording['response']);
+                }
             }
         }
 
@@ -94,7 +106,9 @@ class Cassette
 
         $recording = array(
             'request'  => $request->toArray(),
-            'response' => $response->toArray()
+            'response' => $response->toArray(),
+            // Save the nth time that this request was executed
+            'index' => $this->indexTable[$request->getHash()]
         );
 
         $this->storage->storeRecording($recording);
@@ -128,5 +142,14 @@ class Cassette
     protected function getRequestMatchers()
     {
         return $this->config->getRequestMatchers();
+    }
+
+    protected function iterateIndex(Request $request)
+    {
+        $hash = $request->getHash();
+        if (!isset($this->indexTable[$hash])) {
+            $this->indexTable[$hash] = -1;
+        }
+        $this->indexTable[$hash]++;
     }
 }

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -35,7 +35,7 @@ class Cassette
      *
      * @var array
      */
-    protected $indexTable = [];
+    protected $indexTable = array();
 
     /**
      * Creates a new cassette.
@@ -136,7 +136,7 @@ class Cassette
 
     public function resetIndex()
     {
-        $this->indexTable = [];
+        $this->indexTable = array();
     }
 
     /**

--- a/src/VCR/Request.php
+++ b/src/VCR/Request.php
@@ -335,4 +335,14 @@ class Request
         $this->postFiles[] = $file;
     }
 
+    /**
+     * Generate a string representation of the request
+     *
+     * @return string
+     */
+    public function getHash()
+    {
+        return md5(serialize($this->toArray()));
+    }
+
 }

--- a/tests/VCR/CassetteTest.php
+++ b/tests/VCR/CassetteTest.php
@@ -36,11 +36,14 @@ class CassetteTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request('GET', 'https://example.com');
         $response1 = new Response(200, array(), 'sometest');
-        $response2 = new Response(200, array(), 'sometest');
+        $response2 = new Response(200, array(), 'sometest2');
         $this->cassette->record($request, $response1);
         $this->cassette->record($request, $response2);
 
+        $this->resetIndex();
+
         $this->assertEquals($response1->toArray(), $this->cassette->playback($request)->toArray());
+        $this->assertEquals($response2->toArray(), $this->cassette->playback($request)->toArray());
     }
 
     public function testPlaybackAlreadyRecordedRequest()
@@ -48,6 +51,8 @@ class CassetteTest extends \PHPUnit_Framework_TestCase
         $request = new Request('GET', 'https://example.com');
         $response = new Response(200, array(), 'sometest');
         $this->cassette->record($request, $response);
+
+        $this->resetIndex();
 
         $this->assertEquals($response->toArray(), $this->cassette->playback($request)->toArray());
     }
@@ -65,6 +70,15 @@ class CassetteTest extends \PHPUnit_Framework_TestCase
         $response = new Response(200, array(), 'sometest');
         $this->cassette->record($request, $response);
 
+        $this->resetIndex();
+
         $this->assertTrue($this->cassette->hasResponse($request), 'Expected true if request was found.');
+    }
+
+    private function resetIndex()
+    {
+        // needed to simulate that a testcase has been run, and we are
+        // rerunning the same tests again, thus needing to load from cassette
+        $this->cassette->resetIndex();
     }
 }

--- a/tests/fixtures/unittest_curl_test
+++ b/tests/fixtures/unittest_curl_test
@@ -19,3 +19,4 @@
             X-XSS-Protection: '1; mode=block'
             X-Frame-Options: SAMEORIGIN
         body: "This is a curl test dummy."
+    index: 0

--- a/tests/fixtures/unittest_guzzle_test
+++ b/tests/fixtures/unittest_guzzle_test
@@ -20,3 +20,4 @@
             x-ec-custom-error: '1'
             Content-Length: '1270'
         body: "This is a guzzle test dummy."
+    index: 0

--- a/tests/fixtures/unittest_soap_test
+++ b/tests/fixtures/unittest_soap_test
@@ -19,6 +19,7 @@
             Date: 'Fri, 25 Apr 2014 09:22:59 GMT'
             Content-Length: '756'
         body: '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><GetCityWeatherByZIPResponse xmlns="http://ws.cdyne.com/WeatherWS/"><GetCityWeatherByZIPResult><Success>true</Success><ResponseText>City Found</ResponseText><State>NY</State><City>New York</City><WeatherStationCity>White Plains</WeatherStationCity><WeatherID>3</WeatherID><Description>Mostly Cloudy</Description><Temperature>1337</Temperature><RelativeHumidity>75</RelativeHumidity><Wind>NE7</Wind><Pressure>30.12F</Pressure><Visibility /><WindChill /><Remarks /></GetCityWeatherByZIPResult></GetCityWeatherByZIPResponse></soap:Body></soap:Envelope>'
+    index: 0
 -
     request:
         method: POST
@@ -43,3 +44,4 @@
             Date: 'Sat, 21 Feb 2015 14:09:36 GMT'
             Content-Length: '753'
         body: '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><GetCityWeatherByZIPResponse xmlns="http://ws.cdyne.com/WeatherWS/"><GetCityWeatherByZIPResult><Success>true</Success><ResponseText>City Found</ResponseText><State>NY</State><City>New York</City><WeatherStationCity>White Plains</WeatherStationCity><WeatherID>15</WeatherID><Description>N/A</Description><Temperature>63</Temperature><RelativeHumidity>87</RelativeHumidity><Wind>E7</Wind><Pressure>29.97S</Pressure><Visibility /><WindChill /><Remarks /></GetCityWeatherByZIPResult></GetCityWeatherByZIPResponse></soap:Body></soap:Envelope>'
+    index: 1

--- a/tests/fixtures/unittest_streamwrapper_test
+++ b/tests/fixtures/unittest_streamwrapper_test
@@ -21,3 +21,4 @@
             x-ec-custom-error: '1'
             Content-Length: '1270'
         body: "This is a stream wrapper test dummy."
+    index: 0

--- a/tests/integration/soap/src/VCR/Example/ExampleSoapClient.php
+++ b/tests/integration/soap/src/VCR/Example/ExampleSoapClient.php
@@ -8,7 +8,7 @@ namespace VCR\Example;
  */
 class ExampleSoapClient
 {
-    const EXAMPLE_WSDL = 'http://www.w3schools.com/webservices/tempconvert.asmx?wsdl';
+    const EXAMPLE_WSDL = 'http://www.w3schools.com/xml/tempconvert.asmx?WSDL';
 
     public function call($zip = '10')
     {


### PR DESCRIPTION
This PR will introduce the tracking of identical requests, thus enabling PHP-VCR to record different responses of the same request within the same cassette. This closes issue #132 

Right now PHP-VCR only tracks one occurrence of a given request
per cassette. An example of why this is troublesome is given below.
- (1) Request a resource from an external endpoint (GET /resource)
- (2) Request an update to that resource (PUT /resource)
- (3) Re-request the resource to confirm it was persisted remotely (GET /resource)

Requests (1) and (3) are identical, however the responses are expected
to be different. PHP-VCR will only record (1) and use the saved version
on (3).

This commit keeps track of the order of occurrence of requests, meaning
(1) is the 1st occurrence of (GET /resource) and (3) is the 2nd. When
the test is re-run, when running (3) PHP-VCR will now look for a
saved request which is the 2nd (GET /resource).

Ref #132 
