### PR TITLE
[Curl] Add \r\n to HTTP status and headers to mimic what curl does

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -59,7 +59,7 @@ class CurlHelper
         if (isset($curlOptions[CURLOPT_HEADERFUNCTION])) {
             $headerList = array(HttpUtil::formatAsStatusString($response));
             $headerList = array_merge($headerList, HttpUtil::formatHeadersForCurl($response->getHeaders()));
-            $headerList[] = '';
+            $headerList[] = "\r\n";
             foreach ($headerList as $header) {
                 call_user_func($curlOptions[CURLOPT_HEADERFUNCTION], $ch, $header);
             }

--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -91,14 +91,14 @@ class HttpUtil
      * Returns a list of headers from a key/value paired array.
      *
      * @param array $headers Headers as key/value pairs.
-     * @return array List of headers ['Content-Type: text/html', '...'].
+     * @return array List of headers ["Content-Type: text/html\r\n", '...'].
      */
     public static function formatHeadersForCurl(array $headers)
     {
         $curlHeaders = array();
 
         foreach ($headers as $key => $value) {
-            $curlHeaders[] = $key . ': ' . $value;
+            $curlHeaders[] = $key . ': ' . $value . "\r\n";
         }
 
         return $curlHeaders;
@@ -108,25 +108,30 @@ class HttpUtil
      * Returns a HTTP status line from specified response.
      *
      * @param Response $response
+     *
      * @return string HTTP status line.
      */
     public static function formatAsStatusString(Response $response)
     {
         return 'HTTP/' . $response->getHttpVersion()
-             . ' ' . $response->getStatusCode()
-             . ' ' . $response->getStatusMessage();
+            . ' ' . $response->getStatusCode()
+            . ' ' . $response->getStatusMessage()
+            . "\r\n";
     }
 
     /**
      * Returns a HTTP status line with headers from specified response.
      *
      * @param Response $response
+     *
      * @return string HTTP status line.
      */
     public static function formatAsStatusWithHeadersString(Response $response)
     {
         $headers = self::formatHeadersForCurl($response->getHeaders());
         array_unshift($headers, self::formatAsStatusString($response));
-        return join("\r\n", $headers) . "\r\n\r\n";
+
+        // Only one \r\n, as self::formatHeadersForCurl() returns an empty line as the last header already;
+        return join('', $headers) . "\r\n";
     }
 }

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -252,9 +252,9 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
         CurlHelper::handleOutput($response, $curlOptions, curl_init());
 
         $expected = array(
-            'HTTP/1.1 200 OK',
-            'Content-Length: 0',
-            ''
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n"
         );
         $this->assertEquals($expected, $actualHeaders);
     }


### PR DESCRIPTION
### Context

When returning the array of cURL raw headers, PHP-VCR returns them like this

```php
[
    "Content-Type: text/html; charset=UTF-8",
    "Content-Encoding: gzip",
]
```

However, cURL returns them more "raw", with the trailing `\r\n` mandatory at the end of every HTTP header line:

```php
[
    "Content-Type: text/html; charset=UTF-8\r\n",
    "Content-Encoding: gzip\r\n",
]
```

This PR changes the PHP-VCR behavior. This is necessary to HTTP clients, like Symfony HTTP Client that rely on those `\r\n` to [detect the end of the headers and the beginning of the request body, when parsing it.](https://github.com/symfony/http-client/blob/b42500787e4bbca335af4ed0fe377462fefc3733/Response/CurlResponse.php#L300) ([or just to extract it via `substr()`](https://github.com/symfony/http-client/blob/b42500787e4bbca335af4ed0fe377462fefc3733/Response/CurlResponse.php#L302))

### What has been done

`VCR/Util/HttpUtil:formatHeadersForCurl()` and `VCR/Util/HttpUtil:formatAsStatusString()` now returns a trailing `\r\n` to the HTTP status and HTTP header strings. 

This is the actual PHP cURL behavior. 

Note: **This could, however be a BC change** if someone was relying on not having those `\r\n`. However, it would then break in actual cURL requests, so I doubt that it is the case. 

### How to test

Unit tests were updated.


