### PR TITLE
composer: bump to PHP 7.0+ as only developed version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
 
     "require": {
+        "php": "^7:0",
         "ext-curl": "*",
         "beberlei/assert": "^2.0",
         "symfony/yaml": "~2.1|^3.0",


### PR DESCRIPTION
See: http://php.net/supported-versions.php

![uu](https://cloud.githubusercontent.com/assets/924196/22532219/254ae6ba-e8e6-11e6-93cf-076637c1135b.png)
