### PR TITLE
Fixes #103 is_writable on NFS mounts

### DIFF
--- a/src/VCR/CodeTransform/StreamProcessorCodeTransform.php
+++ b/src/VCR/CodeTransform/StreamProcessorCodeTransform.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace VCR\CodeTransform;
+
+class StreamProcessorCodeTransform extends AbstractCodeTransform
+{
+    const NAME = 'vcr_stream_processor';
+
+    private static $patterns = array(
+        '/(?<!::|->|\w_)\\\?is_writable\s*\(/i' => '\VCR\Util\StreamProcessor::is_writable(',
+        '/(?<!::|->|\w_)\\\?is_writeable\s*\(/i' => '\VCR\Util\StreamProcessor::is_writable(',
+    );
+
+    /**
+     * @inheritdoc
+     */
+    protected function transformCode($code)
+    {
+        return preg_replace(array_keys(self::$patterns), array_values(self::$patterns), $code);
+    }
+}

--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -2,6 +2,7 @@
 
 namespace VCR\Util;
 
+use VCR\CodeTransform\StreamProcessorCodeTransform;
 use VCR\Configuration;
 use VCR\CodeTransform\AbstractCodeTransform;
 
@@ -61,6 +62,10 @@ class StreamProcessor
     {
         if ($configuration) {
             static::$configuration = $configuration;
+
+            $codeTransformer = new StreamProcessorCodeTransform();
+            $codeTransformer->register();
+            $this->appendCodeTransformer($codeTransformer);
         }
     }
 
@@ -573,6 +578,24 @@ class StreamProcessor
                 break;
         }
         $this->intercept();
+
+        return $result;
+    }
+
+    /**
+     * Tells whether the filename is writable.
+     *
+     * @link http://php.net/manual/en/function.is-writable.php
+     * @param string $filename The filename being checked.
+     */
+    public static function is_writable($filename)
+    {
+        $hook = new self;
+        $hook->restore();
+
+        $result = is_writable($filename);
+
+        $hook->intercept();
 
         return $result;
     }

--- a/tests/VCR/CodeTransform/StreamProcessorCodeTransformTest.php
+++ b/tests/VCR/CodeTransform/StreamProcessorCodeTransformTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace VCR\CodeTransform;
+
+use lapistano\ProxyObject\ProxyBuilder;
+
+class StreamProcessorCodeTransformTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider codeSnippetProvider
+     */
+    public function testTransformCode($expected, $code)
+    {
+        $proxy = new ProxyBuilder('\VCR\CodeTransform\StreamProcessorCodeTransform');
+        $filter = $proxy
+            ->setMethods(array('transformCode'))
+            ->getProxy();
+
+        $this->assertEquals($expected, $filter->transformCode($code));
+    }
+
+    public function codeSnippetProvider()
+    {
+        return array(
+            array('\VCR\Util\StreamProcessor::is_writable(', 'is_writable ('),
+            array('\VCR\Util\StreamProcessor::is_writable(', '\\is_writable ('),
+            array('SomeClass::is_writable (', 'SomeClass::is_writable ('),
+            array('$object->is_writable (', '$object->is_writable ('),
+            array('function something_is_writable(', 'function something_is_writable('),
+
+            array('\VCR\Util\StreamProcessor::is_writable(', 'is_writeable ('),
+            array('SomeClass::is_writeable (', 'SomeClass::is_writeable ('),
+            array('$object->is_writeable (', '$object->is_writeable ('),
+            array('function something_is_writeable(', 'function something_is_writeable(')
+        );
+    }
+}

--- a/tests/VCR/Util/StreamProcessorTest.php
+++ b/tests/VCR/Util/StreamProcessorTest.php
@@ -98,8 +98,27 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
         restore_error_handler();
     }
 
+    public function testWritableForUnknownUser()
+    {
+        // This test should run in a Virtualbox VM using NFS to mount
+        // the tests fixtures, see https://github.com/php-vcr/php-vcr/issues/103.
+
+        // If it doesn't run the test also has value but doesn't test the bug.
+        $file = 'tests/fixtures/streamprocessor_data_wrong_user';
+
+        $processor = new StreamProcessor();
+        $processor->restore();
+        $this->assertTrue(is_writeable($file), "$file is not writable in the first place.");
+
+        $processor->intercept();
+        $this->assertTrue(is_writeable($file), "$file is not writable while intercepting.");
+
+        $processor->restore();
+        $this->assertTrue(is_writeable($file), "$file is not writable after intercepting.");
+    }
+
     /**
-     * @expectedException PHPUnit_Framework_Error_Warning
+     * @expectedException \PHPUnit_Framework_Error_Warning
      */
     public function testUrlStatFileNotFound()
     {

--- a/tests/fixtures/streamprocessor_data_wrong_user
+++ b/tests/fixtures/streamprocessor_data_wrong_user
@@ -1,0 +1,1 @@
+This is a testfile.


### PR DESCRIPTION
### Context

In #103 @dbu and @Danno040 discovered that there is an issue when using vagrant/virtualbox + NFS  mounts and trying to access.

### What has been done

- Overwrite `is_writable` calls with our own implementation that makes sure to restore stream wrappers for that call and intercept after again
- Added test a test

### How to test

- Checkout the source code of this project, switch to the `fix/is_writable_nfs` branch
- `composer install`
- Create a `Vagrantfile` with this content

    ```
    Vagrant.configure(2) do |config|
      config.vm.synced_folder ".", "/vagrant", type: "nfs"
      config.vm.network "private_network", type: "dhcp"
      config.vm.box = "laravel/homestead-7"
    end
    ```
- Run `vagrant up` and `vagrant ssh`
- Comment the  `appendCodeTransformer` line in the constructor of `StreamProcessor`
- `cd /vagrant && vendor/bin/phpunit --filter testWritableForUnknownUser`
- The test should fail
- Uncomment that line
- The test should pass

### Notes

- This is done to make sure to get [this `if` in the php-source](https://github.com/php/php-src/blob/2104bea5d756dfa40b605a4a2765a3bc4637a76c/ext/standard/filestat.c#L777) code to evaluate to `true`. Doing so will use the default behaviour which hits the C access functions instead of a manual access check based on the `uid`, `gid` and `mode`.


