### PR TITLE
Increase performance by storing response body separately

### DIFF
--- a/src/VCR/Storage/AbstractStorage.php
+++ b/src/VCR/Storage/AbstractStorage.php
@@ -118,4 +118,26 @@ abstract class AbstractStorage implements Storage
             fclose($this->handle);
         }
     }
+
+    protected function storeBody(&$recording)
+    {
+        if (!isset($recording['response']['body'])) {
+            return;
+        }
+        $body = dirname($this->filePath).uniqid('/body_', true);
+        file_put_contents($body, $recording['response']['body']);
+        $recording['response']['body'] = $body;
+    }
+
+    protected function loadBody(&$recording)
+    {
+        if (!isset($recording['response']['body'])) {
+            return;
+        }
+        if (!is_file($recording['response']['body'])) {
+            return;
+        }
+
+        $recording['response']['body'] = file_get_contents($recording['response']['body']);
+    }
 }

--- a/src/VCR/Storage/AbstractStorage.php
+++ b/src/VCR/Storage/AbstractStorage.php
@@ -124,7 +124,7 @@ abstract class AbstractStorage implements Storage
         if (!isset($recording['response']['body'])) {
             return;
         }
-        $body = dirname($this->filePath).uniqid('/body_', true);
+        $body = dirname($this->filePath) . uniqid('/body_', true);
         file_put_contents($body, $recording['response']['body']);
         $recording['response']['body'] = $body;
     }

--- a/src/VCR/Storage/Json.php
+++ b/src/VCR/Storage/Json.php
@@ -17,6 +17,7 @@ class Json extends AbstractStorage
      */
     public function storeRecording(array $recording)
     {
+        $this->storeBody($recording);
         fseek($this->handle, -1, SEEK_END);
         if (ftell($this->handle) > 2) {
             fwrite($this->handle, ',');
@@ -38,6 +39,7 @@ class Json extends AbstractStorage
     public function next()
     {
         $this->current = json_decode($this->readNextRecord(), true);
+        $this->loadBody($this->current);
         ++$this->position;
     }
 

--- a/src/VCR/Storage/Yaml.php
+++ b/src/VCR/Storage/Yaml.php
@@ -4,7 +4,6 @@ namespace VCR\Storage;
 
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Dumper;
-use VCR\Util\Assertion;
 
 /**
  * Yaml based storage for records.
@@ -45,6 +44,7 @@ class Yaml extends AbstractStorage
      */
     public function storeRecording(array $recording)
     {
+        $this->storeBody($recording);
         fseek($this->handle, -1, SEEK_END);
         fwrite($this->handle, "\n" . $this->yamlDumper->dump(array($recording), 4));
         fflush($this->handle);
@@ -58,6 +58,7 @@ class Yaml extends AbstractStorage
     public function next()
     {
         $recording = $this->yamlParser->parse($this->readNextRecord());
+        $this->loadBody($recording[0]);
         $this->current = $recording[0];
         ++$this->position;
     }


### PR DESCRIPTION
### Context

If you have a file with multiple large multi line response bodies, it will cause php-vcr to become very slow

### What has been done

- On storing the requests, looks for the response body and puts it in a separate file
- On loading, it will test if the body has been replaced with a file reference, and replaces the placeholder with the content fetched from the file

### How to test

- Make a test that requests multiple large response bodies

### Todo

- improve detection of placeholder?
- This is basically a RFC PR, not per se final

### Notes

- caused a functional test of mine to go from 30s to 0.5s


