### PR TITLE
Add a return value

### DIFF
--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -335,5 +335,6 @@ class CurlHook implements LibraryHook
                 static::curlSetopt($curlHandle, $option, $value);
             }
         }
+        return true;
     }
 }


### PR DESCRIPTION
Some libraries depend on this function returning a value.

### Context
I was mocking requests to [Twilio](https://github.com/twilio/twilio-php) and I realized that that library depends on `curl_setopt_array` returning something.

### What has been done
Added a simple return value.


