### PR TITLE
Fixes #153: SoapClient::__getLastRequest() returns NULL in PHP 5.3 and 5.4

### DIFF
--- a/src/VCR/Util/SoapClient.php
+++ b/src/VCR/Util/SoapClient.php
@@ -48,7 +48,7 @@ class SoapClient extends \SoapClient
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
         // Save a copy of the request, not the request itself -- see issue #153
-        $this->request = '' . $request;
+        $this->request = (string) $request;
 
         $soapHook = $this->getLibraryHook();
 

--- a/src/VCR/Util/SoapClient.php
+++ b/src/VCR/Util/SoapClient.php
@@ -47,7 +47,8 @@ class SoapClient extends \SoapClient
      */
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
-        $this->request = $request;
+        // Save a copy of the request, not the request itself -- see issue #153
+        $this->request = '' . $request;
 
         $soapHook = $this->getLibraryHook();
 

--- a/tests/VCR/LibraryHooks/SoapHookTest.php
+++ b/tests/VCR/LibraryHooks/SoapHookTest.php
@@ -72,6 +72,22 @@ class SoapHookTest extends \PHPUnit_Framework_TestCase
         $client->GetCityWeatherByZIP(array('ZIP' => '10013'));
     }
 
+    public function testShouldReturnLastRequestWithTraceOn()
+    {
+        $this->soapHook->enable($this->getContentCheckCallback());
+
+        $client = new \SoapClient(
+            'http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL',
+            array('soap_version' => SOAP_1_1, 'trace' => 1)
+        );
+        $client->setLibraryHook($this->soapHook);
+        $client->GetCityWeatherByZIP(array('ZIP' => '10013'));
+        $actual = $client->__getLastRequest();
+
+        $this->soapHook->disable();
+        $this->assertTrue(!is_null($actual), '__getLastRequest() returned NULL.');
+    }
+
     /**
      * @return \callable
      */


### PR DESCRIPTION
Please refer to https://github.com/php-vcr/php-vcr/pull/154 and https://github.com/php-vcr/php-vcr/issues/152
Credits to @buduchail