### PR TITLE
Override the content type and encoding in the XML to work similar to SoapClient

### DIFF
--- a/src/VCR/LibraryHooks/SoapHook.php
+++ b/src/VCR/LibraryHooks/SoapHook.php
@@ -74,13 +74,21 @@ class SoapHook implements LibraryHook
 
         $vcrRequest = new Request('POST', $location);
 
+        $encoding = 'utf-8';
+        if (array_key_exists('encoding', $options)) {
+            $encoding = $options['encoding'];
+        }
+
         if ($version === SOAP_1_1) {
-            $vcrRequest->setHeader('Content-Type', 'text/xml; charset=utf-8;');
+            $vcrRequest->setHeader(
+                'Content-Type',
+                sprintf('text/xml; charset=%s;', $encoding)
+            );
             $vcrRequest->setHeader('SOAPAction', $action);
         } else { // >= SOAP_1_2
             $vcrRequest->setHeader(
                 'Content-Type',
-                sprintf('application/soap+xml; charset=utf-8; action="%s"', $action)
+                sprintf('application/soap+xml; charset=%s; action="%s"', $encoding, $action)
             );
         }
 

--- a/src/VCR/Util/SoapClient.php
+++ b/src/VCR/Util/SoapClient.php
@@ -50,6 +50,9 @@ class SoapClient extends \SoapClient
     {
         // Save a copy of the request, not the request itself -- see issue #153
         $this->request = (string) $request;
+        if (array_key_exists('encoding', $this->options)) {
+            $request = $this->request = preg_replace('/encoding="UTF-8"/', sprintf('encoding="%s"', $this->options['encoding']), $this->request);
+        }
 
         $soapHook = $this->getLibraryHook();
 


### PR DESCRIPTION
### Context

PHP-VCR ignores the encoding required from the WSDL which one needs to manually pass in.

### What has been done

- If encoding is in options in the SoapHook set the content type header for the encoding
- In the XML if the encoding is in the options replace UTF-8 with the given encoding.

### How to test

- Test SoapClient against http://ws.dev.freepaid.co.za/airtimeplus/

### Todo

- [ ]

### Notes

-
-