### PR TITLE
#336 Proper Detection of EventDispatcherInterface [1.5]

### DIFF
--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -4,6 +4,7 @@ namespace VCR;
 
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 use VCR\Event\AfterHttpRequestEvent;
 use VCR\Event\AfterPlaybackEvent;
 use VCR\Event\BeforeHttpRequestEvent;
@@ -95,15 +96,16 @@ class Videorecorder
      */
     private function dispatch(Event $event, $eventName = null): Event
     {
-        if (class_exists(\Symfony\Component\EventDispatcher\Event::class)) {
-            $res = $this->getEventDispatcher()->dispatch($eventName, $event);
+        $dispatcher = $this->getEventDispatcher();
 
-            Assertion::isInstanceOf($res, Event::class);
-
-            return $res;
+        // The `EventDispatcherInterface` of `Symfony\Contracts` is only implemented in Symfony 4.3 or higher
+        if ($dispatcher instanceof ContractsEventDispatcherInterface) {
+            // Symfony 4.3 or higher
+            $res = $dispatcher->dispatch($event, $eventName);
+        } else {
+            // Symfony 4.2 or lower
+            $res = $dispatcher->dispatch($eventName, $event);
         }
-
-        $res = $this->getEventDispatcher()->dispatch($event, $eventName);
 
         Assertion::isInstanceOf($res, Event::class);
 


### PR DESCRIPTION
Follow-up for #358 (not needed for master)

Fix issue #336

### Context
dispatch() was called with wrong order of parameters when using Codeception 4.1.15 or higher which added a class alias for EventDispatcher\Event.

### What has been done
- Using recommendation by @naktibalda to detect which version of dispatch method must be used.

### How to test

- install codeception/codeception ^4.1.14
- install php-vcr ^1.5
- install symfony/event-dispatcher ^5.0
- Call Videorecorder->handleRequest() with proper cassette inserted
- Must not produce error: [TypeError] Argument 1 passed to Symfony\Component\EventDispatcher\EventDispatcher::dispatch() must be an object, string given, called in .../vendor/php-vcr/php-vcr/src/VCR/Videorecorder.php on line 99
