### PR TITLE
add redactions to VCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Disclaimer: Doing this in PHP is not as easy as in programming languages which s
   implement a custom request matcher to handle any need.
 * The recorded requests and responses are stored on disk in a serialization format of your choice
   (currently YAML and JSON are built in, and you can easily implement your own custom serializer)
+* Private data can be redacted from storage using `addRedaction()`
 * Supports PHPUnit annotations.
 
 ## Usage example

--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -84,10 +84,10 @@ class Configuration
      *
      * Format:
      * array(
-     *  '<REPLACEMENT>' => Closure(VCR\Request $request, VCR\Response $response): ?string
+     *  '<REPLACEMENT>' => callable(VCR\Request $request, VCR\Response $response): ?string
      * )
      *
-     * @var array<string, Closure>
+     * @var array<string, callable>
      */
     private $redactions;
 
@@ -384,7 +384,7 @@ class Configuration
     /**
      * Gets the defined redactions.
      *
-     * @return array<string, string|callable>
+     * @return array<string, callable>
      */
     public function getRedactions(): array
     {
@@ -394,21 +394,19 @@ class Configuration
     /**
      * Adds a redaction.
      *
-     * @param string          $replacement  the string that replaces the private value in storage
-     * @param string|callable $value Either the secret to replace, or a callback which returns the secret
+     * @param string          $replacement The string that replaces the private value in storage
+     * @param string|callable $secret      Either the secret to replace, or a callback which returns the secret
      */
     public function addRedaction(string $replacement, $secret): self
     {
-        if (\is_string($secret) && $replacement != "") {
-            $func = function($request, $response) use ($secret) {
+        if (\is_string($secret) && '' != $replacement) {
+            $func = function ($request, $response) use ($secret) {
                 return $secret;
             };
         } elseif (\is_callable($secret)) {
             $func = $secret;
         } else {
-            throw new \InvalidArgumentException(
-                "Redaction replacement string must be a non-empty string or callable."
-            );
+            throw new \InvalidArgumentException('Redaction replacement string must be a non-empty string or callable.');
         }
 
         $this->redactions[$replacement] = $func;

--- a/src/VCR/Storage/Storage.php
+++ b/src/VCR/Storage/Storage.php
@@ -15,7 +15,7 @@ interface Storage extends \Iterator
     /**
      * Stores an array of data.
      *
-     * @param array<string,string|null|array<string,mixed>> $recording array to store in storage
+     * @param array<string,string|array<string,mixed>|null> $recording array to store in storage
      */
     public function storeRecording(array $recording): void;
 

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -111,7 +111,7 @@ class CurlHelper
             case \CURLINFO_HEADER_SIZE:
                 $info = mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
                 break;
-            case CURLPROXY_HTTPS:
+            case \CURLPROXY_HTTPS:
                 $info = '';
                 break;
             default:

--- a/src/VCR/Util/Scrubber.php
+++ b/src/VCR/Util/Scrubber.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace VCR\Util;
+
+use VCR\Configuration;
+use VCR\Request;
+use VCR\Response;
+
+class Scrubber
+{
+
+    /**
+     * VCR configuration.
+     *
+     * @var Configuration
+     */
+    protected $config;
+
+    /**
+     * Create a new Scrubber.
+     *
+     * @param Configuration $config configuration to use for this scrubber
+     */
+    public function __construct(Configuration $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Scrub the given request/response of all secrets, using the configured redactions.
+     *
+     * @param Request  $request  request to scrub
+     * @param Response $response response to scrub
+     * @return array   The scrubbed recording, ie. an array with request and response keys
+     */
+    public function scrub(Request $request, Response $response)
+    {
+        $redactions = $this->evaluateRedactions($request, $response);
+        $recording = $this->buildRecording($request, $response);
+
+        return $this->scrubArray($recording, $redactions);
+    }
+
+    /**
+     * Unmask the redacted parts of a recording, using the configured redactions.
+     *
+     * @param array  $recording  The recording, ie. an array with 'request' and 'response' keys
+     * @return array The unscrubbed recording
+     */
+    public function unscrub($recording)
+    {
+        $request = Request::fromArray($recording['request']);
+        $response = Response::fromArray($recording['response']);
+
+        $unmaskings = array_flip($this->evaluateRedactions($request, $response));
+
+        return $this->scrubArray($recording, $unmaskings);
+    }
+
+    /**
+     * Evaluate the configured redactions in the context of the request/response pair.
+     *
+     * @param Request  $request      The request
+     * @param Response $response     The response
+     * @return array<string, string> An array of token => replacement pairs
+     */
+    private function evaluateRedactions($request, $response)
+    {
+        $replacements = [];
+
+        foreach ($this->config->getRedactions() as $replacement => $callback) {
+            $privateData = $callback($request, $response);
+            if ($privateData) {
+                if (!\is_string($privateData)) {
+                    throw new \InvalidArgumentException("Redaction callback for $replacement did not return a string");
+                }
+                $replacements[$replacement] = $privateData;
+            }
+        }
+
+        return $replacements;
+    }
+
+    /**
+     * Builds a recording in standard VCR format.
+     *
+     * @param Request  $request  The request
+     * @param Response $response The response
+     * @return array   The recording, ie. an array with request and response keys
+     */
+    private function buildRecording(Request $request, Response $response)
+    {
+        return [
+            'request' => $request->toArray(),
+            'response' => $response->toArray()
+        ];
+    }
+
+    /**
+     * Walk an array recursively, replacing substrings on each key.
+     *
+     * @param  array                $arr          The array to traverse
+     * @param  array<string,string> $replacements Replacements in search=>replacement pairs
+     * @return array                The resulting array with all replacements performed
+     */
+    private function scrubArray(array &$arr, $replacements)
+    {
+        $search = array_values($replacements);
+        $replace = array_keys($replacements);
+
+        foreach ($arr as $key => $value) {
+            if (\is_string($value)) {
+                $arr[$key] = str_replace($search, $replace, $value);
+            } elseif (\is_array($value)) {
+                $arr[$key] = $this->scrubArray($value, $replacements);
+            }
+        }
+
+        return $arr;
+    }
+}

--- a/src/VCR/Util/Scrubber.php
+++ b/src/VCR/Util/Scrubber.php
@@ -8,7 +8,6 @@ use VCR\Response;
 
 class Scrubber
 {
-
     /**
      * VCR configuration.
      *
@@ -31,7 +30,8 @@ class Scrubber
      *
      * @param Request  $request  request to scrub
      * @param Response $response response to scrub
-     * @return array   The scrubbed recording, ie. an array with request and response keys
+     *
+     * @return array<string,mixed> The scrubbed recording
      */
     public function scrub(Request $request, Response $response)
     {
@@ -44,8 +44,9 @@ class Scrubber
     /**
      * Unmask the redacted parts of a recording, using the configured redactions.
      *
-     * @param array  $recording  The recording, ie. an array with 'request' and 'response' keys
-     * @return array The unscrubbed recording
+     * @param array<string,mixed> $recording The recording, ie. an array with 'request' and 'response' keys
+     *
+     * @return array<string,mixed> The unscrubbed recording
      */
     public function unscrub($recording)
     {
@@ -60,8 +61,9 @@ class Scrubber
     /**
      * Evaluate the configured redactions in the context of the request/response pair.
      *
-     * @param Request  $request      The request
-     * @param Response $response     The response
+     * @param Request  $request  The request
+     * @param Response $response The response
+     *
      * @return array<string, string> An array of token => replacement pairs
      */
     private function evaluateRedactions($request, $response)
@@ -86,22 +88,24 @@ class Scrubber
      *
      * @param Request  $request  The request
      * @param Response $response The response
-     * @return array   The recording, ie. an array with request and response keys
+     *
+     * @return array<string,mixed> The recording, ie. an array with request and response keys
      */
     private function buildRecording(Request $request, Response $response)
     {
         return [
             'request' => $request->toArray(),
-            'response' => $response->toArray()
+            'response' => $response->toArray(),
         ];
     }
 
     /**
      * Walk an array recursively, replacing substrings on each key.
      *
-     * @param  array                $arr          The array to traverse
-     * @param  array<string,string> $replacements Replacements in search=>replacement pairs
-     * @return array                The resulting array with all replacements performed
+     * @param array<string,mixed>  $arr          The array to traverse
+     * @param array<string,string> $replacements Replacements in search=>replacement pairs
+     *
+     * @return array<string,mixed> The resulting array with all replacements performed
      */
     private function scrubArray(array &$arr, $replacements)
     {

--- a/tests/VCR/ConfigurationTest.php
+++ b/tests/VCR/ConfigurationTest.php
@@ -163,4 +163,35 @@ class ConfigurationTest extends TestCase
         $this->expectExceptionMessage("Mode 'invalid' does not exist.");
         $this->config->setMode('invalid');
     }
+
+    public function testAddRedactionFailsWithNoToken(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Redaction replacement string must be a non-empty string or callable.");
+        $this->config->addRedaction('', 'secret123');
+    }
+
+    public function testAddRedactionWithString(): void
+    {
+        $this->config->addRedaction('<PASSWORD>', 'secret123');
+        $filters = $this->config->getRedactions();
+        $this->assertCount(1, $filters);
+        $this->assertArrayHasKey('<PASSWORD>', $filters);
+        $this->assertIsCallable($filters['<PASSWORD>']);
+
+        $request = new \VCR\Request('GET', 'http://example.com');
+        $response = new \VCR\Response(200, [], 'body');
+        $this->assertEquals('secret123', $filters['<PASSWORD>']($request, $response));
+    }
+
+    public function testAddRedactionWithCallable(): void
+    {
+        $expected = function ($request, $response) {
+            return 'secret123';
+        };
+
+        $this->config->addRedaction('<PASSWORD>', $expected);
+        $filters = $this->config->getRedactions();
+        $this->assertEquals($expected, $filters['<PASSWORD>']);
+    }
 }

--- a/tests/VCR/ConfigurationTest.php
+++ b/tests/VCR/ConfigurationTest.php
@@ -167,7 +167,7 @@ class ConfigurationTest extends TestCase
     public function testAddRedactionFailsWithNoToken(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage("Redaction replacement string must be a non-empty string or callable.");
+        $this->expectExceptionMessage('Redaction replacement string must be a non-empty string or callable.');
         $this->config->addRedaction('', 'secret123');
     }
 
@@ -180,7 +180,9 @@ class ConfigurationTest extends TestCase
         $this->assertIsCallable($filters['<PASSWORD>']);
 
         $request = new \VCR\Request('GET', 'http://example.com');
-        $response = new \VCR\Response(200, [], 'body');
+        $response = new \VCR\Response('200', [], 'body');
+
+        /* @phpstan-ignore-next-line */
         $this->assertEquals('secret123', $filters['<PASSWORD>']($request, $response));
     }
 

--- a/tests/VCR/ScrubbingTest.php
+++ b/tests/VCR/ScrubbingTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace VCR;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Cassette;
+use VCR\Configuration;
+use VCR\Request;
+use VCR\Storage\Blackhole;
+
+/**
+ * Test private data scrubbing and replacement.
+ */
+class ScrubbingTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->request = new Request('GET', 'http://example.com?secret=query_secret', [
+            'X-Req-Header: secret;request_header_secret'
+        ]);
+        $this->request->setBody('This is a request_body_secret');
+        $this->request->setPostFields([
+            'password' => 'post_field_secret'
+        ]);
+        $this->response = new Response(200, [
+            'X-Resp-Header: secret;response_header_secret'
+        ], 'This is a response_body_secret');
+        $this->storage = new class() extends Blackhole {
+            public $recording;
+
+            public function storeRecording(array $recording): void
+            {
+                $this->recording = $recording;
+            }
+        };
+    }
+
+    public function testItStillReturnsRecording(): void
+    {
+        $config = new Configuration();
+        $config->addRedaction('<SECRET1>', 'response_body_secret');
+        $cassette = new Cassette('test', $config, $this->storage);
+        $cassette->record($this->request, $this->response);
+
+        $this->assertArrayHasKey('request', $this->storage->recording);
+        $this->assertArrayHasKey('response', $this->storage->recording);
+    }
+
+    public function testItScrubsInRequest(): void
+    {
+        $config = new Configuration();
+        $config->addRedaction('<REQ_QUERY_SECRET>', 'query_secret')
+            ->addRedaction('<REQ_HEADER_SECRET>', 'request_header_secret')
+            ->addRedaction('<REQ_BODY_SECRET>', 'request_body_secret')
+            ->addRedaction('<REQ_FIELD_SECRET>', 'post_field_secret');
+
+        $cassette = new Cassette('test', $config, $this->storage);
+        $cassette->record($this->request, $this->response);
+        $requestPart = $this->storage->recording['request'];
+
+        $this->assertEquals('http://example.com?secret=<REQ_QUERY_SECRET>', $requestPart['url']);
+        $this->assertContains('X-Req-Header: secret;<REQ_HEADER_SECRET>', $requestPart['headers']);
+        $this->assertEquals('This is a <REQ_BODY_SECRET>', $requestPart['body']);
+        $this->assertEquals('<REQ_FIELD_SECRET>', $requestPart['post_fields']['password']);
+    }
+
+    public function testItReplacesMultipleInOneField()
+    {
+        $config = new Configuration();
+        $config->addRedaction('<SECRET1>', 'password is passw0rd')
+            ->addRedaction('<SECRET2>', 'pin is 1234');
+        $this->request->setBody('Your password is passw0rd and your pin is 1234.');
+
+        $cassette = new Cassette('test', $config, $this->storage);
+        $cassette->record($this->request, $this->response);
+        $requestPart = $this->storage->recording['request'];
+        $this->assertEquals('Your <SECRET1> and your <SECRET2>.', $requestPart['body']);
+    }
+
+    public function testScrubsInResponse(): void
+    {
+        $config = new Configuration();
+        $config->addRedaction('<RESP_BODY_SECRET>', 'response_body_secret')
+            ->addRedaction('<RESP_HEADER_SECRET>', 'response_header_secret');
+        $cassette = new Cassette('test', $config, $this->storage);
+        $cassette->record($this->request, $this->response);
+        $responsePart = $this->storage->recording['response'];
+
+        $this->assertContains('X-Resp-Header: secret;<RESP_HEADER_SECRET>', $responsePart['headers']);
+        $this->assertEquals('This is a <RESP_BODY_SECRET>', $responsePart['body']);
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testDynamicFilterReturningFalseyWorks()
+    {
+        $config = new Configuration();
+        $config->addRedaction('<DYNAMIC_SECRET>', function (Request $request, Response $response) {
+            return null;
+        });
+        $cassette = new Cassette('test', $config, $this->storage);
+        $cassette->record($this->request, $this->response);
+    }
+
+    public function testDynamicFilterReturningTruthyIsScrubbed()
+    {
+        $config = new Configuration();
+        $config->addRedaction('<DYNAMIC_SECRET>', function (Request $request, Response $response) {
+            return 'This is a response_body_secret';
+        });
+        $cassette = new Cassette('test', $config, $this->storage);
+        $cassette->record($this->request, $this->response);
+        $responsePart = $this->storage->recording['response'];
+
+        $this->assertEquals('<DYNAMIC_SECRET>', $responsePart['body']);
+    }
+
+    public function testWorksWithNoMatchingFilters()
+    {
+        $config = new Configuration();
+        $config->enableRequestMatchers(['url']);
+        $cassette = new Cassette('scrubbing_test', $config, new Storage\Yaml('tests/fixtures', 'scrubbing_test'));
+
+        $response = $cassette->playback($this->request);
+
+        $this->assertEquals('This is a scrubbed test dummy.', $response->getBody());
+        $this->assertEquals('"359670651"', $response->getHeader('Etag'));
+    }
+
+    public function testUnscrubsResponseFields()
+    {
+        $config = new Configuration();
+        $config->enableRequestMatchers(['url'])
+            ->addRedaction('359670651', 'RESP_HEADER_SECRET')
+            ->addRedaction('scrubbed test dummy', 'RESP_BODY_SECRET');
+        $cassette = new Cassette('scrubbing_test', $config, new Storage\Yaml('tests/fixtures', 'scrubbing_test'));
+
+        $response = $cassette->playback($this->request);
+
+        $this->assertEquals('This is a RESP_BODY_SECRET.', $response->getBody());
+        $this->assertEquals('"RESP_HEADER_SECRET"', $response->getHeader('Etag'));
+    }
+
+    public function testMatchesRequestsAfterUnscrubbing()
+    {
+        $config = new Configuration();
+        $config->enableRequestMatchers(['url'])
+            ->addRedaction('query_secret', 'secret123')
+            ->addRedaction('scrubbed test dummy', 'RESP_BODY_SECRET');
+        $cassette = new Cassette('scrubbing_test', $config, new Storage\Yaml('tests/fixtures', 'scrubbing_test'));
+
+        $this->request->setUrl('http://example.com?secret=secret123');
+        $response = $cassette->playback($this->request);
+
+        $this->assertNotNull($response);
+        $this->assertEquals('This is a RESP_BODY_SECRET.', $response->getBody());
+    }
+}

--- a/tests/VCR/ScrubbingTest.php
+++ b/tests/VCR/ScrubbingTest.php
@@ -74,7 +74,7 @@ class ScrubbingTest extends TestCase
         $requestPart = $this->storedRecording()['request'];
 
         $this->assertEquals('http://example.com?secret=<REQ_QUERY_SECRET>', $requestPart['url']);
-        $this->assertContains('X-Req-Header: secret;<REQ_HEADER_SECRET>', $requestPart['headers']);
+        $this->assertEquals('secret;<REQ_HEADER_SECRET>', $requestPart['headers']['X-Req-Header']);
         $this->assertEquals('This is a <REQ_BODY_SECRET>', $requestPart['body']);
         $this->assertEquals('<REQ_FIELD_SECRET>', $requestPart['post_fields']['password']);
     }
@@ -101,7 +101,7 @@ class ScrubbingTest extends TestCase
         $cassette->record($this->request, $this->response);
         $responsePart = $this->storedRecording()['response'];
 
-        $this->assertContains('X-Resp-Header: secret;<RESP_HEADER_SECRET>', $responsePart['headers']);
+        $this->assertEquals('secret;<RESP_HEADER_SECRET>', $responsePart['headers']['X-Resp-Header']);
         $this->assertEquals('This is a <RESP_BODY_SECRET>', $responsePart['body']);
     }
 

--- a/tests/fixtures/scrubbing_test
+++ b/tests/fixtures/scrubbing_test
@@ -1,0 +1,22 @@
+
+-
+    request:
+        method: GET
+        url: 'http://example.com?secret=query_secret'
+        headers:
+            Host: example.com
+            Content-Length: '0'
+    response:
+        status: 200
+        headers:
+            Accept-Ranges: bytes
+            Cache-Control: max-age=604800
+            Content-Type: text/html
+            Date: 'Fri, 25 Apr 2014 09:14:54 GMT'
+            Etag: '"359670651"'
+            Expires: 'Fri, 02 May 2014 09:14:54 GMT'
+            Last-Modified: 'Fri, 09 Aug 2013 23:54:35 GMT'
+            Server: 'EOS (lax004/2813)'
+            x-ec-custom-error: '1'
+            Content-Length: '1272'
+        body: "This is a scrubbed test dummy."


### PR DESCRIPTION
### Context

Typically there are lots of private values in network request/response that should not be saved to storage, and potentially be committed as part of a cassette. This PR allows users to specify redactions to be applied before/after storage. In all other respects the library works as it did before.

### What has been done

- added ability to specify redactions to be applied
- added scrubbing/unscrubbing just before a recording is recorded/played back
- tests

### How to test

- run unit tests

### Notes

- I don't really like the asymmetry between `scrub($request, $response)` and `unscrub($recording)`. It's like that because each direction instantiates `Request` or `Response` objects at different times, and was an attempt to prevent needless array<->object conversions, but maybe it's not worth bothering.
- `Scrubber`/`scrub`/`unscrub` perhaps isn't the best naming


