### PR TITLE
Always override request method if CURLOPT_CUSTOMREQUEST is set

### DIFF
--- a/src/VCR/Request.php
+++ b/src/VCR/Request.php
@@ -148,6 +148,10 @@ class Request
      */
     public function getMethod()
     {
+        if ($this->getCurlOption(CURLOPT_CUSTOMREQUEST) !== null) {
+            return $this->getCurlOption(CURLOPT_CUSTOMREQUEST);
+        }
+
         return $this->method;
     }
 

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -140,7 +140,7 @@ class CurlHelper
                 $request->setUrl($value);
                 break;
             case CURLOPT_CUSTOMREQUEST:
-                $request->setMethod($value);
+                $request->setCurlOption(CURLOPT_CUSTOMREQUEST, $value);
                 break;
             case CURLOPT_POST:
                 if ($value == true) {

--- a/tests/VCR/RequestTest.php
+++ b/tests/VCR/RequestTest.php
@@ -215,4 +215,19 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request('GET', 'http://example.com:5000/foo?param=key');
         $this->assertEquals('example.com:5000', $request->getHost());
     }
+
+    public function testCurlCustomRequestOverridesMethod()
+    {
+        $postRequest = new Request('POST', 'http://example.com');
+        $getRequest = new Request('GET', 'http://example.com');
+
+        $this->assertEquals('POST', $postRequest->getMethod());
+        $this->assertEquals('GET', $getRequest->getMethod());
+
+        $postRequest->setCurlOption(CURLOPT_CUSTOMREQUEST, 'PUT');
+        $getRequest->setCurlOption(CURLOPT_CUSTOMREQUEST, 'POST');
+
+        $this->assertEquals('PUT', $postRequest->getMethod());
+        $this->assertEquals('POST', $getRequest->getMethod());
+    }
 }

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -402,4 +402,26 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
+
+    public function testSetCurlOptionCustomRequest()
+    {
+        $request = new Request('POST', 'http://example.com');
+
+        CurlHelper::setCurlOptionOnRequest($request, CURLOPT_CUSTOMREQUEST, 'PUT');
+
+        $this->assertEquals('PUT', $request->getCurlOption(CURLOPT_CUSTOMREQUEST));
+    }
+
+    public function testCurlCustomRequestAlwaysOverridesMethod()
+    {
+        $request = new Request('POST', 'http://example.com');
+
+        CurlHelper::setCurlOptionOnRequest($request, CURLOPT_CUSTOMREQUEST, 'DELETE');
+
+        $this->assertEquals('DELETE', $request->getMethod());
+
+        CurlHelper::setCurlOptionOnRequest($request, CURLOPT_POSTFIELDS, array('some' => 'test'));
+
+        $this->assertEquals('DELETE', $request->getMethod());
+    }
 }


### PR DESCRIPTION
### Context
The cURL option CURLOPT_CUSTOMREQUEST can be used to send PUT/DELETE requests with message bodies. Currently, `CurlHelper` handles this option by calling `Request::setMethod`. This is not sufficient, because the handling of other options (such as CURLOPT_POSTFIELDS) also call `setMethod` and therefore override the custom request method. Seeing that there already is a way to set cURL options on the Request object, I've created a patch that makes php-vcr behave more like cURL itself.

### What has been done

- `Request::getMethod` returns the value of CURLOPT_CUSTOMREQUEST if set.
- `CurlHelper::setCurlOptionOnRequest` sets CURLOPT_CUSTOMREQUEST on the request instead of calling `setMethod`

### How to test

- See added test cases
- Try sending a PUT/DELETE request with a message body (I'm using Guzzle 6.2.1)

### Notes

- Did not run SOAP Weather test cases as the service is broken for me atm.
