### PR TITLE
Add function to easily retrieve request matcher names.

### DIFF
--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -266,6 +266,16 @@ class Configuration
     }
 
     /**
+     * Returns a list of valid names for request matchers, to pass to enableRequestMatchers.
+     *
+     * @return array List of strings, each representing a valid matcher name.
+     */
+    public function getAvailableRequestMatcherNames()
+    {
+        return array_keys($this->availableRequestMatchers);
+    }
+
+    /**
      * Adds a new RequestMatcher callback.
      *
      * @param string $name Name of the RequestMatcher.
@@ -299,7 +309,7 @@ class Configuration
             throw new \InvalidArgumentException("Request matchers don't exist: " . join(', ', $invalidMatchers));
         }
         $this->enabledRequestMatchers = $matchers;
-        
+
         return $this;
     }
 

--- a/tests/VCR/ConfigurationTest.php
+++ b/tests/VCR/ConfigurationTest.php
@@ -28,6 +28,16 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->config->setCassettePath('invalid_path');
     }
 
+    public function testGetAvailableMatcherNames()
+    {
+        $reflect = new \ReflectionClass($this->config);
+        $availableMatchers = $reflect->getProperty('availableRequestMatchers');
+        $availableMatchers->setAccessible(true);
+        $availableMatcherNames = array_keys($availableMatchers->getValue($this->config));
+
+        $this->assertSame($this->config->getAvailableRequestMatcherNames(), $availableMatcherNames);
+    }
+
     public function testGetLibraryHooks()
     {
         $this->assertEquals(


### PR DESCRIPTION
### Context

PHP-VCR expects me to enable matchers by name, but provides no way to get a list of names of available matchers from which to select.

### What has been done

- Add a function to get all names for available matchers.

### How to test

- Use the function.