### PR TITLE
Issue #213. Don't set Host header in setUrl if already set.

### DIFF
--- a/src/VCR/Request.php
+++ b/src/VCR/Request.php
@@ -132,7 +132,9 @@ class Request
     public function setUrl($url)
     {
         $this->url = $url;
-        $this->setHeader('Host', $this->getHost());
+        if (! array_key_exists('Host', $this->headers)) {
+            $this->setHeader('Host', $this->getHost());
+        }
     }
 
     /**

--- a/tests/VCR/RequestTest.php
+++ b/tests/VCR/RequestTest.php
@@ -216,6 +216,22 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('example.com:5000', $request->getHost());
     }
 
+    public function testDoNotOverwriteHostHeader()
+    {
+        $this->request = new Request(
+          'GET',
+          'http://example.com',
+          array('User-Agent' => 'Unit-Test', 'Host' => 'www.example.com'));
+
+        $this->assertEquals(
+            array(
+                'User-Agent' => 'Unit-Test',
+                'Host'       => 'www.example.com'
+            ),
+            $this->request->getHeaders()
+        );
+    }
+
     public function testCurlCustomRequestOverridesMethod()
     {
         $postRequest = new Request('POST', 'http://example.com');


### PR DESCRIPTION
### Context

If a header has been set manually, do not overwrite it with the one from the URL.
Issue #213 

### What has been done

- Do not overwrite the Host Header in setUrl if it is already set
- Test to verify

### How to test

- vendor/bin/phpunit tests/VCR/RequestTest.php

