### PR TITLE
Implement recording of identical requests with backwards compatibility and separation of concerns.

### DIFF
--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -72,6 +72,12 @@ class Cassette
     {
         foreach ($this->storage as $recording) {
             $storedRequest = Request::fromArray($recording['request']);
+
+            // Support legacy cassettes which do not have the 'index' key
+            if (!array_key_exists('index', $recording)) {
+              $recording['index'] = 0;
+            }
+
             if ($index == $recording['index']) {
                 if ($storedRequest->matches($request, $this->getRequestMatchers())) {
                   return Response::fromArray($recording['response']);

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -72,7 +72,7 @@ class Cassette
     {
         foreach ($this->storage as $recording) {
             $storedRequest = Request::fromArray($recording['request']);
-            if ($index === $recording['index']) {
+            if ($index == $recording['index']) {
                 if ($storedRequest->matches($request, $this->getRequestMatchers())) {
                   return Response::fromArray($recording['response']);
                 }

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -91,7 +91,7 @@ class Cassette
      *
      * @return void
      */
-    public function record(Request $request, Response $response, $index)
+    public function record(Request $request, Response $response, $index = 0)
     {
         if ($this->hasResponse($request, $index)) {
             return;

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -73,7 +73,7 @@ class Cassette
         foreach ($this->storage as $recording) {
             $storedRequest = Request::fromArray($recording['request']);
 
-            // Support legacy cassettes which do not have the 'index' key
+            // Support legacy cassettes which do not have the 'index' key.
             if (!array_key_exists('index', $recording)) {
               $recording['index'] = 0;
             }

--- a/src/VCR/Request.php
+++ b/src/VCR/Request.php
@@ -350,4 +350,15 @@ class Request
     {
         $this->postFiles[] = $file;
     }
+
+    /**
+     * Generate a string representation of the request.
+     *
+     * @return string
+     */
+    public function getHash()
+    {
+        return md5(serialize($this->toArray()));
+    }
+
 }

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -318,24 +318,24 @@ class Videorecorder
         }
     }
 
-  /**
-   * Increment the index for a given request.
-   *
-   * @param \VCR\Request $request
-   * @return mixed
-   */
+    /**
+     * Increment the index for a given request.
+     *
+     * @param \VCR\Request $request
+     * @return mixed
+     */
     protected function iterateIndex(Request $request)
     {
-      $hash = $request->getHash();
-      if (!isset($this->indexTable[$hash])) {
-        $this->indexTable[$hash] = -1;
-      }
-      return ++$this->indexTable[$hash];
+        $hash = $request->getHash();
+        if (!isset($this->indexTable[$hash])) {
+            $this->indexTable[$hash] = -1;
+        }
+        return ++$this->indexTable[$hash];
     }
 
-  /**
-   * Clear the indexTable property.
-   */
+    /**
+     * Clear the indexTable property.
+     */
     public function resetIndex()
     {
         $this->indexTable = array();

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -160,7 +160,9 @@ class Videorecorder
     public function eject()
     {
         Assertion::true($this->isOn, 'Please turn on VCR before ejecting a cassette, use: VCR::turnOn().');
+
         $this->cassette = null;
+        $this->resetIndex();
     }
 
     /**
@@ -185,6 +187,7 @@ class Videorecorder
 
         $this->cassette = new Cassette($cassetteName, $this->config, $storage);
         $this->enableLibraryHooks();
+        $this->resetIndex();
     }
 
     /**
@@ -330,4 +333,11 @@ class Videorecorder
       return ++$this->indexTable[$hash];
     }
 
+  /**
+   * Clear the indexTable property.
+   */
+    public function resetIndex()
+    {
+        $this->indexTable = array();
+    }
 }

--- a/tests/VCR/CassetteTest.php
+++ b/tests/VCR/CassetteTest.php
@@ -4,6 +4,7 @@ namespace VCR;
 
 use org\bovigo\vfs\vfsStream;
 
+
 /**
  * Test integration of PHPVCR with PHPUnit.
  */
@@ -66,5 +67,27 @@ class CassetteTest extends \PHPUnit_Framework_TestCase
         $this->cassette->record($request, $response);
 
         $this->assertTrue($this->cassette->hasResponse($request), 'Expected true if request was found.');
+    }
+
+    /**
+     * Test playback of a legacy cassette which does not have an index key.
+     */
+    public function testPlaybackLegacyCassette()
+    {
+        $request = new Request('GET', 'https://example.com');
+        $response = new Response(200, array(), 'sometest');
+
+        // Create recording array with no index key.
+        $recording = array(
+            'request'  => $request->toArray(),
+            'response' => $response->toArray(),
+        );
+
+        $storage = new Storage\Yaml(vfsStream::url('test/'), 'json_test');
+        $storage->storeRecording($recording);
+        $configuration = new Configuration();
+        $cassette = new Cassette('cassette_name', $configuration, $storage);
+
+        $this->assertEquals($response->toArray(), $cassette->playback($request)->toArray());
     }
 }

--- a/tests/VCR/CassetteTest.php
+++ b/tests/VCR/CassetteTest.php
@@ -70,25 +70,6 @@ class CassetteTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test playback of a legacy cassette which does not have an index key.
-     */
-    public function testPlaybackLegacyCassette()
-    {
-        $request = new Request('GET', 'https://example.com');
-        $response = new Response(200, array(), 'sometest');
-
-        // Create recording array with no index key.
-        $recording = array(
-            'request'  => $request->toArray(),
-            'response' => $response->toArray(),
-        );
-
-        $cassette = $this->createCassetteWithRecordings(array($recording));
-
-        $this->assertEquals($response->toArray(), $cassette->playback($request)->toArray());
-    }
-
-    /**
      * Ensure that if a second identical request is played back from a legacy
      * cassette, the first response will be returned.
      */

--- a/tests/VCR/VideorecorderTest.php
+++ b/tests/VCR/VideorecorderTest.php
@@ -27,10 +27,11 @@ class VideorecorderTest extends \PHPUnit_Framework_TestCase
         $configuration->enableLibraryHooks(array());
         $videorecorder = $this->getMockBuilder('\VCR\Videorecorder')
             ->setConstructorArgs(array($configuration, new Util\HttpClient(), VCRFactory::getInstance()))
-            ->setMethods(array('eject'))
+            ->setMethods(array('eject', 'resetIndex'))
             ->getMock();
 
         $videorecorder->expects($this->exactly(2))->method('eject');
+        $videorecorder->expects($this->exactly(2))->method('resetIndex');
 
         $videorecorder->turnOn();
         $videorecorder->insertCassette('cassette1');


### PR DESCRIPTION
### Context
This PR was inspired by #161 and it fixes #132.  #161 didn't quite work for our use case.  `Cassette::hasResponse()` caused Cassette::$indexTable to be incremented resulting in non-sequential indexes and off-by-one issues. 

#### Use case
[Terminus](https://github.com/pantheon-systems/terminus) uses phpVCR.  Certain Behat tests run commands that repeatedly check the status of a task.  When the task finishes its status changes from null to 'success' or 'failed'.  With phpVCR 1.4.4 only the first status check request is recorded. 

### What has been done
I've repurposed some of the methods from #161, but I've removed `Cassette::$indexTable` and added an `$indexTable` property to Videorecorder instead. The thinking here is that `$indexTable` manages state and moving this responsibility to Videorecorder maintains better separation of concerns. (In fact making this change required no adjustments to existing unit tests.)

`Cassette::playback()`:
* takes an optional `$index` parameter (making it possible to playback a specific index multiple times -- should such a need arise).
* assigns an index of 0 to legacy cassettes which don't have indexes for *backwards compatibility*.

`Videorecorder::handleRequest()`:
* determines the current request index and passes it to `Cassette:playback()` using the optional parameter.
* clears the index state when a cassette is ejected or loaded.

New unit tests:
* `testPlaybackOfIdenticalRequestsFromLegacyCassette()` ensures proper behavior with legacy cassettes.
* `testPlaybackOfIdenticalRequests()` ensures proper behavior with indexed cassettes.
* Improvement to `testInsertCassetteEjectExisting()` ensure that `Videorecorder::resetIndex()`is called.

### How to test

1. `composer install` and `composer test` and ensure that tests are passing.
2. Enable phpVcr and run code that makes repeated identical requests to an API endpoint. Look at the cassette and see that each request was recorded and that they are differentiated by an `index: N` key value at the end of the request/response recording. Play back the recording and observe that the responses are played back sequentially. 

## Thanks
Thanks to @dsnopek for his input!


