### PR TITLE
Improving performance of YAML storage

### DIFF
--- a/src/VCR/Storage/Yaml.php
+++ b/src/VCR/Storage/Yaml.php
@@ -75,14 +75,12 @@ class Yaml extends AbstractStorage
 
         $isInRecord = false;
         $recording = '';
-        $lastChar = null;
 
-        while (false !== ($char = fgetc($this->handle))) {
-            $isNewArrayStart = ($char === '-') && ($lastChar === "\n" || $lastChar === null);
-            $lastChar = $char;
+        while (false !== ($line = fgets($this->handle))) {
+            $isNewArrayStart = strpos($line, '-') === 0;
 
             if ($isInRecord && $isNewArrayStart) {
-                fseek($this->handle, -1, SEEK_CUR);
+                fseek($this->handle, -strlen($line), SEEK_CUR);
                 break;
             }
 
@@ -91,11 +89,11 @@ class Yaml extends AbstractStorage
             }
 
             if ($isInRecord) {
-                $recording .= $char;
+                $recording .= $line;
             }
         }
 
-        if ($char == false) {
+        if ($line == false) {
             $this->isEOF = true;
         }
 


### PR DESCRIPTION
### Context

I'm working on an API that involves file uploads. Even if the files are small, my typical cassette weights ~500kB. I've noticed that my tests were quite slow and quite CPU intensive.

Without PHP-VCR, my test suite lasts 5 seconds (including calls to the API).
With PHP-VCR, my test suite lasts 24 seconds.

```
PHPUnit 7.1.5 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 23.99 seconds, Memory: 12.00MB

OK (1 test, 4 assertions)
```

I used XDebug profiling and KCachegrind to pinpoint the issue.
Almost 90% of the time is spent in the `Yaml::readNextRecord` method. Thats because there is a call to `fgetc` for each character of the file (so a ~500kB file triggers ~500.000 loops in the `while` clause.

### What has been done

I have simply replaced `fgetc` with `fgets`. I'm reading the file line by line instead of character by character. This is way faster!

My tests are now running in 1.11 seconds!

```
PHPUnit 7.2.3 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 1.11 seconds, Memory: 12.00MB

OK (1 test, 4 assertions)
```

This is a x20 boost, so definitely worthwhile!

### How to test

You have to use a big cassette to see the benefits. I did not include performance tests in this PR (not sure if this is worthwhile or how to do this exactly).

Also, this PR does not include a fix for the Json storage that has probably the same performance issue.
