### PR TITLE
Update SoapCodeTransform regex

### DIFF
--- a/src/VCR/CodeTransform/SoapCodeTransform.php
+++ b/src/VCR/CodeTransform/SoapCodeTransform.php
@@ -13,7 +13,7 @@ class SoapCodeTransform extends AbstractCodeTransform
 
     private static $patterns = array(
         '@new\s+\\\?SoapClient\W*\(@i',
-        '@extends\s+\\\?SoapClient@i',
+        '@extends\s+\\\?SoapClient\b@i',
     );
 
     /**

--- a/tests/VCR/CodeTransform/SoapCodeTransformTest.php
+++ b/tests/VCR/CodeTransform/SoapCodeTransformTest.php
@@ -26,6 +26,8 @@ class SoapCodeTransformTest extends \PHPUnit_Framework_TestCase
           array('new \VCR\Util\SoapClient(', 'new SoapClient('),
           array('extends \VCR\Util\SoapClient', 'extends \SoapClient'),
           array("extends \\VCR\\Util\\SoapClient\n", "extends \\SoapClient\n"),
+          array("extends MySoapClientBuilder\n", "extends MySoapClientBuilder\n"),
+          array("extends SoapClientFactory\n", "extends SoapClientFactory\n"),
           array('new SoapClientExtended(', 'new SoapClientExtended('),
           array('new \SoapClientExtended(', 'new \SoapClientExtended('),
         );


### PR DESCRIPTION
### Context
Fixes issue #282 

### What has been done

- Added a failing test to see that Builders / factories and such don't get replaced
- Added a word boundary to te regex to make it work

### How to test

- Test is included

### Notes

This makes everything that extends some SoapClientBuilder or Factory testable but now only things that extend SoapClient will be replaced.


