### PR TITLE
Disabled opcache when intercepting file

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -72,6 +72,7 @@ class StreamProcessor
     public function intercept()
     {
         if (!$this->isIntercepting) {
+            ini_set('opcache.enable', 0);
             stream_wrapper_unregister(self::PROTOCOL);
             $this->isIntercepting = stream_wrapper_register(self::PROTOCOL, __CLASS__);
         }


### PR DESCRIPTION
### Context

This PR fixes #195.

When using PHP-VCR in a web application (not in unit tests), Opcache is enabled.
Opcache prevents the file stream wrapper from triggering (because no file is opened), which can result in a "caching" of a wrong version of the file.

### How to reproduce

- Install a Symfony project with PHP-VCR bundle.
- Start with the PHP-VCR disabled.
- Perform a Guzzle request
- The Guzzle\CurlHandler class is loaded into opcache
- Enable PHP-VCR
- You will see that PHP-VCR fails to intercept the Guzzle\CurlHandler.php file because this file is in Opcache (and therefore, the file handler is not triggered when the file is required).
- Restart Apache (this will empty Opcache)
- Test again, now PHP-VCR manages to intercept the file and everything works as expected.

### What has been done

Just before registering the file stream wrapper, we disable Opcache using `ini_set('opcache.enable', 0);`.

Because opcache is disabled, every "require" now triggers the "file" stream wrapper and PHP-VCR works as expected :wink:.
