### PR TITLE
Add CURLINFO_PRIVATE to CurlHelper

### DIFF
--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -296,6 +296,14 @@ class CurlHook implements LibraryHook
      */
     public static function curlGetinfo($curlHandle, $option = 0)
     {
+        // Workaround for CURLINFO_PRIVATE.
+        // It can be set AND read before the response is available, e.g by symfony/http-client.
+        //   - If the response is available, we read from it.
+        //   - If not, we return what was first set.
+        if ($option === CURLINFO_PRIVATE && !in_array((int) $curlHandle, self::$responses, true)) {
+            return static::$curlOptions[(int) $curlHandle][CURLOPT_PRIVATE];
+        }
+
         return CurlHelper::getCurlOptionFromResponse(
             self::$responses[(int) $curlHandle],
             $option

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -111,10 +111,6 @@ class CurlHelper
             case CURLINFO_HEADER_SIZE:
                 $info =  mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
                 break;
-            case CURLINFO_PRIVATE:
-                $curlInfoPrivate = $response->getCurlInfo($option);
-                $info = $curlInfoPrivate !== null ? $curlInfoPrivate : '';
-                break;
             default:
                 $info = $response->getCurlInfo($option);
                 break;

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -111,6 +111,10 @@ class CurlHelper
             case CURLINFO_HEADER_SIZE:
                 $info =  mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
                 break;
+            case CURLINFO_PRIVATE:
+                $curlInfoPrivate = $response->getCurlInfo($option);
+                $info = $curlInfoPrivate !== null ? $curlInfoPrivate : '';
+                break;
             default:
                 $info = $response->getCurlInfo($option);
                 break;

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -216,6 +216,22 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         $this->curlHook->disable();
     }
 
+    public function testShouldHandleCurlOptPrivate()
+    {
+        $this->curlHook->enable($this->getTestCallback());
+
+        $curlHandle = curl_init('http://example.com');
+        curl_setopt($curlHandle, CURLOPT_PRIVATE, 'private');
+
+        $this->assertEquals('private', curl_getinfo($curlHandle, CURLINFO_PRIVATE));
+
+        curl_exec($curlHandle);
+        curl_close($curlHandle);
+
+        $this->assertEquals('private', curl_getinfo($curlHandle, CURLINFO_PRIVATE));
+        $this->curlHook->disable();
+    }
+
     public function testShouldReturnCurlInfoAllKeys()
     {
         $this->curlHook->enable($this->getTestCallback());

--- a/tests/VCR/RequestTest.php
+++ b/tests/VCR/RequestTest.php
@@ -219,9 +219,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testDoNotOverwriteHostHeader()
     {
         $this->request = new Request(
-          'GET',
-          'http://example.com',
-          array('User-Agent' => 'Unit-Test', 'Host' => 'www.example.com')
+            'GET',
+            'http://example.com',
+            array('User-Agent' => 'Unit-Test', 'Host' => 'www.example.com')
         );
 
         $this->assertEquals(


### PR DESCRIPTION
## Context

This PR adds the handling of `CURLINFO_PRIVATE` in PHP VCR. This header is used by the symfony/http-client, and make it incompatible with PHP VCR.

There was a previous PR with such a fix (#278) but it was failing for PHP < 7.

### What has been done

- We added support for `CURLINFO_PRIVATE` 

### How to test

- The test harness should handle it.
- To manually test, use PHP VCR with symfony/http-client