### PR TITLE
Never validate curl post settings for non post requests

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -197,6 +197,10 @@ class CurlHelper
      */
     public static function validateCurlPOSTBody(Request $request, $curlHandle = null)
     {
+        if ('POST' !== $request->getMethod()) {
+            return;
+        }
+        
         $readFunction = $request->getCurlOption(CURLOPT_READFUNCTION);
         if (is_null($readFunction)) {
             return;


### PR DESCRIPTION
After my latest dependency update I suddenly get `To set a CURLOPT_READFUNCTION, CURLOPT_INFILESIZE must be set.` exceptions even though I send a `GET` request.
Something must have changed here but I guess it's just save to always early return if the request is not a `POST` request anyway because that's essentially what the method is for 😄 


