### PR TITLE
Added 'strict' mode which requires all requests to play in order.

### DIFF
--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -141,6 +141,7 @@ class Configuration
         VCR::MODE_NEW_EPISODES,
         VCR::MODE_ONCE,
         VCR::MODE_NONE,
+        VCR::MODE_STRICT
     );
 
     /**

--- a/src/VCR/VCR.php
+++ b/src/VCR/VCR.php
@@ -28,6 +28,11 @@ class VCR
      */
     const MODE_NONE = 'none';
 
+    /**
+     * Treat as read only and require all requests to be replayed in order.
+     */
+    const MODE_STRICT = 'strict';
+
     public static function __callStatic($method, $parameters)
     {
         $instance = VCRFactory::get('VCR\Videorecorder');

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -154,12 +154,12 @@ class Videorecorder
     {
         Assertion::true($this->isOn, 'Please turn on VCR before ejecting a cassette, use: VCR::turnOn().');
 
-	$cassette = $this->cassette;
-	$this->cassette = null;
+        $cassette = $this->cassette;
+        $this->cassette = null;
 
         if ($cassette && $this->config->getMode() === VCR::MODE_STRICT && !$cassette->isFinished()) {
             throw new \LogicException(
-               "Strict playback was requested but the cassette did not play in its entirety."
+                'Strict playback was requested but the cassette did not play in its entirety.'
             );
         }
     }

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -184,6 +184,10 @@ class Videorecorder
 
         $storage = $this->factory->get('Storage', array($cassetteName));
 
+        if ($this->config->getMode() === VCR::MODE_STRICT) {
+            $storage->rewind();
+        }
+
         $this->cassette = new Cassette($cassetteName, $this->config, $storage);
         $this->enableLibraryHooks();
     }

--- a/tests/VCR/RequestTest.php
+++ b/tests/VCR/RequestTest.php
@@ -219,9 +219,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testDoNotOverwriteHostHeader()
     {
         $this->request = new Request(
-          'GET',
-          'http://example.com',
-          array('User-Agent' => 'Unit-Test', 'Host' => 'www.example.com')
+            'GET',
+            'http://example.com',
+            array('User-Agent' => 'Unit-Test', 'Host' => 'www.example.com')
         );
 
         $this->assertEquals(


### PR DESCRIPTION
### Context
This is a refresh of https://github.com/php-vcr/php-vcr/pull/160.   I removed the SOAPAction specific change since it was not material to this fix.   For tests which issue multiple requests, this resulted in a huge performance benefit to not have to search the entire yml object on every request.

### What has been done

Adds a strict mode which only replays requests in order and throws an exception if all requests are not played.

### How to test
Add
```
\VCR\VCR::configure()->setMode(\VCR\VCR::MODE_STRICT);
```
to your code.  Watch your tests run faster.

### Todo

- Add unit tests

