### PR TITLE
Add a file check to StreamProcessor

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -171,6 +171,10 @@ class StreamProcessor
      */
     public function stream_open($path, $mode, $options, &$openedPath)
     {
+        if ('r' === substr($mode, 0, 1) && !is_file($path)) {
+            return false;
+        }
+
         $this->restore();
 
         if (isset($this->context)) {

--- a/tests/VCR/Util/StreamProcessorTest.php
+++ b/tests/VCR/Util/StreamProcessorTest.php
@@ -58,7 +58,19 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testStreamOpenShouldNotFailOnInexistingFile()
+    public function streamOpenFileModesWhichDoNotCreateFiles()
+    {
+        return array(
+            array('r'),
+            array('rb'),
+            array('rt'),
+            array('r+')
+        );
+    }
+    /**
+     * @dataProvider streamOpenFileModesWhichDoNotCreateFiles
+     */
+    public function testStreamOpenShouldNotFailOnNonExistingFile($fileMode)
     {
         $test = $this;
         set_error_handler(function ($errno, $errstr, $errfile, $errline) use ($test) {
@@ -67,7 +79,7 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
 
         $processor = new StreamProcessor();
 
-        $result = $processor->stream_open('tests/fixtures/unknown', 'r', StreamProcessor::STREAM_OPEN_FOR_INCLUDE, $fullPath);
+        $result = $processor->stream_open('tests/fixtures/unknown', $fileMode, StreamProcessor::STREAM_OPEN_FOR_INCLUDE, $fullPath);
         $this->assertFalse($result);
 
         restore_error_handler();

--- a/tests/VCR/Util/StreamProcessorTest.php
+++ b/tests/VCR/Util/StreamProcessorTest.php
@@ -58,6 +58,21 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testStreamOpenShouldNotFailOnInexistingFile()
+    {
+        $test = $this;
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use ($test) {
+            $test->fail('should not throw errors');
+        });
+
+        $processor = new StreamProcessor();
+
+        $result = $processor->stream_open('tests/fixtures/unknown', 'r', StreamProcessor::STREAM_OPEN_FOR_INCLUDE, $fullPath);
+        $this->assertFalse($result);
+
+        restore_error_handler();
+    }
+
     public function testUrlStatSuccessfully()
     {
         $test = $this;


### PR DESCRIPTION
If a file which StreamProcessor should process doesn't exist, `fopen`
gives a warning. In PHPUnit context this warning will be translated into
an exception which will then leave StreamProcessor in disabled state.