### PR TITLE
Fix permission deny warrning if the fixture file has read-only permission

### DIFF
--- a/src/VCR/Storage/AbstractStorage.php
+++ b/src/VCR/Storage/AbstractStorage.php
@@ -76,7 +76,7 @@ abstract class AbstractStorage implements Storage
         Assertion::file($this->filePath, "Specified path '{$this->filePath}' is not a file.");
         Assertion::readable($this->filePath, "Specified file '{$this->filePath}' must be readable.");
 
-        $this->handle = fopen($this->filePath, $this->filePath, is_writable($this->filePath) ? 'r+' : 'r');
+        $this->handle = fopen($this->filePath, is_writable($this->filePath) ? 'r+' : 'r');
     }
 
     /**

--- a/src/VCR/Storage/AbstractStorage.php
+++ b/src/VCR/Storage/AbstractStorage.php
@@ -76,7 +76,7 @@ abstract class AbstractStorage implements Storage
         Assertion::file($this->filePath, "Specified path '{$this->filePath}' is not a file.");
         Assertion::readable($this->filePath, "Specified file '{$this->filePath}' must be readable.");
 
-        $this->handle = fopen($this->filePath, 'r+');
+        $this->handle = fopen($this->filePath, $this->filePath, is_writable($this->filePath) ? 'r+' : 'r');
     }
 
     /**


### PR DESCRIPTION
If the fixture file has read-only permission function fopen throw a warning because r+ mode is used

