### PR TITLE
Removing the automatic POST method for CURLOPT_POSTFIELDS

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -160,7 +160,6 @@ class CurlHelper
                 } else {
                     $request->setBody($value);
                 }
-                $request->setMethod('POST');
                 break;
             case CURLOPT_HTTPHEADER:
                 foreach ($value as $header) {

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -127,16 +127,6 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $request->getHeaders());
     }
 
-    public function testSetCurlOptionOnRequestPostFieldsSetsPostMethod()
-    {
-        $request = new Request('GET', 'example.com');
-        $payload = json_encode(array('some' => 'test'));
-
-        CurlHelper::setCurlOptionOnRequest($request, CURLOPT_POSTFIELDS, $payload);
-
-        $this->assertEquals('POST', $request->getMethod());
-    }
-
     public function testSetCurlOptionReadFunctionToNull()
     {
         $request = new Request('POST', 'example.com');


### PR DESCRIPTION
### Context
PUT- and DELETE-method requests can no longer be used with PHP-VCR because their methods are overridden.

### What has been done
Fixes #187 by reverting #175

### How to test
Same as before

### Todo
Perhaps a functional test to always ensure the method type is never corrupted

### Notes
- Had to pin to 1.3.1
- If this is necessary, would it do to check for an extant method and set if it is not present instead of this reversion? I'd be happy to rearrange this.