### PR TITLE
Add return type to AbstractCodeTransform::filter

### DIFF
--- a/src/VCR/CodeTransform/AbstractCodeTransform.php
+++ b/src/VCR/CodeTransform/AbstractCodeTransform.php
@@ -37,7 +37,7 @@ abstract class AbstractCodeTransform extends \php_user_filter
      *
      * @see http://www.php.net/manual/en/php-user-filter.filter.php
      */
-    public function filter($in, $out, &$consumed, $closing)
+    public function filter($in, $out, &$consumed, $closing): int
     {
         while ($bucket = stream_bucket_make_writeable($in)) {
             $bucket->data = $this->transformCode($bucket->data);


### PR DESCRIPTION
Fixes the following deprecation notice:
```
PHP Deprecated:  Return type of VCR\CodeTransform\AbstractCodeTransform::filter($in, $out, &$consumed, $closing) should either be compatible with php_user_filter::filter($in, $out, &$consumed, bool $closing): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /.../vendor/php-vcr/php-vcr/src/VCR/CodeTransform/AbstractCodeTransform.php on line 40
```
