### PR TITLE
Fix RuntimeException with SplFileInfo->isFile()

### DIFF
--- a/src/VCR/Util/Assertion.php
+++ b/src/VCR/Util/Assertion.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Util;
 
 use Assert\Assertion as BaseAssertion;

--- a/src/VCR/Util/HttpClient.php
+++ b/src/VCR/Util/HttpClient.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Util;
 
 use VCR\Request;

--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -302,7 +302,11 @@ class StreamProcessor
                 // Use native error handler
                 return false;
             });
-            $result = @stat($path);
+            try {
+                $result = @stat($path);
+            } catch (\RuntimeException $e) {
+                $result = false;
+            }
             restore_error_handler();
         } else {
             $result = stat($path);

--- a/tests/VCR/Util/StreamHelperTest.php
+++ b/tests/VCR/Util/StreamHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Util;
 
 use VCR\Request;

--- a/tests/VCR/Util/StreamProcessorTest.php
+++ b/tests/VCR/Util/StreamProcessorTest.php
@@ -85,6 +85,16 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
         restore_error_handler();
     }
 
+    public function testUrlStatViaSplFileInfoShouldNotFailOnNonExistingFile()
+    {
+        $path = new \SplFileInfo('tests/fixtures/unknown');
+        try {
+            $path->isFile();
+        } catch (\RuntimeException $e) {
+            $this->fail('should not throw RuntimeException');
+        }
+    }
+
     public function testUrlStatSuccessfully()
     {
         $test = $this;

--- a/tests/VCR/Util/StreamProcessorTest.php
+++ b/tests/VCR/Util/StreamProcessorTest.php
@@ -87,12 +87,15 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testUrlStatViaSplFileInfoShouldNotFailOnNonExistingFile()
     {
+        $processor = new StreamProcessor();
+        $processor->intercept();
         $path = new \SplFileInfo('tests/fixtures/unknown');
         try {
             $path->isFile();
         } catch (\RuntimeException $e) {
             $this->fail('should not throw RuntimeException');
         }
+        $processor->restore();
     }
 
     public function testUrlStatSuccessfully()

--- a/tests/integration/soap/src/VCR/Example/ExampleSoapClient.php
+++ b/tests/integration/soap/src/VCR/Example/ExampleSoapClient.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Example;
 
 /**


### PR DESCRIPTION
### Context
With stream_wrapper handling enabled, SplFileInfo->isFile() triggers a RuntimeException for non-existing files.

### What has been done

- Simply added a try/catch around the line triggering the exception, ```$result = @stat($path);```

### How to test

- ```VCR::turnOn()```
- ```$path = new \SplFileInfo('missingFile');```
- ```$path->isFile()```
