### PR TITLE
Setting CURLOPT_NOBODY automatically sets method to HEAD

### DIFF
--- a/src/VCR/Util/Assertion.php
+++ b/src/VCR/Util/Assertion.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Util;
 
 use Assert\Assertion as BaseAssertion;

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -142,6 +142,11 @@ class CurlHelper
             case CURLOPT_CUSTOMREQUEST:
                 $request->setCurlOption(CURLOPT_CUSTOMREQUEST, $value);
                 break;
+            case CURLOPT_NOBODY:
+                if ($value == true && $request->getMethod() == 'GET') {
+                    $request->setMethod('HEAD');
+                }
+                break;
             case CURLOPT_POST:
                 if ($value == true) {
                     $request->setMethod('POST');

--- a/src/VCR/Util/HttpClient.php
+++ b/src/VCR/Util/HttpClient.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Util;
 
 use VCR\Request;

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -191,6 +191,14 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $request->getBody());
     }
 
+    public function testSetCurlOptionOnRequestNoBody()
+    {
+        $request = new Request('GET', 'example.com');
+        CurlHelper::setCurlOptionOnRequest($request, CURLOPT_NOBODY, true);
+
+        $this->assertEquals('HEAD', $request->getMethod());
+    }
+
     public function testHandleResponseReturnsBody()
     {
         $curlOptions = array(

--- a/tests/VCR/Util/StreamHelperTest.php
+++ b/tests/VCR/Util/StreamHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Util;
 
 use VCR\Request;

--- a/tests/integration/soap/src/VCR/Example/ExampleSoapClient.php
+++ b/tests/integration/soap/src/VCR/Example/ExampleSoapClient.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Example;
 
 /**


### PR DESCRIPTION
### Context
Fixes problem when using php-vcr with Guzzle 3.

Per PHP docs, setting curl option `CURLOPT_NOBODY` to true automatically sets the method to HEAD
http://php.net/manual/en/function.curl-setopt.php
Guzzle 3 properly sets the request method to HEAD, but VCR's curl hook defaults back to GET.

### What has been done

- Added a clause to the switch statement in `CurlHelper::setCurlOptionOnRequest`

### How to test

Demonstration of issue pre-patch:

- ```composer require guzzlehttp/guzzle:~3.0```
- 
```php
VCR::turnOn();
VCR::insertCassette('head.yml');
$client = new \Guzzle\Http\Client();
$request = $client->head('http://headers.jsontest.com');
$response = $request->send();
VCR::turnOff();
```
- ```cat head.yml```
The request method in head.yml is "GET" instead of "HEAD"