### PR TITLE
Use https for integration tests

### DIFF
--- a/tests/integration/guzzle/6/test/AsyncTest.php
+++ b/tests/integration/guzzle/6/test/AsyncTest.php
@@ -10,8 +10,8 @@ use org\bovigo\vfs\vfsStream;
  */
 class AsyncTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_GET_URL = 'http://api.chew.pro/trbmb';
-    const TEST_GET_URL_2 = 'http://api.chew.pro/trbmb?foo=42';
+    const TEST_GET_URL = 'https://api.chew.pro/trbmb';
+    const TEST_GET_URL_2 = 'https://api.chew.pro/trbmb?foo=42';
 
     public function setUp()
     {

--- a/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
+++ b/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
@@ -9,8 +9,8 @@ use org\bovigo\vfs\vfsStream;
  */
 class ExampleHttpClientTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_GET_URL = 'http://api.chew.pro/trbmb';
-    const TEST_POST_URL = 'http://httpbin.org/post';
+    const TEST_GET_URL = 'https://api.chew.pro/trbmb';
+    const TEST_POST_URL = 'https://httpbin.org/post';
     const TEST_POST_BODY = '{"foo":"bar"}';
 
     protected $ignoreHeaders = array(


### PR DESCRIPTION
### Context
Fixing integration tests

### What has been done

- Using https for the testing urls to avoid redirections

### How to test

- travis


