### PR TITLE
Updates symfony deps to 4.3 and fixes deprecation warnings

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "e7620447991c15ab183fd84a2b8dfde2",
@@ -63,29 +63,36 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.0.0",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "6223fb2b68e7059e8d5843c0103999a84e7275cf"
+                "reference": "429d0a1451d4c9c4abe1959b2986b88794b9b7d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/6223fb2b68e7059e8d5843c0103999a84e7275cf",
-                "reference": "6223fb2b68e7059e8d5843c0103999a84e7275cf",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/429d0a1451d4c9c4abe1959b2986b88794b9b7d2",
+                "reference": "429d0a1451d4c9c4abe1959b2986b88794b9b7d2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3",
+                "symfony/event-dispatcher-contracts": "^1.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "1.1"
             },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
                 "symfony/expression-language": "~3.4|~4.0",
+                "symfony/http-foundation": "^3.4|^4.0",
+                "symfony/service-contracts": "^1.1",
                 "symfony/stopwatch": "~3.4|~4.0"
             },
             "suggest": {
@@ -95,7 +102,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -122,7 +129,65 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-09T17:30:28+00:00"
+            "time": "2019-08-26T08:55:16+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "c61766f4440ca687de1084a5c00b08e167a2575c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c61766f4440ca687de1084a5c00b08e167a2575c",
+                "reference": "c61766f4440ca687de1084a5c00b08e167a2575c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/event-dispatcher": "",
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-06-20T06:46:26+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -289,12 +354,12 @@
             "version": "v1.6.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikey179/vfsStream.git",
+                "url": "https://github.com/bovigo/vfsStream.git",
                 "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
                 "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
                 "shasum": ""
             },
@@ -972,6 +1037,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
         },
         {

--- a/src/VCR/Event/AfterHttpRequestEvent.php
+++ b/src/VCR/Event/AfterHttpRequestEvent.php
@@ -4,7 +4,7 @@ namespace VCR\Event;
 
 use VCR\Request;
 use VCR\Response;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class AfterHttpRequestEvent extends Event
 {

--- a/src/VCR/Event/AfterPlaybackEvent.php
+++ b/src/VCR/Event/AfterPlaybackEvent.php
@@ -5,7 +5,7 @@ namespace VCR\Event;
 use VCR\Cassette;
 use VCR\Request;
 use VCR\Response;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class AfterPlaybackEvent extends Event
 {

--- a/src/VCR/Event/BeforeHttpRequestEvent.php
+++ b/src/VCR/Event/BeforeHttpRequestEvent.php
@@ -3,7 +3,7 @@
 namespace VCR\Event;
 
 use VCR\Request;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class BeforeHttpRequestEvent extends Event
 {

--- a/src/VCR/Event/BeforePlaybackEvent.php
+++ b/src/VCR/Event/BeforePlaybackEvent.php
@@ -4,7 +4,7 @@ namespace VCR\Event;
 
 use VCR\Cassette;
 use VCR\Request;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class BeforePlaybackEvent extends Event
 {

--- a/src/VCR/Event/BeforeRecordEvent.php
+++ b/src/VCR/Event/BeforeRecordEvent.php
@@ -5,7 +5,7 @@ namespace VCR\Event;
 use VCR\Cassette;
 use VCR\Request;
 use VCR\Response;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class BeforeRecordEvent extends Event
 {

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -11,7 +11,7 @@ use VCR\Event\BeforePlaybackEvent;
 use VCR\Event\BeforeRecordEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * A videorecorder records requests on a cassette.
@@ -95,13 +95,12 @@ class Videorecorder
     /**
      * Dispatches an event to all registered listeners.
      *
-     * @param string $eventName The name of the event to dispatch.
      * @param Event $event The event to pass to the event handlers/listeners.
-     * @return Event
+     * @return object
      */
-    private function dispatch($eventName, Event $event = null)
+    private function dispatch(Event $event = null, $eventName)
     {
-        return $this->getEventDispatcher()->dispatch($eventName, $event);
+        return $this->getEventDispatcher()->dispatch($event, $eventName);
     }
 
     /**
@@ -218,14 +217,14 @@ class Videorecorder
         }
 
         $event = new BeforePlaybackEvent($request, $this->cassette);
-        $this->dispatch(VCREvents::VCR_BEFORE_PLAYBACK, $event);
+        $this->dispatch($event, VCREvents::VCR_BEFORE_PLAYBACK);
 
         $response = $this->cassette->playback($request);
 
         // Playback succeeded and the recorded response can be returned.
         if (!empty($response)) {
             $event = new AfterPlaybackEvent($request, $response, $this->cassette);
-            $this->dispatch(VCREvents::VCR_AFTER_PLAYBACK, $event);
+            $this->dispatch($event, VCREvents::VCR_AFTER_PLAYBACK);
             return $response;
         }
 
@@ -248,11 +247,11 @@ class Videorecorder
 
         $this->disableLibraryHooks();
 
-        $this->dispatch(VCREvents::VCR_BEFORE_HTTP_REQUEST, new BeforeHttpRequestEvent($request));
+        $this->dispatch(new BeforeHttpRequestEvent($request), VCREvents::VCR_BEFORE_HTTP_REQUEST);
         $response = $this->client->send($request);
-        $this->dispatch(VCREvents::VCR_AFTER_HTTP_REQUEST, new AfterHttpRequestEvent($request, $response));
+        $this->dispatch(new AfterHttpRequestEvent($request, $response), VCREvents::VCR_AFTER_HTTP_REQUEST);
 
-        $this->dispatch(VCREvents::VCR_BEFORE_RECORD, new BeforeRecordEvent($request, $response, $this->cassette));
+        $this->dispatch(new BeforeRecordEvent($request, $response, $this->cassette), VCREvents::VCR_BEFORE_RECORD);
         $this->cassette->record($request, $response);
         $this->enableLibraryHooks();
 

--- a/tests/VCR/VCRTest.php
+++ b/tests/VCR/VCRTest.php
@@ -2,7 +2,7 @@
 
 namespace VCR;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use org\bovigo\vfs\vfsStream;
 
 /**
@@ -10,6 +10,8 @@ use org\bovigo\vfs\vfsStream;
  */
 class VCRTest extends \PHPUnit_Framework_TestCase
 {
+    private $events = [];
+
     public static function setupBeforeClass()
     {
         VCR::configure()->setCassettePath('tests/fixtures') ;


### PR DESCRIPTION
### Context
I recently upgraded to Symfony 4.3 and got a lot of deprecation warnings from this library. I fixed that in this PR.

### What has been done

- Updated symfony components to 4.3 level
- Fixed the deprecation warnings in the library to use the new EventDispatcher interface
- Created a private property in the VCR unit test to improve the failed messages from phpunit

### How to test

- Unit tests still work after fixes

### Notes

- This is a BC break for Symfony < 4.3, so maybe this can be tagged to 2.0 or something. I saw in the issue list that the deprecation warnings occurred to other people as well so they'll probably appreciate this as well.


