### PR TITLE
add return value to curl_setopt_array

### DIFF
--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -330,9 +330,10 @@ class CurlHook implements LibraryHook
     public static function curlSetoptArray($curlHandle, $options)
     {
         if (is_array($options)) {
-            $return_values = array_map(function ($option, $value) use ($curlHandle) {
+            $curlSetopt = function ($option, $value) use ($curlHandle) {
                 return static::curlSetopt($curlHandle, $option, $value);
-            }, array_keys($options), $options);
+            };
+            $return_values = array_map($curlSetopt, array_keys($options), $options);
 
             return !in_array(false, $return_values);
         }

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -330,9 +330,13 @@ class CurlHook implements LibraryHook
     public static function curlSetoptArray($curlHandle, $options)
     {
         if (is_array($options)) {
-            foreach ($options as $option => $value) {
-                static::curlSetopt($curlHandle, $option, $value);
-            }
+            $return_values = array_map(function ($option, $value) use ($curlHandle) {
+                return static::curlSetopt($curlHandle, $option, $value);
+            }, array_keys($options), $options);
+
+            return !in_array(false, $return_values);
         }
+
+        return false;
     }
 }

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -326,12 +326,14 @@ class CurlHook implements LibraryHook
      * @link http://www.php.net/manual/en/function.curl-setopt-array.php
      * @param resource $curlHandle A cURL handle returned by curl_init().
      * @param array    $options    An array specifying which options to set and their values.
+     *
+     * @return boolean  Returns TRUE on success or FALSE on failure.
      */
     public static function curlSetoptArray($curlHandle, $options)
     {
         if (is_array($options)) {
             $curlSetopt = function ($option, $value) use ($curlHandle) {
-                return static::curlSetopt($curlHandle, $option, $value);
+                return CurlHook::curlSetopt($curlHandle, $option, $value);
             };
             $return_values = array_map($curlSetopt, array_keys($options), $options);
 

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -358,6 +358,37 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         $this->curlHook->disable();
     }
 
+    public function testCurlSetoptArrayShouldReturnTrueIfOptionsAreSuccessful()
+    {
+        $this->curlHook->enable($this->getTestCallback());
+        $curlHandle = curl_init('http://example.com');
+
+        $this->assertTrue(curl_setopt_array(
+            $curlHandle,
+            array(
+                CURLOPT_RETURNTRANSFER => true
+            )
+        ));
+
+        $this->curlHook->disable();
+    }
+
+    public function testCurlSetoptArrayShouldReturnFalseIfOptionNotArray()
+    {
+        $this->curlHook->enable($this->getTestCallback());
+        $curlHandle = curl_init('http://example.com');
+
+        $this->assertFalse(curl_setopt_array(
+            $curlHandle,
+            'test'
+            //array(
+                //CURLOPT_HTTPHEADER => []
+            //)
+        ));
+
+        $this->curlHook->disable();
+    }
+
     /**
      * @return \callable
      */

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -381,9 +381,6 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(curl_setopt_array(
             $curlHandle,
             'test'
-            //array(
-                //CURLOPT_HTTPHEADER => []
-            //)
         ));
 
         $this->curlHook->disable();


### PR DESCRIPTION
### Context
  - `curl_setopt_array` returns a boolean value based on if the set option command was successful or not. See [spec](http://php.net/manual/en/function.curl-setopt-array.php). Currently it's returning null so if theres a statement that checks the success of setting the options, it will return a falsey value. [Example](https://github.com/twilio/twilio-php/blob/ae3477ccf88a0efb5bbe8928274c4a2046aec0c1/Twilio/Http/CurlClient.php#L36)

### What has been done
- update the `curlSetoptArray` to map the return values of `curlSetopt` to determine the return value and return it.

### How to test
- Tests are added with this PR.
  - One caveat is that with newer versions of PHP, `curl_setopt` does not return false. Instead it gives a php warning error if theres a type mismatch.