### PR TITLE
Adding response to curl setopt array

### DIFF
--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -327,13 +327,18 @@ class CurlHook implements LibraryHook
      * @link http://www.php.net/manual/en/function.curl-setopt-array.php
      * @param resource $curlHandle A cURL handle returned by curl_init().
      * @param array    $options    An array specifying which options to set and their values.
+     *
+     * @return boolean Returns TRUE on success of every element of the $options array and FALSE if one fails.
      */
     public static function curlSetoptArray($curlHandle, $options)
     {
+        $result = true;
         if (is_array($options)) {
             foreach ($options as $option => $value) {
-                static::curlSetopt($curlHandle, $option, $value);
+                $result = $result && static::curlSetopt($curlHandle, $option, $value);
             }
         }
+
+        return $result;
     }
 }

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -155,7 +155,7 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         );
 
         $curlHandle = curl_init('http://example.com');
-        curl_setopt_array(
+        $result = curl_setopt_array(
             $curlHandle,
             array(
                 CURLOPT_POSTFIELDS => array('para1' => 'val1', 'para2' => 'val2')
@@ -164,6 +164,7 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         curl_exec($curlHandle);
         curl_close($curlHandle);
         $this->curlHook->disable();
+        $this->assertTrue($result);
     }
 
     public function testShouldReturnCurlInfoStatusCode()


### PR DESCRIPTION
### Context
We need that the hook for curl method curl_setopt_array to return a boolean as its equivalent curl method.

### What has been done
Added a response similar as how it’s working at curl’s curl_setopt_array.

### How to test
The test testShouldPostFieldsAsArrayUsingSetoptarray has been modified to test if that method is returning correct booleans.