### PR TITLE
Make handling of empty strings in CURLOPT_POSTFIELDS consistent.

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -157,7 +157,9 @@ class CurlHelper
                     if (count($value) == 0) {
                         $request->removeHeader('Content-Type');
                     }
-                } else {
+                } elseif (!empty($value)) {
+                    // Empty values are ignored to be consistent with how requests are read out of
+                    // storage using \VCR\Request::fromArray(array $request).
                     $request->setBody($value);
                 }
                 $request->setMethod('POST');

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -71,6 +71,18 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($payload, (string) $request->getBody());
     }
 
+    public function testSetCurlOptionOnRequestPostFieldsEmptyString()
+    {
+        $request = new Request('POST', 'example.com');
+        $payload = '';
+
+        CurlHelper::setCurlOptionOnRequest($request, CURLOPT_POSTFIELDS, $payload);
+
+        // This is consistent with how requests are read out of storage using
+        // \VCR\Request::fromArray(array $request).
+        $this->assertSame(null, $request->getBody());
+    }
+
     public function testSetCurlOptionOnRequestSetSingleHeader()
     {
         $request = new Request('GET', 'example.com');


### PR DESCRIPTION
### Context

Before this change empty strings in CURLOPT_POSTFIELDS weren't treated consistently. CurlHelper called `setBody` with an empty string, whereas `Request::fromArray` wouldn't call `setBody` at all, leaving the body as `null`. This means that stored requests are never matched because `null === ''` is false.

### What has been done

My aim was to make the handling consistent. I've done this by making CurlHelper ignore empty strings, so that it doesn't call `setBody` at all.

### How to test

- The testSetCurlOptionOnRequestPostFieldsEmptyString test has been added to CurlHelperTest.
