### PR TITLE
Chore/add return types for 8 1 iterator compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/fixtures/cassette*
 composer.lock
 .phpunit.result.cache
 .php-cs-fixer.cache
+.idea

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "php-vcr/php-vcr",
+    "name": "covergenius/php-vcr",
     "description": "Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.",
     "license": "MIT",
     "scripts": {
@@ -12,14 +12,17 @@
         {
             "name": "Adrian Philipp",
             "email": "mail@adrian-philipp.com"
+        },
+        {
+            "name": "Cover Genius Engineering Team"
         }
     ],
     "require": {
         "php": "^8.0",
         "ext-curl": "*",
         "beberlei/assert": "^3.2.5",
-        "symfony/yaml": "^3.0|^4.0|^5.0",
-        "symfony/event-dispatcher": "^5.0"
+        "symfony/yaml": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/event-dispatcher": "^5.0|^6.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.0",
@@ -40,6 +43,11 @@
     "autoload-dev": {
         "psr-4": {
             "VCR\\Tests\\": "tests"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
         }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" colors="true" bootstrap="tests/bootstrap.php">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Integration">
+      <directory>./tests/Integration</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/src/VCR/CodeTransform/AbstractCodeTransform.php
+++ b/src/VCR/CodeTransform/AbstractCodeTransform.php
@@ -37,7 +37,7 @@ abstract class AbstractCodeTransform extends \php_user_filter
      *
      * @see http://www.php.net/manual/en/php-user-filter.filter.php
      */
-    public function filter($in, $out, &$consumed, $closing)
+    public function filter($in, $out, &$consumed, $closing): int
     {
         while ($bucket = stream_bucket_make_writeable($in)) {
             $bucket->data = $this->transformCode($bucket->data);

--- a/src/VCR/Storage/AbstractStorage.php
+++ b/src/VCR/Storage/AbstractStorage.php
@@ -68,7 +68,7 @@ abstract class AbstractStorage implements Storage
      *
      * @return array<string,mixed>|null parsed current record
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->current;
     }

--- a/src/VCR/Storage/Blackhole.php
+++ b/src/VCR/Storage/Blackhole.php
@@ -35,10 +35,9 @@ class Blackhole implements Storage
         throw new \BadMethodCallException('Not implemented');
     }
 
-    /** @return array<mixed>|null */
-    public function next(): ?array
+    /** @return void */
+    public function next(): void
     {
-        return null;
     }
 
     public function rewind(): void

--- a/src/VCR/Storage/Yaml.php
+++ b/src/VCR/Storage/Yaml.php
@@ -88,7 +88,7 @@ class Yaml extends AbstractStorage
         $this->position = 0;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         if (null === $this->current) {
             $this->next();

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -36,7 +36,13 @@ class CurlHelper
         \CURLINFO_CONTENT_LENGTH_DOWNLOAD => 'download_content_length',
         \CURLINFO_CONTENT_LENGTH_UPLOAD => 'upload_content_length',
         \CURLINFO_CONTENT_TYPE => 'content_type',
+        \CURLINFO_APPCONNECT_TIME => 'appconnect_time',
     ];
+
+    /**
+     * How many items we expect in the curlinfo array - should correspond to the above list count
+     */
+    const CURLINFO_ITEMS_COUNT = 22;
 
     /**
      * Outputs a response depending on the set cURL option.
@@ -107,6 +113,7 @@ class CurlHelper
                 $info = mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
                 break;
             case \CURLPROXY_HTTPS:
+            case \CURLINFO_APPCONNECT_TIME:
                 $info = '';
                 break;
             default:

--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -68,9 +68,20 @@ class HttpUtil
      */
     public static function parseResponse(string $response): array
     {
-        $response = str_replace("HTTP/1.1 100 Continue\r\n\r\n", '', $response);
+        $parts = explode("\r\n\r\n", $response);
 
-        [$rawHeader, $rawBody] = explode("\r\n\r\n", $response, 2);
+        $headerIndex = 0;
+        foreach ($parts as $index => $part) {
+            if (str_starts_with($part, 'HTTP/')) {
+                $headerIndex = $index;
+            } else {
+                break;
+            }
+        }
+
+        $rawHeader = $parts[$headerIndex];
+        $bodyParts = \array_slice($parts, $headerIndex + 1);
+        $rawBody = implode('\r\n\r\n', $bodyParts);
 
         // Parse headers and status.
         $headers = self::parseRawHeader($rawHeader);

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -12,6 +12,7 @@ use VCR\Configuration;
 use VCR\LibraryHooks\CurlHook;
 use VCR\Request;
 use VCR\Response;
+use VCR\Util\CurlHelper;
 use VCR\Util\StreamProcessor;
 
 final class CurlHookTest extends TestCase
@@ -226,8 +227,10 @@ final class CurlHookTest extends TestCase
         $info = curl_getinfo($curlHandle);
         curl_close($curlHandle);
 
+        $expectedCount = CurlHelper::CURLINFO_ITEMS_COUNT;
+
         $this->assertIsArray($info, 'curl_getinfo() should return an array.');
-        $this->assertCount(21, $info, 'curl_getinfo() should return 21 values.');
+        $this->assertCount($expectedCount, $info, 'curl_getinfo() should return '. $expectedCount .' values.');
         $this->curlHook->disable();
     }
 

--- a/tests/Unit/Storage/AbstractStorageTest.php
+++ b/tests/Unit/Storage/AbstractStorageTest.php
@@ -51,7 +51,7 @@ class TestStorage extends AbstractStorage
     {
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return (bool) $this->position;
     }

--- a/tests/Unit/Util/HttpUtilTest.php
+++ b/tests/Unit/Util/HttpUtilTest.php
@@ -96,6 +96,23 @@ final class HttpUtilTest extends TestCase
         $this->assertEquals($expectedHeaders, $headers);
     }
 
+    public function testParseMultipleResponseCodes(): void
+    {
+        $raw = "HTTP/1.1 200 OK\r\n\r\nHTTP/1.1 200 OK\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";
+        [$status, $headers, $body] = HttpUtil::parseResponse($raw);
+
+        $expectedHeaders = [
+            'Content-Type: text/html',
+            'Date: Fri, 19 Jun 2015 16:05:18 GMT',
+            'Vary: Accept-Encoding',
+            'Content-Length: 0',
+        ];
+
+        $this->assertEquals('HTTP/1.1 201 Created', $status);
+        $this->assertEquals('', $body);
+        $this->assertEquals($expectedHeaders, $headers);
+    }
+
     public function testParseHeadersBasic(): void
     {
         $inputArray = [


### PR DESCRIPTION
### Context
Need to bring package up to PHP8.1 compatibility

### What has been done
Modified various iterator implementations to match 8.1 iterator interface https://www.php.net/manual/en/class.iterator.php

### How to test
Appears to work for 8.0 and 8.1. If you wish to test in 8.1 update the dockerfile to:
`FROM php:8.1-cli-alpine`
And run tests as usual.

Note: No extra tests have been added


