### PR TITLE
Throw VCRException when cURL request fails

### DIFF
--- a/src/VCR/Util/HttpClient.php
+++ b/src/VCR/Util/HttpClient.php
@@ -3,6 +3,7 @@ namespace VCR\Util;
 
 use VCR\Request;
 use VCR\Response;
+use VCR\VCRException;
 
 /**
  * Sends requests over the HTTP protocol.
@@ -13,6 +14,7 @@ class HttpClient
      * Returns a response for specified HTTP request.
      *
      * @param Request $request HTTP Request to send.
+     * @throws \VCR\VCRException on curl error
      *
      * @return Response Response for specified request.
      */
@@ -34,7 +36,7 @@ class HttpClient
         $response = curl_exec($ch);
 
         if ($response === false) {
-          throw new \VCR\VCRException(curl_error($ch), curl_errno($ch));
+          throw new VCRException(curl_error($ch), curl_errno($ch));
         }
 
         list($status, $headers, $body) = HttpUtil::parseResponse($response);

--- a/src/VCR/Util/HttpClient.php
+++ b/src/VCR/Util/HttpClient.php
@@ -31,7 +31,13 @@ class HttpClient
         curl_setopt($ch, CURLOPT_FAILONERROR, false);
         curl_setopt($ch, CURLOPT_HEADER, true);
 
-        list($status, $headers, $body) = HttpUtil::parseResponse(curl_exec($ch));
+        $response = curl_exec($ch);
+
+        if ($response === false) {
+          throw new \VCR\VCRException(curl_error($ch), curl_errno($ch));
+        }
+
+        list($status, $headers, $body) = HttpUtil::parseResponse($response);
 
         return new Response(
             HttpUtil::parseStatus($status),

--- a/src/VCR/Util/HttpClient.php
+++ b/src/VCR/Util/HttpClient.php
@@ -36,7 +36,7 @@ class HttpClient
         $response = curl_exec($ch);
 
         if ($response === false) {
-          throw new VCRException(curl_error($ch), curl_errno($ch));
+            throw new VCRException(curl_error($ch), curl_errno($ch));
         }
 
         list($status, $headers, $body) = HttpUtil::parseResponse($response);

--- a/tests/VCR/Util/HttpClientTest.php
+++ b/tests/VCR/Util/HttpClientTest.php
@@ -16,4 +16,17 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('\VCR\Util\HttpClient', new HttpClient());
     }
+
+    public function testHttpClientRequestThrowsExceptionOnCurlError()
+    {
+        $request = new Request('GET', 'http://error.test', array('User-Agent' => 'Unit-Test'));
+        $client = new HttpClient();
+
+        $this->setExpectedException(
+            'VCR\VCRException',
+            "Couldn't resolve host 'error.test'"
+        );
+
+        $client->send($request);
+    }
 }


### PR DESCRIPTION
Prior to this change, a cURL failure in which `curl_exec()` returns `false`, was resulting in a less than helpful "Undefined offset: 1" exception being thrown from the [`explode()` call in `HttpUtil.parseResponse()`](https://github.com/php-vcr/php-vcr/blob/master/src/VCR/Util/HttpUtil.php#L66)

This change throws a `VCRException` with the underlying curl error and error number, making debugging that much easier
