### PR TITLE
Fix for parsing header values that include colons followed by spaces

### DIFF
--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -19,7 +19,7 @@ class HttpUtil
 
         // Collect matching headers into groups
         foreach ($headers as $line) {
-            list ($key, $value) = explode(': ', $line);
+            list ($key, $value) = explode(': ', $line, 2);
             if (!isset($headerGroups[$key])) {
                 $headerGroups[$key] = array();
             }

--- a/tests/VCR/Util/HttpUtilTest.php
+++ b/tests/VCR/Util/HttpUtilTest.php
@@ -128,4 +128,16 @@ class HttpUtilTest extends \PHPUnit_Framework_TestCase
         $outputArray = HttpUtil::parseHeaders($inputArray);
         $this->assertEquals($excpetedHeaders, $outputArray);
     }
+
+    public function testParseHeadersIncludingColons()
+    {
+        $inputArray = array(
+            'dropbox-api-result: {"name": "a_file.txt"}'
+        );
+        $excpetedHeaders = array(
+            'dropbox-api-result' => '{"name": "a_file.txt"}'
+        );
+        $outputArray = HttpUtil::parseHeaders($inputArray);
+        $this->assertEquals($excpetedHeaders, $outputArray);
+    }
 }


### PR DESCRIPTION
Header values that contain colons followed by spaces can fool `HttpUtil::parseHeaders`. I hit this some Dropbox API responses that include JSON in header values. I've included the simple fix, along with an extra unit test.