### PR TITLE
Implemented buffering in JSON storage for more efficient parsing

### DIFF
--- a/tests/VCR/RequestTest.php
+++ b/tests/VCR/RequestTest.php
@@ -219,9 +219,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testDoNotOverwriteHostHeader()
     {
         $this->request = new Request(
-          'GET',
-          'http://example.com',
-          array('User-Agent' => 'Unit-Test', 'Host' => 'www.example.com')
+            'GET',
+            'http://example.com',
+            array('User-Agent' => 'Unit-Test', 'Host' => 'www.example.com')
         );
 
         $this->assertEquals(

--- a/tests/VCR/Storage/JsonTest.php
+++ b/tests/VCR/Storage/JsonTest.php
@@ -76,6 +76,27 @@ class JsonTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testIterateStringWithCurlyBraces()
+    {
+        $this->iterateAndTest(
+            '[{"para": "}:->"}]',
+            array(
+                array('para' => '}:->'),
+            )
+        );
+    }
+
+    public function testIterateStringWithEscapedCharacters()
+    {
+        $this->iterateAndTest(
+            '[{"para1": "\""}, {"para2": "\\\\"}]',
+            array(
+                array('para1' => '"'),
+                array('para2' => '\\'),
+            )
+        );
+    }
+
     public function testStoreRecording()
     {
         $expected = array(
@@ -120,7 +141,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
         $this->assertJson(file_get_contents($filePath));
     }
 
-    private function iterateAndTest($json, $expected, $message)
+    private function iterateAndTest($json, $expected, $message = '')
     {
         file_put_contents($this->filePath, $json);
 


### PR DESCRIPTION
### Context

Fixes: #296
### What has been done

- Implemented read buffering to improve IO performance.
- Reimplemented parsing using regular expressions to improve parsing performance.
- Implemented detection of string literals in order to avoid parsing their bodies as the storage JSON.

### How to test

- See the existing and newly added tests.

### Todo

- [x] Provide performance testing results.
        ![callgraph](https://user-images.githubusercontent.com/59683/74494220-40a0fd80-4e89-11ea-9762-1744e938b978.png)

