### PR TITLE
Add support for CURLINFO_HEADER_OUT

### DIFF
--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -71,7 +71,7 @@ class Cassette
         foreach ($this->storage as $recording) {
             $storedRequest = Request::fromArray($recording['request']);
             if ($storedRequest->matches($request, $this->getRequestMatchers())) {
-                return Response::fromArray($recording['response']);
+                return Response::fromArray($recording['response'], $storedRequest);
             }
         }
 

--- a/src/VCR/Response.php
+++ b/src/VCR/Response.php
@@ -32,18 +32,21 @@ class Response
 
     protected $httpVersion;
 
+    protected $request;
+
     /**
      * @param string|array $status
      * @param array $headers
      * @param string $body
      * @param array $curlInfo
      */
-    public function __construct($status, array $headers = array(), $body = null, array $curlInfo = array())
+    public function __construct($status, array $headers = array(), $body = null, array $curlInfo = array(), Request $request = null)
     {
         $this->setStatus($status);
         $this->headers = $headers;
         $this->body = $body;
         $this->curlInfo = $curlInfo;
+        $this->request = $request;
     }
 
     /**
@@ -76,7 +79,7 @@ class Response
      * @param  array  $response Array representation of a Response.
      * @return Response A new Response from a specified array
      */
-    public static function fromArray(array $response)
+    public static function fromArray(array $response, Request $request = null)
     {
         $body = isset($response['body']) ? $response['body'] : null;
 
@@ -94,7 +97,9 @@ class Response
         return new static(
             isset($response['status']) ? $response['status'] : 200,
             isset($response['headers']) ? $response['headers'] : array(),
-            $body
+            $body,
+            array(),
+            $request
         );
     }
 
@@ -182,5 +187,15 @@ class Response
             Assertion::numeric($status, 'Response status must be either an array or a number.');
             $this->status['code'] = $status;
         }
+    }
+
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
     }
 }

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -109,7 +109,10 @@ class CurlHelper
                 $info = $response->getHeader('Content-Length');
                 break;
             case CURLINFO_HEADER_SIZE:
-                $info =  mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
+                $info = mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
+                break;
+            case CURLINFO_HEADER_OUT:
+                $info = HttpUtil::formatAsRequestWithHeadersString($response->getRequest());
                 break;
             default:
                 $info = $response->getCurlInfo($option);

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -121,7 +121,10 @@ class CurlHelper
         }
 
         $constants = get_defined_constants(true);
-        $constantNames = array_flip($constants['curl']);
+        $curlInfoConstants = array_filter($constants['curl'], function($k) {
+            return substr($k, 0, 8) === 'CURLINFO';
+        }, ARRAY_FILTER_USE_KEY);
+        $constantNames = array_flip($curlInfoConstants);
         throw new \BadMethodCallException("Not implemented: {$constantNames[$option]} ({$option}) ");
     }
 

--- a/src/VCR/Util/HttpClient.php
+++ b/src/VCR/Util/HttpClient.php
@@ -38,7 +38,8 @@ class HttpClient
             HttpUtil::parseStatus($status),
             HttpUtil::parseHeaders($headers),
             $body,
-            curl_getinfo($ch)
+            curl_getinfo($ch),
+            $request
         );
     }
 }

--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -2,6 +2,7 @@
 
 namespace VCR\Util;
 
+use VCR\Request;
 use VCR\Response;
 
 class HttpUtil
@@ -127,6 +128,27 @@ class HttpUtil
     {
         $headers = self::formatHeadersForCurl($response->getHeaders());
         array_unshift($headers, self::formatAsStatusString($response));
+        return join("\r\n", $headers) . "\r\n\r\n";
+    }
+
+    /**
+     * Returns a HTTP request line from specified request.
+     *
+     * @param Response $response
+     * @return string HTTP request line.
+     */
+    public static function formatAsRequestLine(Request $request)
+    {
+        $path = $request->getPath();
+        return $request->getMethod()
+             . ' ' . (empty($path) ? '/' : $path)
+             . ' HTTP/1.1';
+    }
+
+    public static function formatAsRequestWithHeadersString(Request $request)
+    {
+        $headers = self::formatHeadersForCurl($request->getHeaders());
+        array_unshift($headers, self::formatAsRequestLine($request));
         return join("\r\n", $headers) . "\r\n\r\n";
     }
 }

--- a/tests/VCR/CassetteTest.php
+++ b/tests/VCR/CassetteTest.php
@@ -50,6 +50,7 @@ class CassetteTest extends \PHPUnit_Framework_TestCase
         $this->cassette->record($request, $response);
 
         $this->assertEquals($response->toArray(), $this->cassette->playback($request)->toArray());
+        $this->assertEquals($request, $this->cassette->playback($request)->getRequest());
     }
 
     public function testHasResponseNotFound()

--- a/tests/VCR/ResponseTest.php
+++ b/tests/VCR/ResponseTest.php
@@ -120,6 +120,27 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($curlOptions, $response->getCurlInfo());
     }
 
+    public function testSetsRequestInConstructor()
+    {
+        $expectedRequest = new Request('GET', 'https://localhost:8000', array());
+        $response = new Response(200, array(), null, array(), $expectedRequest);
+
+        $this->assertEquals($expectedRequest, $response->getRequest());
+    }
+
+    public function testSetsRequestInFromArray()
+    {
+        $body = 'this is an example body';
+        $responseArray = array(
+            'headers' => array('Content-Type' => 'application/x-gzip'),
+            'body'    => base64_encode($body)
+        );
+        $expectedRequest = new Request('GET', 'https://localhost:8000', array());
+        $response = Response::fromArray($responseArray, $expectedRequest);
+
+        $this->assertEquals($expectedRequest, $response->getRequest());
+    }
+
     public function testToArray()
     {
         $expectedArray = array(

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -412,6 +412,37 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
                 CURLINFO_HEADER_SIZE,
                 290,
             ),
+            array(
+                Response::fromArray(
+                    array(
+                        'status'    => array(
+                            'http_version' => '1.1',
+                            'code' => 200,
+                            'message' => 'OK',
+                        ),
+                        'headers'   => array(
+                            'Host' => 'localhost:8000',
+                            'Connection' => 'close',
+                            'Content-type' => 'text/html; charset=UTF-8',
+
+                        ),
+                    ),
+                    Request::fromArray(
+                        array(
+                            'method'      => 'GET',
+                            'url'         => 'http://example.com',
+                            'headers'     => array(
+                                'Host' => 'example.com',
+                                'User-Agent' => 'Unit-Test'
+                            )
+                        )
+                    )
+                ),
+                CURLINFO_HEADER_OUT,
+                "GET / HTTP/1.1\r\n"
+                  . "Host: example.com\r\n"
+                  . "User-Agent: Unit-Test\r\n\r\n"
+            ),
         );
     }
 

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -415,6 +415,32 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testGetCurlOptionFromResponseWithUnImplementedOption()
+    {
+        $response = Response::fromArray(
+            array(
+                'status'    => array(
+                    'http_version' => '1.1',
+                    'code' => 200,
+                    'message' => 'OK',
+                ),
+                'headers'   => array(
+                    'Host' => 'localhost:8000',
+                    'Connection' => 'close',
+                    'Content-type' => 'text/html; charset=UTF-8',
+
+                ),
+            )
+        );
+
+        $this->setExpectedException(
+            'BadMethodCallException',
+            'Not implemented: CURLINFO_REDIRECT_TIME (3145747)'
+        );
+
+        CurlHelper::getCurlOptionFromResponse($response, CURLINFO_REDIRECT_TIME);
+    }
+
     public function testSetCurlOptionCustomRequest()
     {
         $request = new Request('POST', 'http://example.com');


### PR DESCRIPTION
### Context

When `curl_setopt($ch, CURLINFO_HEADER_OUT, true)` has been called before a request is sent you should then be able to call `curl_getinfo($ch, CURLINFO_HEADER_OUT)` after the request to get a description of the request that's been sent. Prior to this patch calling `curl_getinfo($ch, CURLINFO_HEADER_OUT)` with VCR enabled would actually cause an exception. To compound the issue the error message was also quite confusing (see https://github.com/php-vcr/php-vcr/issues/201 for an example).

### What has been done

I've taken a second run at solving this as it was still causing problems for me with the PayPal SDK. My previous attempt was https://github.com/php-vcr/php-vcr/pull/198. I have similar misgivings about this version as it does break down some separation of concerns, but I think that's inevitable with this. The response object really does have to know about the request object.

This also required a function to format the Request as a string. I've mimicked curl's output for a simple GET request, but doing it for a POST with a body would take much more work. It's got enough there fulfil my purposes at the moment. It feels like the sort of thing that there may be a standard PHP function out there to do, but I haven't found one.

### How to test

Unit tests have been added. 

