### PR TITLE
Fix curl reset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
       php: 5.6
     - env: TEST_DIR=tests/integration/guzzle/5
       php: 5.6
+    - env: TEST_DIR=tests/integration/guzzle/6
+      php: 5.6
     - env: TEST_DIR=tests/integration/soap
       php: 5.6
 
@@ -56,4 +58,5 @@ cache:
     - tests/integration/guzzle/3/vendor
     - tests/integration/guzzle/4/vendor
     - tests/integration/guzzle/5/vendor
+    - tests/integration/guzzle/6/vendor
     - $HOME/.composer/cache

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -182,6 +182,7 @@ class CurlHook implements LibraryHook
         \curl_reset($curlHandle);
         self::$requests[(int) $curlHandle] = new Request('GET', null);
         self::$curlOptions[(int) $curlHandle] = array();
+        unset(self::$responses[(int) $curlHandle]);
     }
 
     /**

--- a/tests/integration/guzzle/6/ExampleHttpClient.php
+++ b/tests/integration/guzzle/6/ExampleHttpClient.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace VCR\Example;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+
+class ExampleHttpClient
+{
+    public function get($url)
+    {
+        $client = new Client();
+
+        try {
+            $response = $client->get($url);
+            return json_decode($response->getBody(), true);
+        } catch (ClientException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
+
+        return null;
+    }
+
+    public function post($url, $body)
+    {
+        $client = new Client();
+        
+        try {
+            $response = $client->post($url, array('body' => $body));
+            return json_decode($response->getBody(), true);
+        } catch (ClientException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/integration/guzzle/6/composer.json
+++ b/tests/integration/guzzle/6/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "guzzlehttp/guzzle": "~6.0"
+    }
+}

--- a/tests/integration/guzzle/6/phpunit.xml
+++ b/tests/integration/guzzle/6/phpunit.xml
@@ -1,0 +1,14 @@
+<phpunit bootstrap="../test/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+>
+
+    <testsuites>
+        <testsuite>
+            <directory>../test</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/tests/integration/guzzle/6/phpunit.xml
+++ b/tests/integration/guzzle/6/phpunit.xml
@@ -8,6 +8,7 @@
     <testsuites>
         <testsuite>
             <directory>../test</directory>
+            <directory>test</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/integration/guzzle/6/test/AsyncTest.php
+++ b/tests/integration/guzzle/6/test/AsyncTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace VCR\Example;
+
+use GuzzleHttp\Client;
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * Tests example request.
+ */
+class AsyncTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_GET_URL = 'http://api.chew.pro/trbmb';
+    const TEST_GET_URL_2 = 'http://api.chew.pro/trbmb?foo=42';
+
+    public function setUp()
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    public function testAsyncLock()
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+
+        $client = new Client();
+        $promise = $client->getAsync(self::TEST_GET_URL);
+        $response = $promise->wait();
+        $promise = $client->getAsync(self::TEST_GET_URL_2);
+        $promise->wait();
+        // Let's check that we can perform 2 async request on different URLs without locking.
+        // Solves https://github.com/php-vcr/php-vcr/issues/211
+
+        $this->assertValidGETResponse(\GuzzleHttp\json_decode($response->getBody()));
+
+        \VCR\VCR::turnOff();
+    }
+
+    protected function assertValidGETResponse($info)
+    {
+        $this->assertInternalType('array', $info, 'Response is not an array.');
+        $this->assertArrayHasKey('0', $info, 'API did not return any value.');
+    }
+}


### PR DESCRIPTION
### Context

When using PHP-VCR with Guzzle 6 with async requests, the first request is playing correctly but the next request is putting Guzzle in an infinite loop.

It took me a whole day but I traced back this problem to the way the "curl_reset" hook is written. It clears the request but not the response. Hence, when another request is performed (even on a different URL) the same response is sent. This weird behaviour is causing an infinite loop in Guzzle 6.

This problem is probably exactly the same as the issue #211. This PR should fix it.

### What has been done

The first commit of this PR contains only the failing test (to showcase the problem). You see that the test never completes (because of the infinite loop): https://travis-ci.org/php-vcr/php-vcr/jobs/366140696

The second commit is the fix. I simply added one line in the curl_reset hook to remove the response as well as the request.

Note: this PR is based on the branch from PR #246 since I need unit tests from Guzzle 6 that are not yet merged.