### PR TITLE
Implemented stream_stat

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -274,6 +274,14 @@ class StreamProcessor
      */
     public function stream_stat()
     {
+        if (false === $this->resource) {
+            return false;
+        }
+
+        if (!$this->shouldProcess(stream_get_meta_data($this->resource)['uri'])) {
+            return fstat($this->resource);
+        }
+
         return false;
     }
 

--- a/tests/VCR/VCRTest.php
+++ b/tests/VCR/VCRTest.php
@@ -191,6 +191,16 @@ class VCRTest extends TestCase
         VCR::turnOff();
     }
 
+    public function testFinfoWorksCorrectly(): void
+    {
+        $fileinfo = new \finfo(FILEINFO_MIME_TYPE);
+
+        $this->assertEquals(
+            'text/plain',
+            $fileinfo->file(__DIR__.'/../../.gitignore')
+        );
+    }
+
     private function recordAllEvents()
     {
         $allEventsToListen = [


### PR DESCRIPTION
### Context
I was adding tests to a work project using the 1.5.0alpha0 release. The project uses `finfo` to find mime types of files that are to be uploaded to a REST API. Apparently, the `finfo` class uses `stat`, which in this case is routes through `stream_stat` of `StreamWrapper`, which so far had not been implemented.

### What has been done

- I implemented `StreamWrapper#stream_stat`