### PR TITLE
Add recording of curl infos

### DIFF
--- a/src/VCR/Response.php
+++ b/src/VCR/Response.php
@@ -65,7 +65,8 @@ class Response
             array(
                 'status'    => $this->status,
                 'headers'   => $this->getHeaders(),
-                'body'      => $body
+                'body'      => $body,
+                'curl_info' => $this->curlInfo,
             )
         );
     }
@@ -94,7 +95,8 @@ class Response
         return new static(
             isset($response['status']) ? $response['status'] : 200,
             isset($response['headers']) ? $response['headers'] : array(),
-            $body
+            $body,
+            isset($response['curl_info']) ? $response['curl_info'] : array()
         );
     }
 

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -112,7 +112,7 @@ class CurlHelper
                 $info =  mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
                 break;
             default:
-                $info = $response->getCurlInfo($option);
+                $info = $response->getCurlInfo(self::$curlInfoList[$option]);
                 break;
         }
 

--- a/tests/VCR/ResponseTest.php
+++ b/tests/VCR/ResponseTest.php
@@ -120,6 +120,15 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($curlOptions, $response->getCurlInfo());
     }
 
+    public function testRestoreCurlInfoFromArray()
+    {
+        $expectedCurlOptions = array('option' => 'value');
+        $response = new Response(200, array(), null, $expectedCurlOptions);
+        $restoredResponse = Response::fromArray($response->toArray());
+
+        $this->assertEquals($expectedCurlOptions, $response->getCurlInfo());
+    }
+
     public function testToArray()
     {
         $expectedArray = array(
@@ -131,7 +140,10 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
             'headers'   => array(
                 'host' => 'example.com'
             ),
-            'body'      => 'Test response'
+            'body'      => 'Test response',
+            'curl_info' => [
+                'content_type' => 'text/html'
+            ]
         );
 
         $response = Response::fromArray($expectedArray);

--- a/tests/VCR/ResponseTest.php
+++ b/tests/VCR/ResponseTest.php
@@ -141,9 +141,9 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
                 'host' => 'example.com'
             ),
             'body'      => 'Test response',
-            'curl_info' => [
+            'curl_info' => array(
                 'content_type' => 'text/html'
-            ]
+            )
         );
 
         $response = Response::fromArray($expectedArray);

--- a/tests/fixtures/unittest_curl_test
+++ b/tests/fixtures/unittest_curl_test
@@ -11,11 +11,33 @@
         headers:
             Location: 'http://www.google.com/'
             Content-Type: 'text/html; charset=UTF-8'
-            Date: 'Mon, 13 May 2013 08:15:58 GMT'
-            Expires: 'Wed, 12 Jun 2013 08:15:58 GMT'
+            Date: 'Wed, 18 Oct 2017 18:59:08 GMT'
+            Expires: 'Wed, 17 Nov 2017 18:59:08 GMT'
             Cache-Control: 'public, max-age=2592000'
             Server: gws
             Content-Length: '219'
             X-XSS-Protection: '1; mode=block'
             X-Frame-Options: SAMEORIGIN
         body: "This is a curl test dummy."
+        curl_info:
+            url: 'http://google.com/'
+            content_type: 'text/html; charset=UTF-8'
+            http_code: 301
+            header_size: 249
+            request_size: 49
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.194497
+            namelookup_time: 0.132455
+            connect_time: 0.164555
+            pretransfer_time: 0.164586
+            size_upload: !!float 0
+            size_download: !!float 268
+            speed_download: !!float 1377
+            speed_upload: !!float 0
+            download_content_length: !!float 268
+            upload_content_length: !!float -1
+            starttransfer_time: 0.194476
+            certinfo: {  }
+            primary_port: 80


### PR DESCRIPTION
Hello, first of all thanks for this project!

### Context
Trying to test a third party library, I found out that PHP-VCR is not storing curl informations, and this was breaking the tests.

The issue #112 confirmed the missing feature.

### What has been done

- added recording of curl informations
- tests

### How to test

- run tests of `tests/VCR/ResponseTest.php`, should be all green
- register the call produced by this piece of code:

  ```php
  $curl = curl_init('http://example/');
  curl_setopt($curl, CURLOPT_HTTPGET, true);
  $body = curl_exec($curl);
  $contentType = curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
  curl_close($curl);
  ```
- the playback should work as expected

### Notes

Following concerns from @dbu on #112 about making this configurable: making this option configurable is a big tasks; passing around the configuration object require to touch the code in lots of places. For clarity on the main business logic around this PR I didn't do it. Please let me know if it's a requirement.

Thank you