### PR TITLE
(Re-)Add support for symfony/event-dispatcher v4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,12 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8",
         "ext-curl": "*",
         "beberlei/assert": "^3.2.5",
-        "symfony/yaml": "^3.0|^4.0|^5.0",
-        "symfony/event-dispatcher": "^5.0"
+        "symfony/yaml": "^3|^4|^5",
+        "symfony/event-dispatcher": "^4|^5",
+        "symfony/event-dispatcher-contracts": "^1|^2|^3"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,3 +25,7 @@ parameters:
 			count: 1
 			path: src/VCR/Videorecorder.php
 
+		-
+			message: "#^Call to an undefined method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:addListener\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/VCRTest.php

--- a/resources/docker/workspace/Dockerfile
+++ b/resources/docker/workspace/Dockerfile
@@ -8,6 +8,8 @@ RUN apk add --no-cache --virtual .build-deps \
     $PHPIZE_DEPS \
     # for soap
     libxml2-dev \
+    # for xdebug \
+    linux-headers \
     && \
     apk add --no-cache \
     bash \
@@ -22,9 +24,12 @@ RUN apk add --no-cache --virtual .build-deps \
     # pcov for coverage runs
     pcov && docker-php-ext-enable pcov \
     && \
+    # for debugging
+    pecl install xdebug && docker-php-ext-enable xdebug \
+    && \
     apk del .build-deps
 
-COPY --from=composer /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /var/www/html
 

--- a/src/VCR/Event/Event.php
+++ b/src/VCR/Event/Event.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace VCR\Event;
 
-abstract class Event extends \Symfony\Contracts\EventDispatcher\Event
+use Symfony\Contracts\EventDispatcher\Event as BaseEvent;
+
+abstract class Event extends BaseEvent
 {
 }

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace VCR;
 
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use VCR\Event\AfterHttpRequestEvent;
 use VCR\Event\AfterPlaybackEvent;
 use VCR\Event\BeforeHttpRequestEvent;


### PR DESCRIPTION
### Context
To allow an easier upgrade path from php 7 up to 8 (decouple forced symfony upgrade to 5.4) make this library work with both version (4.4 & 5.4) of the symfony/event-dispatcher component.

### What has been done
- Allow lower version for symfony/event-dispatcher component
- Refactored GitHub workflows to run lowest & highest dependency tests

