### PR TITLE
Handle failed requests better when recording

### DIFF
--- a/src/VCR/CodeTransform/CurlCodeTransform.php
+++ b/src/VCR/CodeTransform/CurlCodeTransform.php
@@ -8,6 +8,8 @@ class CurlCodeTransform extends AbstractCodeTransform
 
     private static $patterns = array(
         '/(?<!::|->|\w_)\\\?curl_init\s*\(/i'                => '\VCR\LibraryHooks\CurlHook::curl_init(',
+        '/(?<!::|->|\w_)\\\?curl_errno\s*\(/i'               => '\VCR\LibraryHooks\CurlHook::curl_errno(',
+        '/(?<!::|->|\w_)\\\?curl_error\s*\(/i'               => '\VCR\LibraryHooks\CurlHook::curl_error(',
         '/(?<!::|->|\w_)\\\?curl_exec\s*\(/i'                => '\VCR\LibraryHooks\CurlHook::curl_exec(',
         '/(?<!::|->|\w_)\\\?curl_getinfo\s*\(/i'             => '\VCR\LibraryHooks\CurlHook::curl_getinfo(',
         '/(?<!::|->|\w_)\\\?curl_setopt\s*\(/i'              => '\VCR\LibraryHooks\CurlHook::curl_setopt(',

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -126,6 +126,25 @@ class CurlHelper
     }
 
     /**
+     * Returns a cURL option from a HttpClientException.
+     *
+     * @param  HttpClientException $response exception to get cURL option from.
+     * @param  integer $option cURL option to get.
+     *
+     * @throws \BadMethodCallException
+     * @return mixed Value of the cURL option.
+     */
+    public static function getCurlOptionFromException(HttpClientException $exception, $option = 0)
+    {
+        if ($option == 0) { // 0 == array of all curl options
+            return $exception->curlInfo;
+        } else if (isset($exception->curlInfo[$option])) {
+            return $exception->curlInfo[$option];
+        }
+        return false;
+    }
+
+    /**
      * Sets a cURL option on a Request.
      *
      * @param Request  $request Request to set cURL option to.

--- a/src/VCR/Util/HttpClientException.php
+++ b/src/VCR/Util/HttpClientException.php
@@ -1,0 +1,22 @@
+<?php
+namespace VCR\Util;
+
+use Exception;
+
+/**
+ * An exception from HttpClient::send
+ */
+class HttpClientException extends \Exception
+{
+    public function __construct(
+        $message,
+        $curlInfo,
+        $curlError,
+        $curlErroNo)
+    {
+        parent::__construct($message);
+        $this->curlInfo = $curlInfo;
+        $this->curlError = $curlError;
+        $this->curlErrorNo = $curlErroNo;
+    }
+}

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -247,14 +247,18 @@ class Videorecorder
         }
 
         $this->disableLibraryHooks();
+        try {
 
-        $this->dispatch(VCREvents::VCR_BEFORE_HTTP_REQUEST, new BeforeHttpRequestEvent($request));
-        $response = $this->client->send($request);
-        $this->dispatch(VCREvents::VCR_AFTER_HTTP_REQUEST, new AfterHttpRequestEvent($request, $response));
+            $this->dispatch(VCREvents::VCR_BEFORE_HTTP_REQUEST, new BeforeHttpRequestEvent($request));
+            $response = $this->client->send($request);
 
-        $this->dispatch(VCREvents::VCR_BEFORE_RECORD, new BeforeRecordEvent($request, $response, $this->cassette));
-        $this->cassette->record($request, $response);
-        $this->enableLibraryHooks();
+            $this->dispatch(VCREvents::VCR_AFTER_HTTP_REQUEST, new AfterHttpRequestEvent($request, $response));
+
+            $this->dispatch(VCREvents::VCR_BEFORE_RECORD, new BeforeRecordEvent($request, $response, $this->cassette));
+            $this->cassette->record($request, $response);
+        } finally {
+            $this->enableLibraryHooks();
+        }
 
         return $response;
     }

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -256,8 +256,11 @@ class Videorecorder
 
             $this->dispatch(VCREvents::VCR_BEFORE_RECORD, new BeforeRecordEvent($request, $response, $this->cassette));
             $this->cassette->record($request, $response);
-        } finally {
             $this->enableLibraryHooks();
+        } catch (Exception $e) {
+            // (This simulates a "finally" block; we should change to "finally" when we have PHP >= 5.3)
+            $this->enableLibraryHooks();
+            throw $e;
         }
 
         return $response;

--- a/tests/VCR/LibraryHooks/StreamWrapperHookTest.php
+++ b/tests/VCR/LibraryHooks/StreamWrapperHookTest.php
@@ -95,9 +95,8 @@ class StreamWrapperHookTest extends \PHPUnit_Framework_TestCase
             $this->fail("expected exception");
         } catch (Exception $e) {
             $errWithHook = $e;
-        } finally {
-            VCR::turnOff();
         }
+        VCR::turnOff();
 
         // Here, we'd like to be able to do:
         // $this->assertEquals($errWithoutHook, $errWithHook);

--- a/tests/VCR/LibraryHooks/StreamWrapperHookTest.php
+++ b/tests/VCR/LibraryHooks/StreamWrapperHookTest.php
@@ -2,8 +2,11 @@
 
 namespace VCR\LibraryHooks;
 
+use Exception;
 use VCR\Request;
 use VCR\Response;
+use VCR\VCR;
+use VCR\Videorecorder;
 
 /**
  * Test if intercepting http/https using stream wrapper works.
@@ -50,5 +53,68 @@ class StreamWrapperHookTest extends \PHPUnit_Framework_TestCase
 
         // invalid whence
         $this->assertFalse($hook->stream_seek(0, -1));
+
+        $hook->disable();
+    }
+
+    /**
+     * Check that the StreamWrapperHook does the best it can on a
+     * connection failure.
+     *
+     * Currently the behaviour does differ between with the hook
+     * and without the hook. See implementation notes in
+     * VCR\Util\HttpClient::send
+     */
+    public function testConnectionError()
+    {
+        $errWithoutHook = null;
+        try {
+            $context = stream_context_create(array(
+                'http' => array(
+                    'timeout' => 1
+                )
+            ));
+            file_get_contents('http://httpbin.org/delay/120', null, $context);
+
+            $this->fail("expected exception");
+        } catch (Exception $e) {
+            $errWithoutHook = $e;
+        }
+
+        $errWithHook = null;
+        VCR::turnOn();
+        VCR::insertCassette(str_replace('\\', '/', __CLASS__));
+        try {
+            $context = stream_context_create(array(
+                'http' => array(
+                    'timeout' => 1
+                )
+            ));
+            file_get_contents('http://httpbin.org/delay/120', null, $context);
+
+            $this->fail("expected exception");
+        } catch (Exception $e) {
+            $errWithHook = $e;
+        } finally {
+            VCR::turnOff();
+        }
+
+        // Here, we'd like to be able to do:
+        // $this->assertEquals($errWithoutHook, $errWithHook);
+
+        // but, as you can see:
+        $this->assertEquals(
+            'file_get_contents(http://httpbin.org/delay/120): failed to open stream: HTTP request failed! ',
+            $errWithoutHook->getMessage());
+        $this->assertEquals(
+            '28: Operation timed out after 1000 milliseconds with 0 bytes received',
+            $errWithHook->getMessage());
+
+        $this->assertEquals(
+            'PHPUnit_Framework_Error_Warning',
+            get_class($errWithoutHook));
+        $this->assertEquals(
+            'VCR\Util\HttpClientException',
+            get_class($errWithHook));
     }
 }

--- a/tests/integration/guzzle/5/ExampleHttpClient.php
+++ b/tests/integration/guzzle/5/ExampleHttpClient.php
@@ -7,12 +7,12 @@ use GuzzleHttp\Exception\ClientException;
 
 class ExampleHttpClient
 {
-    public function get($url)
+    public function get($url, $options = array())
     {
         $client = new Client();
 
         try {
-            $response = $client->get($url);
+            $response = $client->get($url, $options);
             return $response->json();
         } catch (ClientException $e) {
             if ($e->getCode() !== 404) {

--- a/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
+++ b/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
@@ -89,11 +89,19 @@ class ExampleHttpClientTest extends \PHPUnit_Framework_TestCase
             get_class($notInterceptedEx),
             get_class($interceptedEx));
         $this->assertEquals(
-            $notInterceptedEx->getMessage(),
-            $interceptedEx->getMessage());
+            $this->normaliseTimeoutExceptionMessage($notInterceptedEx->getMessage()),
+            $this->normaliseTimeoutExceptionMessage($interceptedEx->getMessage()));
         $this->assertEquals(
             $notInterceptedEx->getCode(),
             $interceptedEx->getCode());
+    }
+
+    /**
+     * The timeout exception message includes the exact time taken, which can
+     * vary a bit, but we don't want the test to fail due to timing jitter
+     */
+    private function normaliseTimeoutExceptionMessage($msg) {
+        return preg_replace('/after \d+ milliseconds/', 'after nnn milliseconds', $msg);
     }
 
     protected function requestGET($url = self::TEST_GET_URL, $options = array())


### PR DESCRIPTION
Previously failed requests would throw an unhelpful error if there was a network error while PHP-VCR was enabled.

Now they will simulate curl's behaviour faithfully on failed requests and throw a more helpful exception for the other Hooks.

### Context

The current `LibraryHook` implementations do not handle any request errors.

Currently, if there is a network error when making a request then all the `LibraryHook`s will throw     `Notice: Undefined offset: 1` at [`VCR\Util\HttpUtil.php:70`](https://github.com/php-vcr/php-vcr/blob/7c76cd26b557abf91a49558140e701b0d9309be9/src/VCR/Util/HttpUtil.php#L70-L70) while trying to parse `$response` which is `false`.

### What has been done

I have extended the `VCR\Util\HttpClient` class to throw an exception on a network error, rather than failing with this "Undefined offset" error.

I have extended the `CurlHook` to catch this error and correctly simulate the `curl` library's behaviour in the error case. This means that libraries like `Guzzle` will now behave correctly on network errors.

I have not change the other two `LibraryHook`s, but this change does still improve their behaviour in this case. Previously they would throw the "Notice: Undefined offset: 1" error, but now they will throw a meaningful PHP-VCR exception with details of the network error.

### How to test

I have added integration tests for the `CurlHook` and the `StreamWrapperHook`.

I was unable to add a test for the `SoapHook` as I don't know how to reliably trigger a SOAP network error.

### Todo

- It might be nice to add an integration test for the `SoapHook` if you know a way to reliably trigger a SOAP network error, but I don't think it's necessary
- It might be nice to enhance the `StreamWrapperHook` and `SoapHook` to more accurately simulate their underlying libraries' behaviour in the network error case, but I don't think it's necessary. The proposed behaviour is certainly better than the current behaviour in this scenario.
- I haven't tested `curl_multi_exec` on network errors when PHP-VCR is enabled. I expect the behaviour will be no worse than the current code. The behaviour on success is unchanged.

