### PR TITLE
fix: phpstan ignore error failure on PHP >= 7.2

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,7 @@ parameters:
             message: '#Unreachable statement - code above always terminates.#'
             path: src/VCR/CodeTransform/AbstractCodeTransform.php
         # PHPStan cannot detect that strrpos will succeed (because of Assertion above) in HttpUtil::parseStatus
-        - '#Parameter .* \$str of function substr expects string, string\|false given.#'
+        - '#Parameter .* \$str(ing)? of function substr expects string, string\|false given.#'
         # The EventDispatcherInterface::dispatch signature is different (!) between Symfony <4.3 and >=4.3
         - '/Parameter #1 \$event of method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) expects object, string\|null given./'
         - '/Parameter #2 \$eventName of method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) expects string\|null, VCR\\Event\\Event given./'

--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -82,6 +82,8 @@ class StreamProcessor
      */
     public function restore(): void
     {
+        // stream_wrapper_restore can throw when stream_wrapper was never changed, so we unregister first
+        stream_wrapper_unregister(self::PROTOCOL);
         stream_wrapper_restore(self::PROTOCOL);
     }
 


### PR DESCRIPTION
### Context

phpstan is failing on master branch because of $str substr argument renamed to $string in php 7.2+

### What has been done

- phpstan ignore error regex updated to handle both cases
