### PR TITLE
Replacing tests with WSDL to use the fixtures one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: precise
 
 matrix:
   fast_finish: true

--- a/tests/VCR/LibraryHooks/SoapHookTest.php
+++ b/tests/VCR/LibraryHooks/SoapHookTest.php
@@ -13,6 +13,8 @@ use VCR\Util\StreamProcessor;
  */
 class SoapHookTest extends \PHPUnit_Framework_TestCase
 {
+    const WSDL = 'https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl';
+
     public $expected = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><GetCityWeatherByZIPResponse xmlns="http://ws.cdyne.com/WeatherWS/"><GetCityWeatherByZIPResult><Success>true</Success></GetCityWeatherByZIPResult></GetCityWeatherByZIPResponse></soap:Body></soap:Envelope>';
 
     protected $config;
@@ -30,7 +32,7 @@ class SoapHookTest extends \PHPUnit_Framework_TestCase
     {
         $this->soapHook->enable($this->getContentCheckCallback());
 
-        $client = new \SoapClient('https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl', array('soap_version' => SOAP_1_2));
+        $client = new \SoapClient(self::WSDL, array('soap_version' => SOAP_1_2));
         $client->setLibraryHook($this->soapHook);
         $actual = $client->GetCityWeatherByZIP(array('ZIP' => '10013'));
 
@@ -48,7 +50,7 @@ class SoapHookTest extends \PHPUnit_Framework_TestCase
         $this->soapHook->enable($this->getHeadersCheckCallback($expectedHeaders));
 
         $client = new \SoapClient(
-            'https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl',
+            self::WSDL,
             array('soap_version' => SOAP_1_1)
         );
         $client->setLibraryHook($this->soapHook);
@@ -64,7 +66,7 @@ class SoapHookTest extends \PHPUnit_Framework_TestCase
         $this->soapHook->enable($this->getHeadersCheckCallback($expectedHeaders));
 
         $client = new \SoapClient(
-            'https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl',
+            self::WSDL,
             array('soap_version' => SOAP_1_2)
         );
         $client->setLibraryHook($this->soapHook);
@@ -76,7 +78,7 @@ class SoapHookTest extends \PHPUnit_Framework_TestCase
         $this->soapHook->enable($this->getContentCheckCallback());
 
         $client = new \SoapClient(
-            'https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl',
+            self::WSDL,
             array('soap_version' => SOAP_1_1, 'trace' => 1)
         );
         $client->setLibraryHook($this->soapHook);

--- a/tests/VCR/LibraryHooks/SoapHookTest.php
+++ b/tests/VCR/LibraryHooks/SoapHookTest.php
@@ -30,7 +30,7 @@ class SoapHookTest extends \PHPUnit_Framework_TestCase
     {
         $this->soapHook->enable($this->getContentCheckCallback());
 
-        $client = new \SoapClient('http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL', array('soap_version' => SOAP_1_2));
+        $client = new \SoapClient('https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl', array('soap_version' => SOAP_1_2));
         $client->setLibraryHook($this->soapHook);
         $actual = $client->GetCityWeatherByZIP(array('ZIP' => '10013'));
 
@@ -48,7 +48,7 @@ class SoapHookTest extends \PHPUnit_Framework_TestCase
         $this->soapHook->enable($this->getHeadersCheckCallback($expectedHeaders));
 
         $client = new \SoapClient(
-            'http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL',
+            'https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl',
             array('soap_version' => SOAP_1_1)
         );
         $client->setLibraryHook($this->soapHook);
@@ -64,7 +64,7 @@ class SoapHookTest extends \PHPUnit_Framework_TestCase
         $this->soapHook->enable($this->getHeadersCheckCallback($expectedHeaders));
 
         $client = new \SoapClient(
-            'http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL',
+            'https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl',
             array('soap_version' => SOAP_1_2)
         );
         $client->setLibraryHook($this->soapHook);
@@ -76,7 +76,7 @@ class SoapHookTest extends \PHPUnit_Framework_TestCase
         $this->soapHook->enable($this->getContentCheckCallback());
 
         $client = new \SoapClient(
-            'http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL',
+            'https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl',
             array('soap_version' => SOAP_1_1, 'trace' => 1)
         );
         $client->setLibraryHook($this->soapHook);

--- a/tests/VCR/Util/SoapClientTest.php
+++ b/tests/VCR/Util/SoapClientTest.php
@@ -8,7 +8,7 @@ use VCR\Util\SoapClient;
 
 class SoapClientTest extends \PHPUnit_Framework_TestCase
 {
-    const WSDL = 'http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL';
+    const WSDL = 'https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl';
     const ACTION = 'http://ws.cdyne.com/WeatherWS/GetCityWeatherByZIP';
 
     protected function getLibraryHookMock($enabled)

--- a/tests/VCR/VCRTest.php
+++ b/tests/VCR/VCRTest.php
@@ -67,7 +67,7 @@ class VCRTest extends \PHPUnit_Framework_TestCase
         VCR::turnOn();
         VCR::insertCassette('unittest_soap_test');
 
-        $client = new \SoapClient('http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL', array('soap_version' => SOAP_1_2));
+        $client = new \SoapClient('https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl', array('soap_version' => SOAP_1_2));
         $actual = $client->GetCityWeatherByZIP(array('ZIP' => '10013'));
         $temperature = $actual->GetCityWeatherByZIPResult->Temperature;
 


### PR DESCRIPTION
### Context
Tests are broken due to WSDL not being loaded

### What has been done

- Added the wsdl directly to the repository