### PR TITLE
Stop failing on calls to /dev/urandom

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -171,7 +171,8 @@ class StreamProcessor
      */
     public function stream_open($path, $mode, $options, &$openedPath)
     {
-        if ('r' === substr($mode, 0, 1) && !is_file($path)) {
+        // file_exists catches paths like /dev/urandom that are missed by is_file.
+        if ('r' === substr($mode, 0, 1) && !file_exists($path)) {
             return false;
         }
 

--- a/tests/VCR/VCRTest.php
+++ b/tests/VCR/VCRTest.php
@@ -76,6 +76,24 @@ class VCRTest extends \PHPUnit_Framework_TestCase
         VCR::turnOff();
     }
 
+    public function testShouldNotInterceptCallsToDevUrandom()
+    {
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('/dev/urandom is not supported on Windows');
+        }
+
+        VCR::configure()->enableLibraryHooks(array('stream_wrapper'));
+        VCR::turnOn();
+        VCR::insertCassette('unittest_urandom_test');
+
+        // Just trying to open this will cause an exception if you're using is_file to filter
+        // which paths to intercept.
+        $output = file_get_contents('/dev/urandom', false, null, 0, 16);
+
+        VCR::eject();
+        VCR::turnOff();
+    }
+
     public function testShouldThrowExceptionIfNoCassettePresent()
     {
         $this->setExpectedException(


### PR DESCRIPTION
### Context

`StreamProcessor->stream_open` calls `is_file` to check whether a stream should be intercepted. However, `is_file` returns `false` for /dev/urandom as it's not a regular file. The better check here seems to be `file_exists`.

I've added a test to check it's working. As trying to open /dev/urandom won't work on Windows I've set this test to be skipped on Windows. It's possible there's some other environment that doesn't support /dev/urandom, so worth a think.
