### PR TITLE
feat: Add Symfony HttpClient integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
       php: 7.2
     - env: TEST_DIR=tests/integration/soap
       php: 7.2
+    - env: TEST_DIR=tests/integration/symfony/5
+      php: 7.2
 
 before_install:
   - composer self-update
@@ -51,4 +53,5 @@ cache:
     - tests/integration/guzzle/5/vendor
     - tests/integration/guzzle/6/vendor
     - tests/integration/soap/vendor
+    - tests/integration/symfony/5/vendor
     - $HOME/.composer/cache

--- a/src/VCR/Response.php
+++ b/src/VCR/Response.php
@@ -109,15 +109,17 @@ class Response
     }
 
     /**
+     * @param mixed $default
+     *
      * @return array<string,mixed>|mixed|null
      */
-    public function getCurlInfo(?string $option = null)
+    public function getCurlInfo(?string $option = null, $default = null)
     {
         if (empty($option)) {
             return $this->curlInfo;
         }
         if (!isset($this->curlInfo[$option])) {
-            return null;
+            return $default;
         }
 
         return $this->curlInfo[$option];

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -58,7 +58,7 @@ class CurlHelper
         if (isset($curlOptions[CURLOPT_HEADERFUNCTION])) {
             $headerList = [HttpUtil::formatAsStatusString($response)];
             $headerList = array_merge($headerList, HttpUtil::formatHeadersForCurl($response->getHeaders()));
-            $headerList[] = '';
+            $headerList[] = "\r\n";
             foreach ($headerList as $header) {
                 self::callFunction($curlOptions[CURLOPT_HEADERFUNCTION], $ch, $header);
             }

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -37,6 +37,7 @@ class CurlHelper
         CURLINFO_CONTENT_LENGTH_UPLOAD => 'upload_content_length',
         CURLINFO_CONTENT_TYPE => 'content_type',
         CURLINFO_PRIVATE => 'private',
+        CURLINFO_CERTINFO => 'certinfo',
     ];
 
     /**
@@ -116,6 +117,9 @@ class CurlHelper
                 $info = '';
             case CURLINFO_PRIVATE:
                 $info = $response->getCurlInfo(self::$curlInfoList[$option], false);
+                break;
+            case CURLINFO_CERTINFO:
+                $info = $response->getCurlInfo(self::$curlInfoList[$option], []);
                 break;
             default:
                 $info = $response->getCurlInfo(self::$curlInfoList[$option]);

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -36,6 +36,7 @@ class CurlHelper
         CURLINFO_CONTENT_LENGTH_DOWNLOAD => 'download_content_length',
         CURLINFO_CONTENT_LENGTH_UPLOAD => 'upload_content_length',
         CURLINFO_CONTENT_TYPE => 'content_type',
+        CURLINFO_PRIVATE => 'private',
     ];
 
     /**
@@ -98,7 +99,7 @@ class CurlHelper
         switch ($option) {
             case 0: // 0 == array of all curl options
                 $info = [];
-                foreach (self::$curlInfoList as $option => $key) {
+                foreach (self::$curlInfoList as $curlOption => $key) {
                     $info[$key] = $response->getCurlInfo($key);
                 }
                 break;
@@ -113,6 +114,8 @@ class CurlHelper
                 break;
             case CURLPROXY_HTTPS:
                 $info = '';
+            case CURLINFO_PRIVATE:
+                $info = $response->getCurlInfo(self::$curlInfoList[$option], false);
                 break;
             default:
                 $info = $response->getCurlInfo(self::$curlInfoList[$option]);

--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -92,7 +92,7 @@ class HttpUtil
      *
      * @param array<string,string|array<string,string>> $headers Headers as key/value pairs
      *
-     * @return string[] List of headers ['Content-Type: text/html', '...'].
+     * @return string[] List of headers ["Content-Type: text/html\r\n", '...'].
      */
     public static function formatHeadersForCurl(array $headers): array
     {
@@ -101,10 +101,10 @@ class HttpUtil
         foreach ($headers as $key => $values) {
             if (\is_array($values)) {
                 foreach ($values as $value) {
-                    $curlHeaders[] = $key.': '.$value;
+                    $curlHeaders[] = $key.': '.$value."\r\n";
                 }
             } else {
-                $curlHeaders[] = $key.': '.$values;
+                $curlHeaders[] = $key.': '.$values."\r\n";
             }
         }
 
@@ -120,7 +120,8 @@ class HttpUtil
     {
         return 'HTTP/'.$response->getHttpVersion()
              .' '.$response->getStatusCode()
-             .' '.$response->getStatusMessage();
+             .' '.$response->getStatusMessage()
+             ."\r\n";
     }
 
     /**
@@ -133,6 +134,7 @@ class HttpUtil
         $headers = self::formatHeadersForCurl($response->getHeaders());
         array_unshift($headers, self::formatAsStatusString($response));
 
-        return implode("\r\n", $headers)."\r\n\r\n";
+        // Only one \r\n, as self::formatHeadersForCurl() returns an empty line as the last header already;
+        return implode('', $headers)."\r\n";
     }
 }

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -217,7 +217,7 @@ class CurlHookTest extends TestCase
         curl_close($curlHandle);
 
         $this->assertInternalType('array', $info, 'curl_getinfo() should return an array.');
-        $this->assertCount(22, $info, 'curl_getinfo() should return 22 values.');
+        $this->assertCount(23, $info, 'curl_getinfo() should return 23 values.');
         $this->curlHook->disable();
     }
 

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -390,6 +390,24 @@ class CurlHelperTest extends TestCase
         $this->assertEquals($expectedBody, file_get_contents($testFile));
     }
 
+    public function testGetCurlOptionFromResponseHandleCertinfo()
+    {
+        $status = [
+            'code' => 200,
+            'message' => 'OK',
+            'http_version' => '1.1',
+        ];
+        $headers = [
+            'Content-Length' => 0,
+        ];
+        $response = new Response($status, $headers, 'example response');
+
+        $this->assertEquals(
+            [],
+            CurlHelper::getCurlOptionFromResponse($response, CURLINFO_CERTINFO)
+        );
+    }
+
     /**
      * @dataProvider getCurlOptionProvider()
      *

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -260,9 +260,9 @@ class CurlHelperTest extends TestCase
         CurlHelper::handleOutput($response, $curlOptions, curl_init());
 
         $expected = [
-            'HTTP/1.1 200 OK',
-            'Content-Length: 0',
-            '',
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
         ];
         $this->assertEquals($expected, $actualHeaders);
     }

--- a/tests/integration/symfony/5/ExampleHttpClient.php
+++ b/tests/integration/symfony/5/ExampleHttpClient.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace VCR\Example;
+
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class ExampleHttpClient
+{
+    /**
+     * @var HttpClientInterface
+     */
+    private $client;
+
+    public function __construct()
+    {
+        $this->client = HttpClient::create(['http_version' => '1.1']);
+    }
+
+    public function get($url)
+    {
+        try {
+            $response = $this->client->request('GET', $url);
+
+            return json_decode($response->getContent(), true);
+        } catch (ClientExceptionInterface $e) {
+            if (404 !== $e->getResponse()->getStatusCode()) {
+                throw $e;
+            }
+        }
+
+        return null;
+    }
+
+    public function post($url, $body)
+    {
+        try {
+            $response = $this->client->request('POST', $url, ['body' => $body]);
+
+            return json_decode($response->getContent(), true);
+        } catch (ClientExceptionInterface $e) {
+            if (404 !== $e->getResponse()->getStatusCode()) {
+                throw $e;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/integration/symfony/5/composer.json
+++ b/tests/integration/symfony/5/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "symfony/http-client": "~5.0"
+    }
+}

--- a/tests/integration/symfony/5/phpunit.xml
+++ b/tests/integration/symfony/5/phpunit.xml
@@ -1,0 +1,15 @@
+<phpunit bootstrap="../test/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+>
+
+    <testsuites>
+        <testsuite name="Symfony 5 test suite">
+            <directory>../test</directory>
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/tests/integration/symfony/5/test/ErrorTest.php
+++ b/tests/integration/symfony/5/test/ErrorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace VCR\Example;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * Tests behaviour when an error occurs.
+ */
+class ErrorTest extends TestCase
+{
+    const TEST_GET_URL = 'http://localhost:9959';
+
+    public function setUp()
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    public function testConnectException()
+    {
+        $nonInstrumentedException = null;
+        try {
+            $client = HttpClient::create();
+            $response = $client->request('GET', self::TEST_GET_URL);
+            $response->getHeaders();
+        } catch (TransportExceptionInterface $e) {
+            $nonInstrumentedException = $e;
+        }
+        self::assertNotNull($nonInstrumentedException);
+        $catched = false;
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+        try {
+            $client = HttpClient::create();
+            $response = $client->request('GET', self::TEST_GET_URL);
+            $response->getHeaders();
+        } catch (TransportExceptionInterface $e) {
+            $catched = true;
+            self::assertEquals($e->getMessage(), $nonInstrumentedException->getMessage());
+        }
+        self::assertTrue($catched);
+        \VCR\VCR::turnOff();
+    }
+
+    protected function assertValidGETResponse($info)
+    {
+    }
+}

--- a/tests/integration/symfony/Readme.md
+++ b/tests/integration/symfony/Readme.md
@@ -1,0 +1,7 @@
+Integration tests for Symfony HttpClient
+========================================
+
+There is a folder for each major Symfony HttpClient version which includes a composer file and an example implementation
+of the `ExampleHttpClient` class.
+
+The tests in the `./test/` folder are run for each Symfony HttpClient version.

--- a/tests/integration/symfony/test/VCR/Example/ExampleHttpClientTest.php
+++ b/tests/integration/symfony/test/VCR/Example/ExampleHttpClientTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace VCR\Example;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests example request.
+ */
+class ExampleHttpClientTest extends TestCase
+{
+    const TEST_GET_URL = 'https://api.chew.pro/trbmb';
+    const TEST_POST_URL = 'https://httpbin.org/post';
+    const TEST_POST_BODY = '{"foo":"bar"}';
+
+    protected $ignoreHeaders = [
+        'Accept',
+        'Connect-Time',
+        'Total-Route-Time',
+        'X-Request-Id',
+    ];
+
+    public function setUp()
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    public function testRequestGET()
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+        $originalRequest = $this->requestGET();
+        $this->assertValidGETResponse($originalRequest);
+        $interceptedRequest = $this->requestGET();
+        $this->assertValidGETResponse($interceptedRequest);
+        self::assertEquals($originalRequest, $interceptedRequest);
+        $repeatInterceptedRequest = $this->requestGET();
+        self::assertEquals($interceptedRequest, $repeatInterceptedRequest);
+        \VCR\VCR::turnOff();
+    }
+
+    public function testRequestPOST()
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+        $originalRequest = $this->requestPOST();
+        $this->assertValidPOSTResponse($originalRequest);
+        $interceptedRequest = $this->requestPOST();
+        $this->assertValidPOSTResponse($interceptedRequest);
+        self::assertEquals($originalRequest, $interceptedRequest);
+        $repeatInterceptedRequest = $this->requestPOST();
+        self::assertEquals($interceptedRequest, $repeatInterceptedRequest);
+        \VCR\VCR::turnOff();
+    }
+
+    protected function requestGET()
+    {
+        $exampleClient = new ExampleHttpClient();
+
+        $response = $exampleClient->get(self::TEST_GET_URL);
+
+        return $response;
+    }
+
+    protected function requestPOST()
+    {
+        $exampleClient = new ExampleHttpClient();
+
+        $response = $exampleClient->post(self::TEST_POST_URL, self::TEST_POST_BODY);
+        foreach ($this->ignoreHeaders as $header) {
+            unset($response['headers'][$header]);
+        }
+        unset($response['origin']);
+
+        return $response;
+    }
+
+    protected function requestPOSTIntercepted()
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+        $info = $this->requestPOST();
+        \VCR\VCR::turnOff();
+
+        return $info;
+    }
+
+    protected function assertValidGETResponse($info)
+    {
+        self::assertIsArray($info, 'Response is not an array.');
+        self::assertArrayHasKey('0', $info, 'API did not return any value.');
+    }
+
+    protected function assertValidPOSTResponse($info)
+    {
+        self::assertIsArray($info, 'Response is not an array.');
+        self::assertArrayHasKey('url', $info, "Key 'url' not found.");
+        self::assertEquals(self::TEST_POST_URL, $info['url'], "Value for key 'url' wrong.");
+        self::assertArrayHasKey('headers', $info, "Key 'headers' not found.");
+        self::assertIsArray($info['headers'], 'Headers is not an array.');
+        self::assertEquals(self::TEST_POST_BODY, $info['data'], 'Correct request body was not sent.');
+    }
+}

--- a/tests/integration/symfony/test/bootstrap.php
+++ b/tests/integration/symfony/test/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once __DIR__.'/../../../../vendor/autoload.php';
+$loader = require_once 'vendor/autoload.php';
+
+/*
+ * @var \Composer\Autoload\ClassLoader
+ */
+$loader->addClassMap([
+    'VCR\\Example\\ExampleHttpClient' => 'ExampleHttpClient.php',
+]);
+
+\VCR\VCR::turnOn();
+\VCR\VCR::turnOff();


### PR DESCRIPTION
### Context
php-vcr does not seems to work with Symfony HttpClient (#329). Here is the error:  
`RuntimeException: Unexpected error, could not find curl_getinfo in response or errors`

### What has been done

- Integration tests from guzzle have been duplicated for symfony/http-client in order to fix the issue

### How to test

- 

### Todo

- [ ] Find what is the issue and fix it
