### PR TITLE
Fix issue if multiple headers are returned

### DIFF
--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -66,8 +66,10 @@ class HttpUtil
     public static function parseResponse($response)
     {
         $response = str_replace("HTTP/1.1 100 Continue\r\n\r\n", '', $response);
-            
-        list($rawHeader, $rawBody) = explode("\r\n\r\n", $response, 2);
+
+        $responseChunks = explode("\r\n\r\n", $response);
+        $rawBody = array_pop($responseChunks);
+        $rawHeader = array_pop($responseChunks);
 
         // Parse headers and status.
         $headers = self::parseRawHeader($rawHeader);


### PR DESCRIPTION
### Context

If multiple headers are returned the and `CURLOPT_HEADER` is set to `false` the first header will be removed but the response contains all other headers.

### What has been done

- Removes all headers expect the last one.

### How to test

- The behavior can be discovered by a curl request which returns multiple headers.

