### PR TITLE
cURL errors are not handled correctly 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     - env: TEST_DIR=tests/integration/guzzle/6
       php: 5.6
     - env: TEST_DIR=tests/integration/soap
-      php: 5.6
+      php: 7.2
 
 before_install:
   - composer self-update

--- a/src/VCR/CodeTransform/CurlCodeTransform.php
+++ b/src/VCR/CodeTransform/CurlCodeTransform.php
@@ -16,7 +16,9 @@ class CurlCodeTransform extends AbstractCodeTransform
         '/(?<!::|->|\w_)\\\?curl_multi_remove_handle\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_multi_remove_handle(',
         '/(?<!::|->|\w_)\\\?curl_multi_exec\s*\(/i'          => '\VCR\LibraryHooks\CurlHook::curl_multi_exec(',
         '/(?<!::|->|\w_)\\\?curl_multi_info_read\s*\(/i'     => '\VCR\LibraryHooks\CurlHook::curl_multi_info_read(',
-        '/(?<!::|->|\w_)\\\?curl_reset\s*\(/i'               => '\VCR\LibraryHooks\CurlHook::curl_reset('
+        '/(?<!::|->|\w_)\\\?curl_reset\s*\(/i'               => '\VCR\LibraryHooks\CurlHook::curl_reset(',
+        '/(?<!::|->|\w_)\\\?curl_error\s*\(/i'               => '\VCR\LibraryHooks\CurlHook::curl_error(',
+        '/(?<!::|->|\w_)\\\?curl_errno\s*\(/i'               => '\VCR\LibraryHooks\CurlHook::curl_errno('
     );
 
     /**

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -6,6 +6,7 @@ use VCR\Util\Assertion;
 use VCR\Request;
 use VCR\Response;
 use VCR\CodeTransform\AbstractCodeTransform;
+use VCR\Util\CurlException;
 use VCR\Util\CurlHelper;
 use VCR\Util\StreamProcessor;
 use VCR\Util\TextUtil;
@@ -49,6 +50,11 @@ class CurlHook implements LibraryHook
      * @var array Last active curl_multi_exec() handles.
      */
     protected static $multiExecLastChs = array();
+
+    /**
+     * @var CurlException[] Last cURL error, as a CurlException.
+     */
+    protected static $lastErrors = array();
 
     /**
      * @var AbstractCodeTransform
@@ -197,17 +203,22 @@ class CurlHook implements LibraryHook
      */
     public static function curlExec($curlHandle)
     {
-        $request = self::$requests[(int) $curlHandle];
-        CurlHelper::validateCurlPOSTBody($request, $curlHandle);
+        try {
+            $request = self::$requests[(int) $curlHandle];
+            CurlHelper::validateCurlPOSTBody($request, $curlHandle);
 
-        $requestCallback = self::$requestCallback;
-        self::$responses[(int) $curlHandle] = $requestCallback($request);
+            $requestCallback = self::$requestCallback;
+            self::$responses[(int) $curlHandle] = $requestCallback($request);
 
-        return CurlHelper::handleOutput(
-            self::$responses[(int) $curlHandle],
-            self::$curlOptions[(int) $curlHandle],
-            $curlHandle
-        );
+            return CurlHelper::handleOutput(
+                self::$responses[(int) $curlHandle],
+                self::$curlOptions[(int) $curlHandle],
+                $curlHandle
+            );
+        } catch (CurlException $e) {
+            self::$lastErrors[(int) $curlHandle] = $e;
+            return false;
+        }
     }
 
     /**
@@ -296,10 +307,16 @@ class CurlHook implements LibraryHook
      */
     public static function curlGetinfo($curlHandle, $option = 0)
     {
-        return CurlHelper::getCurlOptionFromResponse(
-            self::$responses[(int) $curlHandle],
-            $option
-        );
+        if (isset(self::$responses[(int) $curlHandle])) {
+            return CurlHelper::getCurlOptionFromResponse(
+                self::$responses[(int) $curlHandle],
+                $option
+            );
+        } elseif (isset(self::$lastErrors[(int) $curlHandle])) {
+            return self::$lastErrors[(int) $curlHandle]->getInfo();
+        } else {
+            throw new \RuntimeException('Unexpected error, could not find curl_getinfo in response or errors');
+        }
     }
 
     /**
@@ -335,5 +352,40 @@ class CurlHook implements LibraryHook
                 static::curlSetopt($curlHandle, $option, $value);
             }
         }
+    }
+
+    /**
+     * Return a string containing the last error for the current session
+     *
+     * @link https://php.net/manual/en/function.curl-error.php
+     * @param resource $curlHandle
+     *
+     * @return string the error message or '' (the empty string) if no
+     * error occurred.
+     */
+    public static function curlError($curlHandle)
+    {
+        if (isset(self::$lastErrors[(int) $curlHandle])) {
+            return self::$lastErrors[(int) $curlHandle]->getMessage();
+        }
+        return '';
+    }
+
+    /**
+     * Return the last error number
+     *
+     * @link https://php.net/manual/en/function.curl-errno.php
+     *
+     * @param resource $curlHandle
+     *
+     * @return int the error number or 0 (zero) if no error
+     * occurred.
+     */
+    public static function curlErrno($curlHandle)
+    {
+        if (isset(self::$lastErrors[(int) $curlHandle])) {
+            return self::$lastErrors[(int) $curlHandle]->getCode();
+        }
+        return 0;
     }
 }

--- a/src/VCR/LibraryHooks/StreamWrapperHook.php
+++ b/src/VCR/LibraryHooks/StreamWrapperHook.php
@@ -5,6 +5,7 @@ namespace VCR\LibraryHooks;
 use VCR\Request;
 use VCR\Response;
 use VCR\Util\Assertion;
+use VCR\Util\CurlException;
 use VCR\Util\HttpUtil;
 use VCR\Util\StreamHelper;
 
@@ -90,9 +91,12 @@ class StreamWrapperHook implements LibraryHook
         $request = StreamHelper::createRequestFromStreamContext($this->context, $path);
 
         $requestCallback = self::$requestCallback;
-        $this->response = $requestCallback($request);
-
-        return true;
+        try {
+            $this->response = $requestCallback($request);
+            return true;
+        } catch (CurlException $e) {
+            return false;
+        }
     }
 
     /**

--- a/src/VCR/Util/CurlException.php
+++ b/src/VCR/Util/CurlException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace VCR\Util;
+
+class CurlException extends \Exception
+{
+    private $info;
+
+    /**
+     * @param resource $ch The cURL handler
+     * @return CurlException
+     */
+    public static function create($ch)
+    {
+        $e = new CurlException(curl_error($ch), curl_errno($ch));
+        $e->info = curl_getinfo($ch);
+        return $e;
+    }
+
+    /**
+     * Returns the curl_info array.
+     *
+     * @return array
+     */
+    public function getInfo()
+    {
+        return $this->info;
+    }
+}

--- a/src/VCR/Util/HttpClient.php
+++ b/src/VCR/Util/HttpClient.php
@@ -16,6 +16,8 @@ class HttpClient
      * @param Request $request HTTP Request to send.
      *
      * @return Response Response for specified request.
+     *
+     * @throws CurlException In case of cURL error
      */
     public function send(Request $request)
     {
@@ -32,7 +34,11 @@ class HttpClient
         curl_setopt($ch, CURLOPT_FAILONERROR, false);
         curl_setopt($ch, CURLOPT_HEADER, true);
 
-        list($status, $headers, $body) = HttpUtil::parseResponse(curl_exec($ch));
+        $result = curl_exec($ch);
+        if ($result === false) {
+            throw CurlException::create($ch);
+        }
+        list($status, $headers, $body) = HttpUtil::parseResponse($result);
 
         return new Response(
             HttpUtil::parseStatus($status),

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -248,12 +248,20 @@ class Videorecorder
 
         $this->disableLibraryHooks();
 
-        $this->dispatch(VCREvents::VCR_BEFORE_HTTP_REQUEST, new BeforeHttpRequestEvent($request));
-        $response = $this->client->send($request);
-        $this->dispatch(VCREvents::VCR_AFTER_HTTP_REQUEST, new AfterHttpRequestEvent($request, $response));
+        try {
+            $this->dispatch(VCREvents::VCR_BEFORE_HTTP_REQUEST, new BeforeHttpRequestEvent($request));
+            $response = $this->client->send($request);
+            $this->dispatch(VCREvents::VCR_AFTER_HTTP_REQUEST, new AfterHttpRequestEvent($request, $response));
 
-        $this->dispatch(VCREvents::VCR_BEFORE_RECORD, new BeforeRecordEvent($request, $response, $this->cassette));
-        $this->cassette->record($request, $response);
+            $this->dispatch(VCREvents::VCR_BEFORE_RECORD, new BeforeRecordEvent($request, $response, $this->cassette));
+            $this->cassette->record($request, $response);
+        } catch (\Exception $e) {
+            $this->enableLibraryHooks();
+            throw $e;
+        } catch (\Throwable $e) {
+            $this->enableLibraryHooks();
+            throw $e;
+        }
         $this->enableLibraryHooks();
 
         return $response;

--- a/tests/VCR/Util/HttpClientTest.php
+++ b/tests/VCR/Util/HttpClientTest.php
@@ -12,7 +12,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
         // Request on a closed port
         $request = new Request('GET', 'http://localhost:9934');
 
-        $this->expectException('VCR\\VCRException');
+        $this->setExpectedException('VCR\\Util\\CurlException');
         $httpClient->send($request);
     }
 }

--- a/tests/VCR/Util/HttpClientTest.php
+++ b/tests/VCR/Util/HttpClientTest.php
@@ -2,18 +2,17 @@
 
 namespace VCR\Util;
 
-use VCR\Response;
 use VCR\Request;
 
 class HttpClientTest extends \PHPUnit_Framework_TestCase
 {
-    public function testCreateHttpClient()
+    public function testHttpClientOnError()
     {
-        $this->assertInstanceOf('\VCR\Util\HttpClient', new HttpClient());
-    }
+        $httpClient = new HttpClient();
+        // Request on a closed port
+        $request = new Request('GET', 'http://localhost:9934');
 
-    public function testCreateHttpClientWithMock()
-    {
-        $this->assertInstanceOf('\VCR\Util\HttpClient', new HttpClient());
+        $this->expectException('VCR\\VCRException');
+        $httpClient->send($request);
     }
 }

--- a/tests/integration/guzzle/6/test/ErrorTest.php
+++ b/tests/integration/guzzle/6/test/ErrorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace VCR\Example;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use org\bovigo\vfs\vfsStream;
+use VCR\Util\CurlException;
+
+/**
+ * Tests behaviour when an error occurs.
+ */
+class ErrorTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_GET_URL = 'http://localhost:9959';
+
+    public function setUp()
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    public function testConnectException()
+    {
+        $nonInstrumentedException = null;
+        try {
+            $client = new Client();
+            $client->get(self::TEST_GET_URL);
+        } catch (ConnectException $e) {
+            $nonInstrumentedException = $e;
+        }
+        $this->assertNotNull($nonInstrumentedException);
+        $catched = false;
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+        try {
+            $client = new Client();
+            $client->get(self::TEST_GET_URL);
+        } catch (ConnectException $e) {
+            $catched = true;
+            $this->assertEquals($e->getMessage(), $nonInstrumentedException->getMessage());
+        }
+        $this->assertTrue($catched);
+        \VCR\VCR::turnOff();
+    }
+
+    protected function assertValidGETResponse($info)
+    {
+    }
+}

--- a/tests/integration/soap/src/VCR/Example/ExampleSoapClient.php
+++ b/tests/integration/soap/src/VCR/Example/ExampleSoapClient.php
@@ -18,4 +18,10 @@ class ExampleSoapClient
 
         return trim((string) $response->NumberToWordsResult);
     }
+
+    public function callBadUrl()
+    {
+        // The port is not open. This leads to an error
+        $client = new \SoapClient('http://localhost:9945', array('soap_version' => SOAP_1_2));
+    }
 }

--- a/tests/integration/soap/test/VCR/Example/ExampleSoapClientTest.php
+++ b/tests/integration/soap/test/VCR/Example/ExampleSoapClientTest.php
@@ -3,6 +3,7 @@
 namespace VCR\Example;
 
 use org\bovigo\vfs\vfsStream;
+use SoapFault;
 
 /**
  * Converts temperature units from webservicex
@@ -16,6 +17,10 @@ class ExampleSoapClientTest extends \PHPUnit_Framework_TestCase
         // Configure virtual filesystem.
         vfsStream::setup('testDir');
         \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+
+        // Trigger autoload of assertions (broken after VCR is enabled...
+        $this->assertNotNull(1);
+        $this->assertTrue(true);
     }
 
     public function testCallDirectly()
@@ -35,6 +40,34 @@ class ExampleSoapClientTest extends \PHPUnit_Framework_TestCase
     public function testCallDirectlyEqualsIntercepted()
     {
         $this->assertEquals($this->callSoap(), $this->callSoapIntercepted());
+    }
+
+    /**
+     * This test performs a SOAP request on a buggy WSDL.
+     * It checks that the non instrumented code and the instrumented code return the same exception.
+     */
+    public function testCallSoapWithError()
+    {
+        $nonInstrumentedException = null;
+        try {
+            $soapClient = new ExampleSoapClient();
+            $soapClient->callBadUrl();
+        } catch (SoapFault $e) {
+            $nonInstrumentedException = $e;
+        }
+        $this->assertNotNull($nonInstrumentedException);
+        $catched = false;
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+        try {
+            $soapClient = new ExampleSoapClient();
+            $soapClient->callBadUrl();
+        } catch (SoapFault $e) {
+            $catched = true;
+            $this->assertEquals($e->getMessage(), $nonInstrumentedException->getMessage());
+        }
+        $this->assertTrue($catched);
+        \VCR\VCR::turnOff();
     }
 
     protected function callSoap()


### PR DESCRIPTION
### Context

If a cURL error occurs (for instance if an error occurs because we try to access a non existing domain name or open a non existing port), cURL returns "false" and an error is available in `curl_error()`.

See:

https://github.com/php-vcr/php-vcr/blob/378033762ca95e89d9f371c2ae3a58e1e2b030db/src/VCR/Util/HttpClient.php#L35

If an error occurs, "false" is sent to the `HttpUtil::parseResponse` which expects a string. Hence, we get this error:

```
Undefined offset: 1

/home/david/projects/sandbox/php-vcr/src/VCR/Util/HttpUtil.php:70
/home/david/projects/sandbox/php-vcr/src/VCR/Util/HttpClient.php:35
/home/david/projects/sandbox/php-vcr/tests/VCR/Util/HttpClientTest.php:16
```

The first commit of this PR contains a unit test that show the issue.
