### PR TITLE
Fixing broken integration tests

### DIFF
--- a/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
+++ b/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
@@ -9,7 +9,7 @@ use org\bovigo\vfs\vfsStream;
  */
 class ExampleHttpClientTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_GET_URL = 'http://httpbin.org/get';
+    const TEST_GET_URL = 'http://api.chew.pro/trbmb';
     const TEST_POST_URL = 'http://httpbin.org/post';
     const TEST_POST_BODY = '{"foo":"bar"}';
 
@@ -26,44 +26,32 @@ class ExampleHttpClientTest extends \PHPUnit_Framework_TestCase
         \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
     }
 
-    public function testRequestGETDirect()
+    public function testRequestGET()
     {
-        $this->assertValidGETResponse($this->requestGET());
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+        $originalRequest = $this->requestGET();
+        $this->assertValidGETResponse($originalRequest);
+        $interceptedRequest = $this->requestGET();
+        $this->assertValidGETResponse($interceptedRequest);
+        $this->assertEquals($originalRequest, $interceptedRequest);
+        $repeatInterceptedRequest = $this->requestGET();
+        $this->assertEquals($interceptedRequest, $repeatInterceptedRequest);
+        \VCR\VCR::turnOff();
     }
 
-    public function testRequestGETIntercepted()
+    public function testRequestPOST()
     {
-        $this->assertValidGETResponse($this->requestGETIntercepted());
-    }
-
-    public function testRequestGETDirectEqualsIntercepted()
-    {
-        $this->assertEquals($this->requestGET(), $this->requestGETIntercepted());
-    }
-
-    public function testRequestGETInterceptedIsRepeatable()
-    {
-        $this->assertEquals($this->requestGETIntercepted(), $this->requestGETIntercepted());
-    }
-
-    public function testRequestPOSTDirect()
-    {
-        $this->assertValidPOSTResponse($this->requestPOST());
-    }
-
-    public function testRequestPOSTIntercepted()
-    {
-        $this->assertValidPOSTResponse($this->requestPOSTIntercepted());
-    }
-
-    public function testRequestPOSTDirectEqualsIntercepted()
-    {
-        $this->assertEquals($this->requestPOST(), $this->requestPOSTIntercepted());
-    }
-
-    public function testRequestPOSTInterceptedIsRepeatable()
-    {
-        $this->assertEquals($this->requestPOSTIntercepted(), $this->requestPOSTIntercepted());
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+        $originalRequest = $this->requestPOST();
+        $this->assertValidPOSTResponse($originalRequest);
+        $interceptedRequest = $this->requestPOST();
+        $this->assertValidPOSTResponse($interceptedRequest);
+        $this->assertEquals($originalRequest, $interceptedRequest);
+        $repeatInterceptedRequest = $this->requestPOST();
+        $this->assertEquals($interceptedRequest, $repeatInterceptedRequest);
+        \VCR\VCR::turnOff();
     }
 
     protected function requestGET()
@@ -71,9 +59,6 @@ class ExampleHttpClientTest extends \PHPUnit_Framework_TestCase
         $exampleClient = new ExampleHttpClient();
 
         $response = $exampleClient->get(self::TEST_GET_URL);
-        foreach ($this->ignoreHeaders as $header) {
-            unset($response['headers'][$header]);
-        }
 
         return $response;
     }
@@ -86,18 +71,9 @@ class ExampleHttpClientTest extends \PHPUnit_Framework_TestCase
         foreach ($this->ignoreHeaders as $header) {
             unset($response['headers'][$header]);
         }
+        unset($response['origin']);
 
         return $response;
-    }
-
-    protected function requestGETIntercepted()
-    {
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('test-cassette.yml');
-        $info = $this->requestGET();
-        \VCR\VCR::turnOff();
-
-        return $info;
     }
 
     protected function requestPOSTIntercepted()
@@ -113,10 +89,7 @@ class ExampleHttpClientTest extends \PHPUnit_Framework_TestCase
     protected function assertValidGETResponse($info)
     {
         $this->assertInternalType('array', $info, 'Response is not an array.');
-        $this->assertArrayHasKey('url', $info, "Key 'url' not found.");
-        $this->assertEquals(self::TEST_GET_URL, $info['url'], "Value for key 'url' wrong.");
-        $this->assertArrayHasKey('headers', $info, "Key 'headers' not found.");
-        $this->assertInternalType('array', $info['headers'], 'Headers is not an array.');
+        $this->assertArrayHasKey('0', $info, 'API did not return any value.');
     }
 
     protected function assertValidPOSTResponse($info)


### PR DESCRIPTION
### Context

Integration tests are broken.
This seems to be due to a change in Travis.yml.

Indeed, when Travis performs 2 HTTP requests, for some reason, the "Origin" IP of the request is changing between the request.

This is really a Travis issue and not a PHP-VCR issue;
To make sure of this, I've changed .travis.yml and ran twice the "curl http://httpbin.org/get". Here is the output I got:

```
$ curl http://httpbin.org/get
{
  "args": {}, 
  "headers": {
    "Accept": "*/*", 
    "Connection": "close", 
    "Host": "httpbin.org", 
    "User-Agent": "curl/7.22.0 (x86_64-pc-linux-gnu) libcurl/7.22.0 OpenSSL/1.0.1 zlib/1.2.3.4 libidn/1.23 librtmp/2.3"
  }, 
  "origin": "35.202.145.110", 
  "url": "http://httpbin.org/get"
}
The command "curl http://httpbin.org/get" exited with 0.
$ curl http://httpbin.org/get
{
  "args": {}, 
  "headers": {
    "Accept": "*/*", 
    "Connection": "close", 
    "Host": "httpbin.org", 
    "User-Agent": "curl/7.22.0 (x86_64-pc-linux-gnu) libcurl/7.22.0 OpenSSL/1.0.1 zlib/1.2.3.4 libidn/1.23 librtmp/2.3"
  }, 
  "origin": "35.184.226.236", 
  "url": "http://httpbin.org/get"
}
```

See? Twice the same request and 2 different "origin".
This is wreaking havok in the unit tests.

### What has been done

First, I removed the "origin" from the JSON.
Then I realized that the integration tests were not actually testing whether PHP-VCR is working really or not. I mean that if PHP-VCR was actually doing nothing (and simply acting like a pass-through), the tests would still succeed.

So I rewrote the "GET" test and made it point to "http://api.chew.pro/trbmb". This is an API that generates random data.

This way, I can test that PHP-VCR is actually really replaying the request (because if it acts as a pass-through, I would get different data for each request.