### PR TITLE
Set POST method when CURLOPT_POSTFIELDS is set

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -160,6 +160,7 @@ class CurlHelper
                 } else {
                     $request->setBody($value);
                 }
+                $request->setMethod('POST');
                 break;
             case CURLOPT_HTTPHEADER:
                 foreach ($value as $header) {

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -127,6 +127,16 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $request->getHeaders());
     }
 
+    public function testSetCurlOptionOnRequestPostFieldsSetsPostMethod()
+    {
+        $request = new Request('GET', 'example.com');
+        $payload = json_encode(array('some' => 'test'));
+
+        CurlHelper::setCurlOptionOnRequest($request, CURLOPT_POSTFIELDS, $payload);
+
+        $this->assertEquals('POST', $request->getMethod());
+    }
+
     public function testSetCurlOptionReadFunctionToNull()
     {
         $request = new Request('POST', 'example.com');


### PR DESCRIPTION
According to the curl documentation, using CURLOPT_POSTFIELDS implies CURLOPT_POST. This patch ensures that when CURLOPT_POST is not set and CURLOPT_POSTFIELDS is set, the request method is POST.