### PR TITLE
Support curl_multi_getcontent

### DIFF
--- a/src/VCR/CodeTransform/CurlCodeTransform.php
+++ b/src/VCR/CodeTransform/CurlCodeTransform.php
@@ -21,6 +21,7 @@ class CurlCodeTransform extends AbstractCodeTransform
         '/(?<!::|->|\w_)\\\?curl_multi_remove_handle\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_multi_remove_handle(',
         '/(?<!::|->|\w_)\\\?curl_multi_exec\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_multi_exec(',
         '/(?<!::|->|\w_)\\\?curl_multi_info_read\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_multi_info_read(',
+        '/(?<!::|->|\w_)\\\?curl_multi_getcontent\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_multi_getcontent(',
         '/(?<!::|->|\w_)\\\?curl_reset\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_reset(',
         '/(?<!::|->|\w_)\\\?curl_error\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_error(',
         '/(?<!::|->|\w_)\\\?curl_errno\s*\(/i' => '\VCR\LibraryHooks\CurlHook::curl_errno(',

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -37,7 +37,7 @@ class CurlHook implements LibraryHook
     protected static $responses = [];
 
     /**
-     * @var array<int,mixed> additinal curl options, which are not stored within a request
+     * @var array<int,mixed> additional curl options, which are not stored within a request
      */
     protected static $curlOptions = [];
 
@@ -50,6 +50,11 @@ class CurlHook implements LibraryHook
      * @var array<int, array> last active curl_multi_exec() handles
      */
     protected static $multiExecLastChs = [];
+
+    /**
+     * @var array<int, string|null> return values of curl_multi responses
+     */
+    protected static $multiReturnValues = [];
 
     /**
      * @var CurlException[] last cURL error, as a CurlException
@@ -276,7 +281,7 @@ class CurlHook implements LibraryHook
             foreach (self::$multiHandles[(int) $multiHandle] as $curlHandle) {
                 if (!isset(self::$responses[(int) $curlHandle])) {
                     self::$multiExecLastChs[] = $curlHandle;
-                    self::curlExec($curlHandle);
+                    self::$multiReturnValues[(int) $curlHandle] = self::curlExec($curlHandle);
                 }
             }
         }
@@ -304,6 +309,20 @@ class CurlHook implements LibraryHook
         }
 
         return false;
+    }
+
+    /**
+     * Return the content of a cURL handle if CURLOPT_RETURNTRANSFER is set.
+     *
+     * @see https://www.php.net/manual/en/function.curl-multi-getcontent.php
+     *
+     * @param resource $curlHandle
+     *
+     * @return string|null return the content of a cURL handle if CURLOPT_RETURNTRANSFER is set
+     */
+    public static function curlMultiGetcontent($curlHandle): ?string
+    {
+        return self::$multiReturnValues[(int) $curlHandle] ?? null;
     }
 
     /**


### PR DESCRIPTION
### Context
Closes #338

### What has been done

- This adds support for `curl_multi_getcontent` by saving the return values of `curl_exec` if called from `curl_multi_exec`.
