### PR TITLE
Add default return value for CURLINFO_CERTINFO

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -111,6 +111,10 @@ class CurlHelper
             case CURLINFO_HEADER_SIZE:
                 $info =  mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
                 break;
+            case CURLINFO_CERTINFO:
+                $curlInfo = $response->getCurlInfo($option);
+                $info = (!is_null($curlInfo)) ? $curlInfo : [];
+                break;
             default:
                 $info = $response->getCurlInfo($option);
                 break;

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -294,6 +294,24 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedBody, file_get_contents($testFile));
     }
 
+    public function testGetCurlOptionFromResponseHandleCertinfo()
+    {
+        $status = array(
+            'code' => 200,
+            'message' => 'OK',
+            'http_version' => '1.1',
+        );
+        $headers = array(
+            'Content-Length' => 0,
+        );
+        $response = new Response($status, $headers, 'example response');
+
+        $this->assertEquals(
+            [],
+            CurlHelper::getCurlOptionFromResponse($response, CURLINFO_CERTINFO)
+        );
+    }
+
     /**
      * @dataProvider getCurlOptionProvider()
      *

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -307,7 +307,7 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
         $response = new Response($status, $headers, 'example response');
 
         $this->assertEquals(
-            [],
+            array(),
             CurlHelper::getCurlOptionFromResponse($response, CURLINFO_CERTINFO)
         );
     }


### PR DESCRIPTION
### Context

symfony/http-client is using the cURL `CURLINFO_CERTINFO` (see [here](https://github.com/symfony/http-client/blob/master/Response/CurlResponse.php#L371))

However PHP-VCR is not handling this. By default, its value is `[]`, unless a developer use this:

```
curl_setopt($ch, CURLOPT_CERTINFO, 1);
curl_setopt($ch, CURLOPT_VERBOSE, 1);
``` 

### What has been done

This PR allows `curl_getinfo($ch, CURLINFO_CERTINFO)` to return the default cURL value : `[]` when those `curl_setopt` are not set, instead of a PHP VCR Exception.

### How to test

I added a test to `CurlHelperTest`, testing that calling `curl_getinfo($ch, CURLINFO_CERTINFO)` doesn't thrown an exception, but returns the default cURL value.

### Notes

Build is failing because of PHP CS Fixer on files unrelated to this PR. As multiple PRs include that fix, I didn't run the fix again on this one :)