### PR TITLE
Refactoring tests

### DIFF
--- a/tests/VCR/ConfigurationTest.php
+++ b/tests/VCR/ConfigurationTest.php
@@ -136,9 +136,9 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testGetStorage()
     {
         $class = $this->config->getStorage();
-        $this->assertTrue(in_array('Iterator', class_implements($class)));
-        $this->assertTrue(in_array('Traversable', class_implements($class)));
-        $this->assertTrue(in_array('VCR\Storage\AbstractStorage', class_parents($class)));
+        $this->assertContains('Iterator', class_implements($class));
+        $this->assertContains('Traversable', class_implements($class));
+        $this->assertContains('VCR\Storage\AbstractStorage', class_parents($class));
     }
 
     public function testWhitelist()

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -211,8 +211,8 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         $info = curl_getinfo($curlHandle);
         curl_close($curlHandle);
 
-        $this->assertTrue(is_array($info), 'curl_getinfo() should return an array.');
-        $this->assertEquals(21, count($info), 'curl_getinfo() should return 21 values.');
+        $this->assertInternalType('array', $info, 'curl_getinfo() should return an array.');
+        $this->assertCount(21, $info, 'curl_getinfo() should return 21 values.');
         $this->curlHook->disable();
     }
 
@@ -226,7 +226,7 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         $info = curl_getinfo($curlHandle);
         curl_close($curlHandle);
 
-        $this->assertTrue(is_array($info), 'curl_getinfo() should return an array.');
+        $this->assertInternalType('array', $info, 'curl_getinfo() should return an array.');
         $this->assertArrayHasKey('url', $info);
         $this->assertArrayHasKey('content_type', $info);
         $this->assertArrayHasKey('http_code', $info);

--- a/tests/VCR/LibraryHooks/SoapHookTest.php
+++ b/tests/VCR/LibraryHooks/SoapHookTest.php
@@ -38,7 +38,7 @@ class SoapHookTest extends \PHPUnit_Framework_TestCase
 
         $this->soapHook->disable();
         $this->assertInstanceOf('\stdClass', $actual, 'Response was not returned.');
-        $this->assertEquals(true, $actual->GetCityWeatherByZIPResult->Success, 'Response was not returned.');
+        $this->assertTrue($actual->GetCityWeatherByZIPResult->Success, 'Response was not returned.');
     }
 
     public function testShouldHandleSOAPVersion11()
@@ -86,7 +86,7 @@ class SoapHookTest extends \PHPUnit_Framework_TestCase
         $actual = $client->__getLastRequest();
 
         $this->soapHook->disable();
-        $this->assertTrue(!is_null($actual), '__getLastRequest() returned NULL.');
+        $this->assertNotNull($actual, '__getLastRequest() returned NULL.');
     }
 
     /**

--- a/tests/VCR/ResponseTest.php
+++ b/tests/VCR/ResponseTest.php
@@ -51,7 +51,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     public function testGetBodyNoneDefined()
     {
         $response = Response::fromArray(array());
-        $this->assertEquals(null, $response->getBody(true));
+        $this->assertNull($response->getBody(true));
     }
 
     public function testRestoreBodyFromArray()

--- a/tests/VCR/Storage/YamlTest.php
+++ b/tests/VCR/Storage/YamlTest.php
@@ -115,7 +115,7 @@ class YamlTest extends \PHPUnit_Framework_TestCase
         foreach ($this->yamlObject as $recording) {
             $actual[] = $recording;
         }
-        $this->assertEquals(2, count($actual), 'More that two recordings stores.');
+        $this->assertCount(2, $actual, 'More that two recordings stores.');
         $this->assertEquals($expected, $actual[0], 'Storing and reading first recording failed.');
         $this->assertEquals($expected, $actual[1], 'Storing and reading second recording failed.');
     }

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -80,7 +80,7 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
 
         // This is consistent with how requests are read out of storage using
         // \VCR\Request::fromArray(array $request).
-        $this->assertSame(null, $request->getBody());
+        $this->assertNull($request->getBody());
     }
 
     public function testSetCurlOptionOnRequestSetSingleHeader()

--- a/tests/VCR/Util/HttpUtilTest.php
+++ b/tests/VCR/Util/HttpUtilTest.php
@@ -8,24 +8,24 @@ class HttpUtilTest extends \PHPUnit_Framework_TestCase
     {
         $raw = "HTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";
         list($status, $headers, $body) = HttpUtil::parseResponse($raw);
-        
+
         $expectedHeaders = array(
             'Content-Type: text/html',
             'Date: Fri, 19 Jun 2015 16:05:18 GMT',
             'Vary: Accept-Encoding',
             'Content-Length: 0'
         );
-        
+
         $this->assertEquals('HTTP/1.1 201 Created', $status);
         $this->assertEquals(null, $body);
         $this->assertEquals($expectedHeaders, $headers);
     }
-    
+
     public function testParseResponseMultipleHeaders()
     {
         $raw = "HTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept, Accept-Language, Expect\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";
         list($status, $headers, $body) = HttpUtil::parseResponse($raw);
-        
+
         $expectedHeaders = array(
             'Content-Type: text/html',
             'Date: Fri, 19 Jun 2015 16:05:18 GMT',
@@ -33,12 +33,12 @@ class HttpUtilTest extends \PHPUnit_Framework_TestCase
             'Vary: Accept-Encoding',
             'Content-Length: 0'
         );
-        
+
         $this->assertEquals('HTTP/1.1 201 Created', $status);
         $this->assertEquals(null, $body);
         $this->assertEquals($expectedHeaders, $headers);
     }
-    
+
     public function testParseContinuePlusResponse()
     {
         $raw = "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";
@@ -50,12 +50,12 @@ class HttpUtilTest extends \PHPUnit_Framework_TestCase
             'Vary: Accept-Encoding',
             'Content-Length: 0'
         );
-        
+
         $this->assertEquals('HTTP/1.1 201 Created', $status);
         $this->assertEquals(null, $body);
         $this->assertEquals($expectedHeaders, $headers);
     }
-    
+
     public function testParseiMultipleContinuePlusResponse()
     {
         $raw = "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";
@@ -67,7 +67,7 @@ class HttpUtilTest extends \PHPUnit_Framework_TestCase
             'Vary: Accept-Encoding',
             'Content-Length: 0'
         );
-        
+
         $this->assertEquals('HTTP/1.1 201 Created', $status);
         $this->assertEquals(null, $body);
         $this->assertEquals($expectedHeaders, $headers);
@@ -78,7 +78,7 @@ class HttpUtilTest extends \PHPUnit_Framework_TestCase
     {
         $raw = "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept, Accept-Language, Expect\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";
         list($status, $headers, $body) = HttpUtil::parseResponse($raw);
-        
+
         $expectedHeaders = array(
             'Content-Type: text/html',
             'Date: Fri, 19 Jun 2015 16:05:18 GMT',
@@ -86,7 +86,7 @@ class HttpUtilTest extends \PHPUnit_Framework_TestCase
             'Vary: Accept-Encoding',
             'Content-Length: 0'
         );
-        
+
         $this->assertEquals('HTTP/1.1 201 Created', $status);
         $this->assertEquals(null, $body);
         $this->assertEquals($expectedHeaders, $headers);
@@ -109,7 +109,7 @@ class HttpUtilTest extends \PHPUnit_Framework_TestCase
         $outputArray = HttpUtil::parseHeaders($inputArray);
         $this->assertEquals($excpetedHeaders, $outputArray);
     }
-    
+
     public function testParseHeadersMultiple()
     {
         $inputArray = array(

--- a/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
+++ b/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
@@ -50,7 +50,7 @@ class ExampleHttpClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertValidPOSTResponse($this->requestPOST());
     }
-    
+
     public function testRequestPOSTIntercepted()
     {
         $this->assertValidPOSTResponse($this->requestPOSTIntercepted());
@@ -112,20 +112,20 @@ class ExampleHttpClientTest extends \PHPUnit_Framework_TestCase
 
     protected function assertValidGETResponse($info)
     {
-        $this->assertTrue(is_array($info), 'Response is not an array.');
+        $this->assertInternalType('array', $info, 'Response is not an array.');
         $this->assertArrayHasKey('url', $info, "Key 'url' not found.");
         $this->assertEquals(self::TEST_GET_URL, $info['url'], "Value for key 'url' wrong.");
         $this->assertArrayHasKey('headers', $info, "Key 'headers' not found.");
-        $this->assertTrue(is_array($info['headers']), 'Headers is not an array.');
+        $this->assertInternalType('array', $info['headers'], 'Headers is not an array.');
     }
-    
+
     protected function assertValidPOSTResponse($info)
     {
-        $this->assertTrue(is_array($info), 'Response is not an array.');
+        $this->assertInternalType('array', $info, 'Response is not an array.');
         $this->assertArrayHasKey('url', $info, "Key 'url' not found.");
         $this->assertEquals(self::TEST_POST_URL, $info['url'], "Value for key 'url' wrong.");
         $this->assertArrayHasKey('headers', $info, "Key 'headers' not found.");
-        $this->assertTrue(is_array($info['headers']), 'Headers is not an array.');
+        $this->assertInternalType('array', $info['headers'], 'Headers is not an array.');
         $this->assertEquals(self::TEST_POST_BODY, $info['data'], 'Correct request body was not sent.');
     }
 }


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertInternalType` instead of `is_*` functions;
- `assertContains` instead of `in_array` function;
- `assertNull` and `assertNotNull` instead of `is_null` function and comparisons with `null` keyword;
- `assertTrue` instead of comparisons with `true` keyword.