### PR TITLE
StreamProcessor stream_stat to only return false for filtered streams

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -54,6 +54,11 @@ class StreamProcessor
     protected $isIntercepting = false;
 
     /**
+     * @var bool True if any code transformer has been attached to the stream, false otherwise
+     */
+    protected $isTransforming = false;
+
+    /**
      *
      * @param Configuration $configuration
      */
@@ -272,7 +277,11 @@ class StreamProcessor
      */
     public function stream_stat()
     {
-        return false;
+        if ($this->isTransforming) {
+            return false;
+        }
+
+        return \fstat($this->resource);
     }
 
     /**
@@ -629,9 +638,13 @@ class StreamProcessor
      */
     protected function appendFiltersToStream($stream)
     {
+        if (\count(static::$codeTransformers) === 0) {
+            return;
+        }
         foreach (static::$codeTransformers as $codeTransformer) {
             stream_filter_append($stream, $codeTransformer::NAME, STREAM_FILTER_READ);
         }
+        $this->isTransforming = true;
     }
 
     /**

--- a/tests/VCR/Util/StreamProcessorTest.php
+++ b/tests/VCR/Util/StreamProcessorTest.php
@@ -205,10 +205,10 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function streamStatfailsOnlyWhenStreamIsTransformedProvider()
     {
-        return [
-            [false, StreamProcessor::STREAM_OPEN_FOR_INCLUDE, true],
-            [true, StreamProcessor::STREAM_OPEN_FOR_INCLUDE, false],
-        ];
+        return array(
+            array(false, StreamProcessor::STREAM_OPEN_FOR_INCLUDE, true),
+            array(true, StreamProcessor::STREAM_OPEN_FOR_INCLUDE, false),
+        );
     }
 
     protected function getStreamProcessorMock()


### PR DESCRIPTION
### Context
Using php-vcr alongside fpdi causes issues for us because of the way `StreamProcessor` alters result of `\stat` calls.

### What has been done
Currently `StreamProcessor::stream_stat` always returns false even for streams that are not actually being altered (no code transformations attached to the stream). This PR adds a check to only fail the `stream_stat` call if the stream is actually altered.

### How to test
Test has been added to the `StreamProcessorTest` suite.


