### PR TITLE
Apply suggested php-cs-fixer patches

### DIFF
--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -186,19 +186,19 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
     */
     public function testShouldReturnCurlInfoStatusCodeAsInteger()
     {
-      $stringStatusCode = "200";
-      $integerStatusCode = 200;
-      $this->curlHook->enable($this->getTestCallback($stringStatusCode));
+        $stringStatusCode = '200';
+        $integerStatusCode = 200;
+        $this->curlHook->enable($this->getTestCallback($stringStatusCode));
 
-      $curlHandle = curl_init('http://example.com');
-      curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
-      curl_exec($curlHandle);
-      $infoHttpCode = curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
-      curl_close($curlHandle);
+        $curlHandle = curl_init('http://example.com');
+        curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
+        curl_exec($curlHandle);
+        $infoHttpCode = curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
+        curl_close($curlHandle);
 
-      $this->assertSame($integerStatusCode, $infoHttpCode, 'HTTP status not set.');
+        $this->assertSame($integerStatusCode, $infoHttpCode, 'HTTP status not set.');
 
-      $this->curlHook->disable();
+        $this->curlHook->disable();
     }
 
     public function testShouldReturnCurlInfoAll()


### PR DESCRIPTION
### Context
I'm starting to work on updating php-cs-fixer to version 2.0 but first I'd like to create some sort of clean state. Not sure if the code-style violations were intentional.

### What has been done

- Applied the php-cs-fixer violation diffs which fixed the indenting and single quoted strings. 

### How to test

- If the build passes, we should be good right :+1: ? 

