### PR TITLE
Adding PHPStan to CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       php: 7.1
     - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
       php: 7.1
-    - env: TEST_DIR=. PHP_CS_FIXER=true
+    - env: TEST_DIR=. PHP_CS_FIXER=true PHPSTAN=true
       php: 7.2
     - env: TEST_DIR=tests/integration/guzzle/3
       php: 5.6
@@ -49,6 +49,7 @@ install:
 script:
   - $PHPUNIT_BIN --coverage-clover=coverage.clover
   - if [ "${PHP_CS_FIXER}" = "true" ]; then wget http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar && php ./php-cs-fixer-v2.phar fix --dry-run --diff $TRAVIS_BUILD_DIR; fi
+  - if [ "${PHPSTAN}" = "true" ]; then composer require --dev phpstan/phpstan ^0.10 && composer phpstan; fi
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 script:
   - $PHPUNIT_BIN --coverage-clover=coverage.clover
   - if [ "${PHP_CS_FIXER}" = "true" ]; then wget http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar && php ./php-cs-fixer-v2.phar fix --dry-run --diff $TRAVIS_BUILD_DIR; fi
-  - if [ "${PHPSTAN}" = "true" ]; then composer require --dev phpstan/phpstan ^0.10 && composer phpstan; fi
+  - if [ "${PHPSTAN}" = "true" ]; then composer require --dev phpstan/phpstan ^0.12 && composer phpstan; fi
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "test": "./vendor/bin/phpunit",
         "lint": "./vendor/bin/php-cs-fixer fix --verbose --diff --dry-run --config-file=.php_cs",
         "fix": "./vendor/bin/php-cs-fixer fix --verbose --diff --config-file=.php_cs",
-        "phpstan": "phpstan analyse src -c phpstan.neon --level=0 --no-progress -vvv"
+        "phpstan": "phpstan analyse -c phpstan.neon --no-progress -vvv"
     },
 
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "scripts": {
         "test": "./vendor/bin/phpunit",
         "lint": "./vendor/bin/php-cs-fixer fix --verbose --diff --dry-run --config-file=.php_cs",
-        "fix": "./vendor/bin/php-cs-fixer fix --verbose --diff --config-file=.php_cs"
+        "fix": "./vendor/bin/php-cs-fixer fix --verbose --diff --config-file=.php_cs",
+        "phpstan": "phpstan analyse src -c phpstan.neon --level=0 --no-progress -vvv"
     },
 
     "authors": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
-#parameters:
-#    ignoreErrors:
+parameters:
+    ignoreErrors:
+        - "#Call to an undefined static method SoapClient::__construct\\(\\)#"
 #includes:
 #    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+#parameters:
+#    ignoreErrors:
+#includes:
+#    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,4 @@
 parameters:
-    ignoreErrors:
-        - "#Call to an undefined static method SoapClient::__construct\\(\\)#"
-#includes:
-#    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    level: 0
+    paths:
+        - src

--- a/src/VCR/CodeTransform/AbstractCodeTransform.php
+++ b/src/VCR/CodeTransform/AbstractCodeTransform.php
@@ -7,7 +7,7 @@ namespace VCR\CodeTransform;
  *
  * @package VCR\CodeTransform
  */
-abstract class AbstractCodeTransform extends \PHP_User_Filter
+abstract class AbstractCodeTransform extends \php_user_filter
 {
     const NAME = 'vcr_abstract_filter';
 

--- a/src/VCR/Request.php
+++ b/src/VCR/Request.php
@@ -53,7 +53,7 @@ class Request
      * with specified request matcher callbacks.
      *
      * @param  Request $request Request to check if it matches the current one.
-     * @param  \callable[] $requestMatchers Request matcher callbacks.
+     * @param  callable[] $requestMatchers Request matcher callbacks.
      *
      * @throws \BadFunctionCallException If one of the specified request matchers is not callable.
      * @return boolean True if specified request matches the current one.

--- a/src/VCR/Response.php
+++ b/src/VCR/Response.php
@@ -38,7 +38,7 @@ class Response
      * @param string $body
      * @param array $curlInfo
      */
-    public function __construct($status, array $headers = array(), $body = null, array $curlInfo = array())
+    final public function __construct($status, array $headers = array(), $body = null, array $curlInfo = array())
     {
         $this->setStatus($status);
         $this->headers = $headers;

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -17,7 +17,6 @@ class CurlHelper
         //"certinfo"?
         CURLINFO_HTTP_CODE => 'http_code',
         CURLINFO_EFFECTIVE_URL => 'url',
-        CURLINFO_FILETIME => 'filetime',
         CURLINFO_TOTAL_TIME => 'total_time',
         CURLINFO_NAMELOOKUP_TIME => 'namelookup_time',
         CURLINFO_CONNECT_TIME => 'connect_time',


### PR DESCRIPTION
### Context

PHPStan is a static analysis tool. It can be used to detect issues automatically in PHP code.

### What has been done

I added PHPStan in the Travis builds.

The first commit of this PR enables "level 0". I haven't modified the code so the build is expected to fail.

In the following commits, I plan to fix "level 0" bugs, then increase to level 1, fix level 1 bugs, etc... up to level 7 (the maximum level in PHPStan).
