### PR TITLE
Support for ssl requests in some edge cases like paypal php sdk

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,8 @@ parameters:
     level: 7
     paths:
         - src
+    # Can remove reportUnmatchedIgnoredErrors option after php 7.2 is no longer supported
+    reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         # This part of PHP is not very well documented, resulting PHPStan's definitions not being accurate
         - "#Access to an undefined property object::\\$data\\.#"
@@ -14,6 +16,8 @@ parameters:
         # The EventDispatcherInterface::dispatch signature is different (!) between Symfony <4.3 and >=4.3
         - '/Parameter #1 \$event of method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) expects object, string\|null given./'
         - '/Parameter #2 \$eventName of method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) expects string\|null, VCR\\Event\\Event given./'
+        # PHPStan cannot deal with manually defined constants - can be removed once php 7.2 no longer supported
+        - '#Constant CURLPROXY_HTTPS not found.#'
 includes:
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
     - vendor/phpstan/phpstan-beberlei-assert/extension.neon

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -111,6 +111,9 @@ class CurlHelper
             case CURLINFO_HEADER_SIZE:
                 $info = mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
                 break;
+            case CURLPROXY_HTTPS:
+                $info = '';
+                break;
             default:
                 $info = $response->getCurlInfo(self::$curlInfoList[$option]);
                 break;

--- a/src/VCR/VCRFactory.php
+++ b/src/VCR/VCRFactory.php
@@ -32,6 +32,10 @@ class VCRFactory
     protected function __construct(Configuration $config = null)
     {
         $this->config = $config ?: $this->getOrCreate('VCR\Configuration');
+
+        // This constant exists only from PHP 7.3
+        // Once we are no longer supporting 7.2, we can remove this
+        defined('CURLPROXY_HTTPS') or define('CURLPROXY_HTTPS', 2);
     }
 
     protected function createVCRVideorecorder(): Videorecorder

--- a/src/VCR/VCRFactory.php
+++ b/src/VCR/VCRFactory.php
@@ -35,7 +35,7 @@ class VCRFactory
 
         // This constant exists only from PHP 7.3
         // Once we are no longer supporting 7.2, we can remove this
-        defined('CURLPROXY_HTTPS') or define('CURLPROXY_HTTPS', 2);
+        \defined('CURLPROXY_HTTPS') or \define('CURLPROXY_HTTPS', 2);
     }
 
     protected function createVCRVideorecorder(): Videorecorder


### PR DESCRIPTION
### Context
When using SSL requests, for example with paypal php sdk, it fails to go through vcr properly

### What has been done
Added this one option to getCurlOptionFromResponse

### How to test
Not exactly sure, but for example the issue for us happens in PayPal\Api\Sale::refundSale()

### Notes
Added a define for pre - php 7.3, for the curl constant
