### PR TITLE
Dropped support for PHP 7.2

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,11 +1,11 @@
 <?php
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        '@PHP71Migration' => true,
+        '@PHP73Migration' => true,
         '@PHP71Migration:risky' => true,
         '@PHPUnit84Migration:risky' => true,
         // Causes too much problems for now, fix later

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,27 +4,25 @@ matrix:
   fast_finish: true
   include:
     - env: TEST_DIR=. PHP_CS_FIXER=true PHPSTAN=true
-      php: 7.2
+      php: 7.3
     - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
-      php: 7.2
-    - env: TEST_DIR=.
       php: 7.3
     - env: TEST_DIR=.
       php: 7.4
     - env: TEST_DIR=tests/integration/apache
-      php: 7.2
+      php: 7.3
       dist: trusty
       sudo: required
       services:
       - docker
     - env: TEST_DIR=tests/integration/guzzle/3
-      php: 7.2
+      php: 7.3
     - env: TEST_DIR=tests/integration/guzzle/5
-      php: 7.2
+      php: 7.3
     - env: TEST_DIR=tests/integration/guzzle/6
-      php: 7.2
+      php: 7.3
     - env: TEST_DIR=tests/integration/soap
-      php: 7.2
+      php: 7.3
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.3",
         "ext-curl": "*",
         "beberlei/assert": "^3.2.5",
         "symfony/yaml": "~2.1|^3.0|^4.0|^5.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,23 +3,15 @@ parameters:
     paths:
         - src
         - tests/VCR
-    # Can remove reportUnmatchedIgnoredErrors option after php 7.2 is no longer supported
-    reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         # This part of PHP is not very well documented, resulting PHPStan's definitions not being accurate
         - "#Access to an undefined property object::\\$data\\.#"
         - "#Access to an undefined property object::\\$datalen\\.#"
-        -
-            message: '#Unreachable statement - code above always terminates.#'
-            path: src/VCR/CodeTransform/AbstractCodeTransform.php
         # PHPStan cannot detect that strrpos will succeed (because of Assertion above) in HttpUtil::parseStatus
         - '#Parameter .* \$str(ing)? of function substr expects string, string\|false given.#'
         # The EventDispatcherInterface::dispatch signature is different (!) between Symfony <4.3 and >=4.3
         - '/Parameter #1 \$event of method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) expects object, string\|null given./'
         - '/Parameter #2 \$eventName of method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) expects string\|null, VCR\\Event\\Event given./'
-        # PHPStan cannot deal with manually defined constants - can be removed once php 7.2 no longer supported
-        - '#Constant CURLPROXY_HTTPS not found.#'
-        - '#Call to an undefined method (VCR\\Util\\|)SoapClient::GetCityWeatherByZIP\(\)\.#'
         - '#Call to an undefined method org\\bovigo\\vfs\\vfsStreamContent::hasChild\(\)\.#'
 includes:
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/resources/docker/workspace/Dockerfile
+++ b/resources/docker/workspace/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-cli-alpine
+FROM php:7.3-cli-alpine
 
 ARG PUID=1000
 ARG PGID=1000

--- a/src/VCR/Storage/Storage.php
+++ b/src/VCR/Storage/Storage.php
@@ -15,7 +15,7 @@ interface Storage extends \Iterator
     /**
      * Stores an array of data.
      *
-     * @param array<string,string|null|array<string,mixed>> $recording array to store in storage
+     * @param array<string,string|array<string,mixed>|null> $recording array to store in storage
      */
     public function storeRecording(array $recording): void;
 

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -111,7 +111,7 @@ class CurlHelper
             case \CURLINFO_HEADER_SIZE:
                 $info = mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
                 break;
-            case CURLPROXY_HTTPS:
+            case \CURLPROXY_HTTPS:
                 $info = '';
                 break;
             default:


### PR DESCRIPTION
### Context
Support for PHP 7.2 has been dropped, after having reached EOL last year.