### PR TITLE
BUGFIX: ErrorException in VCR/Storage/Yaml.php:61

### DIFF
--- a/src/VCR/Storage/Yaml.php
+++ b/src/VCR/Storage/Yaml.php
@@ -58,8 +58,10 @@ class Yaml extends AbstractStorage
     public function next()
     {
         $recording = $this->yamlParser->parse($this->readNextRecord());
-        $this->current = $recording[0];
-        ++$this->position;
+        if (!is_null($recording)) {
+            $this->current = $recording[0];
+            ++$this->position;
+        }
     }
 
     /**

--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -262,13 +262,17 @@ class StreamProcessor
     /**
      * Retrieve information about a file resource.
      *
+     * Do not return the stat since we don't know the resulting the size that the file will have
+     * after having all transformations applied. When including files, PHP 7.4 and newer are sensitive
+     * to file size reported by stat.
+     *
      * @link http://www.php.net/manual/en/streamwrapper.stream-stat.php
      *
      * @return array See stat().
      */
     public function stream_stat()
     {
-        return fstat($this->resource);
+        return array();
     }
 
     /**


### PR DESCRIPTION
### Context
if the fixture is recently created and it has no content, the parser returns `null` to `$recording`. And array-like access to `null` via `$recording[0]` will raise an exception. With this little check this behavior is fixed and also all tests will work properly.

### What has been done

- added a check if $response is null

### How to test

- write a simple vcr test and try to record a whole new fixture

### Todo

- merge into php-vcr/php-vcr:master and tag a new version

### Notes

- thanks to @morozov who fixed the streamfilter bug
- thanks to @danielbecker who helped debugging this issue
- see https://github.com/php-vcr/php-vcr/issues/289
