### PR TITLE
Fix: Notice Trying to access array offset on value of type null when …

### DIFF
--- a/src/VCR/Storage/Yaml.php
+++ b/src/VCR/Storage/Yaml.php
@@ -58,8 +58,10 @@ class Yaml extends AbstractStorage
     public function next()
     {
         $recording = $this->yamlParser->parse($this->readNextRecord());
-        $this->current = $recording[0];
-        ++$this->position;
+        if (is_array($recording) && count($recording)) {
+          $this->current = $recording[0];
+          ++$this->position;
+        }
     }
 
     /**


### PR DESCRIPTION
…using PHP 7.4.

### Context
Ensure that variable is an array.  PHP 7.4 is less forgiving about this than earlier versions of PHP.  New fixtures can result in a `$recording` value of NULL.  When this happens PHP 7.4 emits a notice. The notice appears in the output of functions under test by Behat and cause failures. 

### What has been done
Add a conditional testing that $recording is an array with at least one element.

### How to test
Without this modification, create a new recording file (aka fixture) and attempt to play it back. Use PHP 7.4.

