### PR TITLE
Update HttpUtil responseParsing to handle multiple HTTP responses

### DIFF
--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -68,9 +68,20 @@ class HttpUtil
      */
     public static function parseResponse(string $response): array
     {
-        $response = str_replace("HTTP/1.1 100 Continue\r\n\r\n", '', $response);
+        $parts = explode("\r\n\r\n", $response);
 
-        [$rawHeader, $rawBody] = explode("\r\n\r\n", $response, 2);
+        $headerIndex = 0;
+        foreach ($parts as $index => $part) {
+            if (str_starts_with($part, 'HTTP/')) {
+                $headerIndex = $index;
+            } else {
+                break;
+            }
+        }
+
+        $rawHeader = $parts[$headerIndex];
+        $bodyParts = \array_slice($parts, $headerIndex + 1);
+        $rawBody = implode('\r\n\r\n', $bodyParts);
 
         // Parse headers and status.
         $headers = self::parseRawHeader($rawHeader);

--- a/tests/Unit/Util/HttpUtilTest.php
+++ b/tests/Unit/Util/HttpUtilTest.php
@@ -96,6 +96,23 @@ final class HttpUtilTest extends TestCase
         $this->assertEquals($expectedHeaders, $headers);
     }
 
+    public function testParseMultipleResponseCodes(): void
+    {
+        $raw = "HTTP/1.1 200 OK\r\n\r\nHTTP/1.1 200 OK\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";
+        [$status, $headers, $body] = HttpUtil::parseResponse($raw);
+
+        $expectedHeaders = [
+            'Content-Type: text/html',
+            'Date: Fri, 19 Jun 2015 16:05:18 GMT',
+            'Vary: Accept-Encoding',
+            'Content-Length: 0',
+        ];
+
+        $this->assertEquals('HTTP/1.1 201 Created', $status);
+        $this->assertEquals('', $body);
+        $this->assertEquals($expectedHeaders, $headers);
+    }
+
     public function testParseHeadersBasic(): void
     {
         $inputArray = [


### PR DESCRIPTION
### Context

Within our projects we use a proxy when connecting to some services, and when doing this we get an extra HTTP/... in the response string that is then parsed. Similar to the 100 continue issue, but ours were 200 OK response from the proxy added ontop

### What has been done

- the HttpUtil parsing of response has been update to only get the headers after the last HTTP/ line, which ideally should make this much more flexible than just stripping any 100 continues
- test added to make sure cases other than 100 continue are treated correctly

### How to test

- If possible use a proxy that adds a response (ideally not 100 continue)
- check the automated test that was added


