### PR TITLE
[RFC] Allow symfony/yaml and symfony/event-dispatcher v4.0 as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,13 @@
     "name": "php-vcr/php-vcr",
     "description": "Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.",
     "license": "MIT",
-    
+
     "scripts": {
         "test": "./vendor/bin/phpunit",
         "lint": "./vendor/bin/php-cs-fixer fix --verbose --diff --dry-run --config-file=.php_cs",
         "fix": "./vendor/bin/php-cs-fixer fix --verbose --diff --config-file=.php_cs"
     },
-    
+
     "authors": [
         {
             "name": "Adrian Philipp",
@@ -19,8 +19,8 @@
     "require": {
         "ext-curl": "*",
         "beberlei/assert": "^2.0",
-        "symfony/yaml": "~2.1|^3.0",
-        "symfony/event-dispatcher": "^2.4|^3.0"
+        "symfony/yaml": "~2.1|^3.0|^4.0",
+        "symfony/event-dispatcher": "^2.4|^3.0|^4.0"
     },
 
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a2fa698e853fdf02252149e20589ec9",
+    "content-hash": "e7620447991c15ab183fd84a2b8dfde2",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -63,30 +63,30 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.3.10",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "d7ba037e4b8221956ab1e221c73c9e27e05dd423"
+                "reference": "6223fb2b68e7059e8d5843c0103999a84e7275cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d7ba037e4b8221956ab1e221c73c9e27e05dd423",
-                "reference": "d7ba037e4b8221956ab1e221c73c9e27e05dd423",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/6223fb2b68e7059e8d5843c0103999a84e7275cf",
+                "reference": "6223fb2b68e7059e8d5843c0103999a84e7275cf",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.3"
+                "symfony/dependency-injection": "<3.4"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0",
-                "symfony/dependency-injection": "~3.3",
-                "symfony/expression-language": "~2.8|~3.0",
-                "symfony/stopwatch": "~2.8|~3.0"
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/stopwatch": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -95,7 +95,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -122,27 +122,30 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-02T06:42:24+00:00"
+            "time": "2017-11-09T17:30:28+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.10",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46"
+                "reference": "b3d0c9c11be3831b84825967dc6b52b5a7b84e04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46",
-                "reference": "8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/b3d0c9c11be3831b84825967dc6b52b5a7b84e04",
+                "reference": "b3d0c9c11be3831b84825967dc6b52b5a7b84e04",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5.9|>=7.0.8"
             },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
             "require-dev": {
-                "symfony/console": "~2.8|~3.0"
+                "symfony/console": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -150,7 +153,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -177,7 +180,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-05T14:43:42+00:00"
+            "time": "2017-11-29T13:28:14+00:00"
         }
     ],
     "packages-dev": [
@@ -279,7 +282,7 @@
                 "proxy-object",
                 "testing"
             ],
-            "time": "2015-06-24 09:27:33"
+            "time": "2015-06-24T09:27:33+00:00"
         },
         {
             "name": "mikey179/vfsStream",

--- a/src/VCR/Util/Assertion.php
+++ b/src/VCR/Util/Assertion.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Util;
 
 use Assert\Assertion as BaseAssertion;

--- a/src/VCR/Util/HttpClient.php
+++ b/src/VCR/Util/HttpClient.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Util;
 
 use VCR\Request;

--- a/tests/VCR/Util/StreamHelperTest.php
+++ b/tests/VCR/Util/StreamHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Util;
 
 use VCR\Request;

--- a/tests/integration/soap/src/VCR/Example/ExampleSoapClient.php
+++ b/tests/integration/soap/src/VCR/Example/ExampleSoapClient.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VCR\Example;
 
 /**


### PR DESCRIPTION
### Context
Symfony 4 was released

### What has been done

- Allow users to use symfony/yaml version 4 as dependency
- Allow users to use symfony/event-dispatcher version 4 as dependency


