### PR TITLE
Large Files Splitting Strings

### DIFF
--- a/src/VCR/CodeTransform/AbstractCodeTransform.php
+++ b/src/VCR/CodeTransform/AbstractCodeTransform.php
@@ -54,9 +54,9 @@ abstract class AbstractCodeTransform extends \PHP_User_Filter
         }
         
         if ($lastBucket !== null) {
-            $bucket->data = $this->transformCode($data);
-            $consumed += $bucket->datalen;
-            stream_bucket_append($out, $bucket);   
+            $lastBucket->data = $this->transformCode($data);
+            $consumed += $lastBucket->datalen;
+            stream_bucket_append($out, $lastBucket);   
         }
 
         return PSFS_PASS_ON;

--- a/src/VCR/CodeTransform/AbstractCodeTransform.php
+++ b/src/VCR/CodeTransform/AbstractCodeTransform.php
@@ -46,10 +46,17 @@ abstract class AbstractCodeTransform extends \PHP_User_Filter
      */
     public function filter($in, $out, &$consumed, $closing)
     {
+        $lastBucket = null;
+        $data = "";
         while ($bucket = stream_bucket_make_writeable($in)) {
-            $bucket->data = $this->transformCode($bucket->data);
+            $data = $data.$bucket->data;
+            $lastBucket = $bucket;
+        }
+        
+        if ($lastBucket !== null) {
+            $bucket->data = $this->transformCode($data);
             $consumed += $bucket->datalen;
-            stream_bucket_append($out, $bucket);
+            stream_bucket_append($out, $bucket);   
         }
 
         return PSFS_PASS_ON;


### PR DESCRIPTION
### Context

For main context see: #268  but the TL;DR is that the code was getting piped into the processor in pieces and was conveniently getting split right on a curl function. 
### What has been done

- This ingests the whole file before running a regex on the strings.
-

### How to test

- All tests should pass normally if you want a large file trying processing against Stripe's CurlClient.

### Todo

- [ ]
- [ ]

### Notes

-
-


