### PR TITLE
Record identical requests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,7 +37,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method toArray\\(\\) on VCR\\\\Response\\|null\\.$#"
-			count: 7
+			count: 5
 			path: tests/Unit/CassetteTest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,6 +36,11 @@ parameters:
 			path: src/VCR/Videorecorder.php
 
 		-
+			message: "#^Cannot call method toArray\\(\\) on VCR\\\\Response\\|null\\.$#"
+			count: 7
+			path: tests/Unit/CassetteTest.php
+
+		-
 			message: "#^Parameter \\#2 \\$requestMatchers of method VCR\\\\Request\\:\\:matches\\(\\) expects array\\<callable\\(\\)\\: mixed\\>, array\\{array\\{'some', 'method'\\}\\} given\\.$#"
 			count: 1
 			path: tests/Unit/RequestTest.php

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -31,7 +31,7 @@ class Cassette
         foreach ($this->storage as $recording) {
             $storedRequest = Request::fromArray($recording['request']);
 
-            // Support legacy cassettes which do not have the 'index' key
+            // Support legacy cassettes which do not have the 'index' key.
             if (!\array_key_exists('index', $recording)) {
                 $recording['index'] = 0;
             }

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -21,32 +21,35 @@ class Cassette
     ) {
     }
 
-    public function hasResponse(Request $request): bool
+    public function hasResponse(Request $request, int $index = 0): bool
     {
-        return null !== $this->playback($request);
+        return null !== $this->playback($request, $index);
     }
 
-    public function playback(Request $request): ?Response
+    public function playback(Request $request, int $index = 0): ?Response
     {
         foreach ($this->storage as $recording) {
             $storedRequest = Request::fromArray($recording['request']);
-            if ($storedRequest->matches($request, $this->getRequestMatchers())) {
-                return Response::fromArray($recording['response']);
+            if ($index === $recording['index']) {
+                if ($storedRequest->matches($request, $this->getRequestMatchers())) {
+                    return Response::fromArray($recording['response']);
+                }
             }
         }
 
         return null;
     }
 
-    public function record(Request $request, Response $response): void
+    public function record(Request $request, Response $response, int $index): void
     {
-        if ($this->hasResponse($request)) {
+        if ($this->hasResponse($request, $index)) {
             return;
         }
 
         $this->storage->storeRecording([
             'request' => $request->toArray(),
             'response' => $response->toArray(),
+            'index' => $index,
         ]);
     }
 

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -31,15 +31,12 @@ class Cassette
         foreach ($this->storage as $recording) {
             $storedRequest = Request::fromArray($recording['request']);
 
-            // Support legacy cassettes which do not have the 'index' key.
-            if (!\array_key_exists('index', $recording)) {
-                $recording['index'] = 0;
-            }
+            // Support legacy cassettes which do not have the 'index' key by setting the index to the searched one to
+            // always match this record if the request matches
+            $recording['index'] ??= $index;
 
-            if ($index == $recording['index']) {
-                if ($storedRequest->matches($request, $this->getRequestMatchers())) {
-                    return Response::fromArray($recording['response']);
-                }
+            if ($storedRequest->matches($request, $this->getRequestMatchers()) && $index == $recording['index']) {
+                return Response::fromArray($recording['response']);
             }
         }
 

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -30,6 +30,12 @@ class Cassette
     {
         foreach ($this->storage as $recording) {
             $storedRequest = Request::fromArray($recording['request']);
+
+            // Support legacy cassettes which do not have the 'index' key
+            if (!\array_key_exists('index', $recording)) {
+                $recording['index'] = 0;
+            }
+
             if ($index == $recording['index']) {
                 if ($storedRequest->matches($request, $this->getRequestMatchers())) {
                     return Response::fromArray($recording['response']);

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -30,7 +30,7 @@ class Cassette
     {
         foreach ($this->storage as $recording) {
             $storedRequest = Request::fromArray($recording['request']);
-            if ($index === $recording['index']) {
+            if ($index == $recording['index']) {
                 if ($storedRequest->matches($request, $this->getRequestMatchers())) {
                     return Response::fromArray($recording['response']);
                 }

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -40,7 +40,7 @@ class Cassette
         return null;
     }
 
-    public function record(Request $request, Response $response, int $index): void
+    public function record(Request $request, Response $response, int $index = 0): void
     {
         if ($this->hasResponse($request, $index)) {
             return;

--- a/src/VCR/Request.php
+++ b/src/VCR/Request.php
@@ -301,4 +301,14 @@ class Request
     {
         $this->postFiles[] = $file;
     }
+
+    /**
+     * Generate a string representation of the request.
+     *
+     * @return string
+     */
+    public function getHash()
+    {
+        return md5(serialize($this->toArray()));
+    }
 }

--- a/src/VCR/Storage/Storage.php
+++ b/src/VCR/Storage/Storage.php
@@ -15,7 +15,7 @@ namespace VCR\Storage;
 interface Storage extends \Iterator
 {
     /**
-     * @param array<string,string|array<string,mixed>|null> $recording
+     * @param array<string,string|array<string,mixed>|null, int> $recording
      */
     public function storeRecording(array $recording): void;
 

--- a/src/VCR/Storage/Storage.php
+++ b/src/VCR/Storage/Storage.php
@@ -15,7 +15,7 @@ namespace VCR\Storage;
 interface Storage extends \Iterator
 {
     /**
-     * @param array<string,string|array<string,mixed>|null, int> $recording
+     * @param array<string,int|string|array<string,mixed>|null> $recording
      */
     public function storeRecording(array $recording): void;
 

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -103,7 +103,9 @@ class Videorecorder
     public function eject(): void
     {
         Assertion::true($this->isOn, 'Please turn on VCR before ejecting a cassette, use: VCR::turnOn().');
+
         $this->cassette = null;
+        $this->resetIndex();
     }
 
     /**
@@ -121,6 +123,7 @@ class Videorecorder
 
         $this->cassette = new Cassette($cassetteName, $this->config, $storage);
         $this->enableLibraryHooks();
+        $this->resetIndex();
     }
 
     /**
@@ -230,5 +233,10 @@ class Videorecorder
         }
 
         return ++$this->indexTable[$hash];
+    }
+
+    public function resetIndex(): void
+    {
+        $this->indexTable = [];
     }
 }

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -140,11 +140,10 @@ class Videorecorder
      * If a request was already recorded on a cassette it's response is returned,
      * otherwise the request is issued and it's response recorded (and returned).
      *
-     * @api
-
-     *
      * @throws \LogicException if the mode is set to none or once and
      *                         the cassette did not have a matching response
+     *
+     * @api
      */
     public function handleRequest(Request $request): Response
     {
@@ -160,7 +159,10 @@ class Videorecorder
 
         // Playback succeeded and the recorded response can be returned.
         if (!empty($response)) {
-            $this->dispatch(new AfterPlaybackEvent($request, $response, $this->cassette), VCREvents::VCR_AFTER_PLAYBACK);
+            $this->dispatch(
+                new AfterPlaybackEvent($request, $response, $this->cassette),
+                VCREvents::VCR_AFTER_PLAYBACK
+            );
 
             return $response;
         }
@@ -225,18 +227,18 @@ class Videorecorder
         }
     }
 
-      protected function iterateIndex(Request $request): int
-      {
-          $hash = $request->getHash();
-          if (!isset($this->indexTable[$hash])) {
-              $this->indexTable[$hash] = -1;
-          }
+    protected function iterateIndex(Request $request): int
+    {
+        $hash = $request->getHash();
+        if (!isset($this->indexTable[$hash])) {
+            $this->indexTable[$hash] = -1;
+        }
 
-          return ++$this->indexTable[$hash];
-      }
+        return ++$this->indexTable[$hash];
+    }
 
-      public function resetIndex(): void
-      {
-          $this->indexTable = [];
-      }
+    public function resetIndex(): void
+    {
+        $this->indexTable = [];
+    }
 }

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -225,18 +225,18 @@ class Videorecorder
         }
     }
 
-    protected function iterateIndex(Request $request): int
-    {
-        $hash = $request->getHash();
-        if (!isset($this->indexTable[$hash])) {
-            $this->indexTable[$hash] = -1;
-        }
+      protected function iterateIndex(Request $request): int
+      {
+          $hash = $request->getHash();
+          if (!isset($this->indexTable[$hash])) {
+              $this->indexTable[$hash] = -1;
+          }
 
-        return ++$this->indexTable[$hash];
-    }
+          return ++$this->indexTable[$hash];
+      }
 
-    public function resetIndex(): void
-    {
-        $this->indexTable = [];
-    }
+      public function resetIndex(): void
+      {
+          $this->indexTable = [];
+      }
 }

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -37,6 +37,11 @@ class Videorecorder
 
     protected EventDispatcherInterface $eventDispatcher;
 
+    /**
+     * @var array<string, int>
+     */
+    protected array $indexTable = [];
+
     public function __construct(
         protected Configuration $config,
         protected HttpClient $client,
@@ -146,7 +151,9 @@ class Videorecorder
 
         $this->dispatch(new BeforePlaybackEvent($request, $this->cassette), VCREvents::VCR_BEFORE_PLAYBACK);
 
-        $response = $this->cassette->playback($request);
+        // Add an index to the request to allow recording identical requests and play them back in the same sequence.
+        $index = $this->iterateIndex($request);
+        $response = $this->cassette->playback($request, $index);
 
         // Playback succeeded and the recorded response can be returned.
         if (!empty($response)) {
@@ -170,7 +177,7 @@ class Videorecorder
             $this->dispatch(new AfterHttpRequestEvent($request, $response), VCREvents::VCR_AFTER_HTTP_REQUEST);
 
             $this->dispatch(new BeforeRecordEvent($request, $response, $this->cassette), VCREvents::VCR_BEFORE_RECORD);
-            $this->cassette->record($request, $response);
+            $this->cassette->record($request, $response, $index);
         } finally {
             $this->enableLibraryHooks();
         }
@@ -213,5 +220,15 @@ class Videorecorder
         if ($this->isOn) {
             $this->turnOff();
         }
+    }
+
+    protected function iterateIndex(Request $request): int
+    {
+        $hash = $request->getHash();
+        if (!isset($this->indexTable[$hash])) {
+            $this->indexTable[$hash] = -1;
+        }
+
+        return ++$this->indexTable[$hash];
     }
 }

--- a/tests/Unit/CassetteTest.php
+++ b/tests/Unit/CassetteTest.php
@@ -70,10 +70,10 @@ final class CassetteTest extends TestCase
     public function testPlaybackOfIdenticalRequestsFromLegacyCassette(): void
     {
         $request1 = new Request('GET', 'https://example.com');
-        $response1 = new Response(200, [], 'response1');
+        $response1 = new Response('200', [], 'response1');
 
         $request2 = new Request('GET', 'https://example.com');
-        $response2 = new Response(200, [], 'response2');
+        $response2 = new Response('200', [], 'response2');
 
         // These are legacy recordings with no index keys.
         $recordings = [
@@ -94,17 +94,48 @@ final class CassetteTest extends TestCase
     }
 
     /**
-     * Ensure that if a second identical request is played back from an cassette
+     * Ensure also mixed cassettes are working properly, if a legacy cassette has a first entry without index (should be
+     * 0) and a second entry for the same request with incremented index (should be 1).
+     */
+    public function testPlaybackOfIdenticalRequestsFromLegacyCassetteWithIndexedRecords(): void
+    {
+        $request1 = new Request('GET', 'https://example.com');
+        $response1 = new Response('200', [], 'response1');
+
+        $request2 = new Request('GET', 'https://example.com');
+        $response2 = new Response('200', [], 'response2');
+
+        // These are legacy recordings with no index keys.
+        $recordings = [
+            [
+                'request' => $request1->toArray(),
+                'response' => $response1->toArray(),
+            ],
+            [
+                'request' => $request2->toArray(),
+                'response' => $response2->toArray(),
+                'index' => 1,
+            ],
+        ];
+
+        $cassette = $this->createCassetteWithRecordings($recordings);
+
+        $this->assertEquals($response1->toArray(), $cassette->playback($request1, 0)->toArray());
+        $this->assertEquals($response2->toArray(), $cassette->playback($request2, 1)->toArray());
+    }
+
+    /**
+     * Ensure that if a second identical request is played back from a cassette
      * with indexed recordings, the response corresponding to the recording
      * index will be returned.
      */
     public function testPlaybackOfIdenticalRequests(): void
     {
         $request1 = new Request('GET', 'https://example.com');
-        $response1 = new Response(200, [], 'response1');
+        $response1 = new Response('200', [], 'response1');
 
         $request2 = new Request('GET', 'https://example.com');
-        $response2 = new Response(200, [], 'response2');
+        $response2 = new Response('200', [], 'response2');
 
         // These are recordings with index keys which support playback of
         // multiple identical requests.

--- a/tests/Unit/CassetteTest.php
+++ b/tests/Unit/CassetteTest.php
@@ -77,11 +77,85 @@ final class CassetteTest extends TestCase
             'response' => $response->toArray(),
         ];
 
-        $storage = new Storage\Yaml(vfsStream::url('test/'), 'json_test');
-        $storage->storeRecording($recording);
-        $configuration = new Configuration();
-        $cassette = new Cassette('cassette_name', $configuration, $storage);
+        $cassette = $this->createCassetteWithRecordings([$recording]);
 
         $this->assertEquals($response->toArray(), $cassette->playback($request)->toArray());
+    }
+
+    /**
+     * Ensure that if a second identical request is played back from a legacy
+     * cassette, the first response will be returned.
+     */
+    public function testPlaybackOfIdenticalRequestsFromLegacyCassette(): void
+    {
+        $request1 = new Request('GET', 'https://example.com');
+        $response1 = new Response(200, [], 'response1');
+
+        $request2 = new Request('GET', 'https://example.com');
+        $response2 = new Response(200, [], 'response2');
+
+        // These are legacy recordings with no index keys.
+        $recordings = [
+            [
+                'request' => $request1->toArray(),
+                'response' => $response1->toArray(),
+            ],
+            [
+                'request' => $request2->toArray(),
+                'response' => $response2->toArray(),
+            ],
+        ];
+
+        $cassette = $this->createCassetteWithRecordings($recordings);
+
+        $this->assertEquals($response1->toArray(), $cassette->playback($request1)->toArray());
+        $this->assertEquals($response1->toArray(), $cassette->playback($request2)->toArray());
+    }
+
+    /**
+     * Ensure that if a second identical request is played back from an cassette
+     * with indexed recordings, the response corresponding to the recording
+     * index will be returned.
+     */
+    public function testPlaybackOfIdenticalRequests(): void
+    {
+        $request1 = new Request('GET', 'https://example.com');
+        $response1 = new Response(200, [], 'response1');
+
+        $request2 = new Request('GET', 'https://example.com');
+        $response2 = new Response(200, [], 'response2');
+
+        // These are recordings with index keys which support playback of
+        // multiple identical requests.
+        $recordings = [
+            [
+                'request' => $request1->toArray(),
+                'response' => $response1->toArray(),
+                'index' => 0,
+            ],
+            [
+                'request' => $request2->toArray(),
+                'response' => $response2->toArray(),
+                'index' => 1,
+            ],
+        ];
+
+        $cassette = $this->createCassetteWithRecordings($recordings);
+
+        $this->assertEquals($response1->toArray(), $cassette->playback($request1, 0)->toArray());
+        $this->assertNotEquals($response1->toArray(), $cassette->playback($request2, 1)->toArray());
+        $this->assertEquals($response2->toArray(), $cassette->playback($request2, 1)->toArray());
+    }
+
+    protected function createCassetteWithRecordings(array $recordings)
+    {
+        $storage = new Storage\Yaml(vfsStream::url('test/'), 'json_test');
+
+        foreach ($recordings as $recording) {
+            $storage->storeRecording($recording);
+        }
+        $configuration = new Configuration();
+
+        return new Cassette('cassette_name', $configuration, $storage);
     }
 }

--- a/tests/Unit/CassetteTest.php
+++ b/tests/Unit/CassetteTest.php
@@ -89,8 +89,8 @@ final class CassetteTest extends TestCase
 
         $cassette = $this->createCassetteWithRecordings($recordings);
 
-        $this->assertEquals($response1->toArray(), $cassette->playback($request1)->toArray());
-        $this->assertEquals($response1->toArray(), $cassette->playback($request2)->toArray());
+        $this->assertEquals($response1->toArray(), $cassette->playback($request1, 0)->toArray());
+        $this->assertEquals($response1->toArray(), $cassette->playback($request2, 1)->toArray());
     }
 
     /**

--- a/tests/Unit/CassetteTest.php
+++ b/tests/Unit/CassetteTest.php
@@ -64,25 +64,6 @@ final class CassetteTest extends TestCase
     }
 
     /**
-     * Test playback of a legacy cassette which does not have an index key.
-     */
-    public function testPlaybackLegacyCassette(): void
-    {
-        $request = new Request('GET', 'https://example.com');
-        $response = new Response(200, [], 'sometest');
-
-        // Create recording array with no index key.
-        $recording = [
-            'request' => $request->toArray(),
-            'response' => $response->toArray(),
-        ];
-
-        $cassette = $this->createCassetteWithRecordings([$recording]);
-
-        $this->assertEquals($response->toArray(), $cassette->playback($request)->toArray());
-    }
-
-    /**
      * Ensure that if a second identical request is played back from a legacy
      * cassette, the first response will be returned.
      */
@@ -147,9 +128,9 @@ final class CassetteTest extends TestCase
         $this->assertEquals($response2->toArray(), $cassette->playback($request2, 1)->toArray());
     }
 
-    protected function createCassetteWithRecordings(array $recordings)
+    protected function createCassetteWithRecordings(array $recordings): Cassette
     {
-        $storage = new Storage\Yaml(vfsStream::url('test/'), 'json_test');
+        $storage = new Yaml(vfsStream::url('test/'), 'json_test');
 
         foreach ($recordings as $recording) {
             $storage->storeRecording($recording);

--- a/tests/Unit/CassetteTest.php
+++ b/tests/Unit/CassetteTest.php
@@ -70,10 +70,10 @@ final class CassetteTest extends TestCase
     public function testPlaybackOfIdenticalRequestsFromLegacyCassette(): void
     {
         $request1 = new Request('GET', 'https://example.com');
-        $response1 = new Response('200', [], 'response1');
+        $response1 = new Response(200, [], 'response1');
 
         $request2 = new Request('GET', 'https://example.com');
-        $response2 = new Response('200', [], 'response2');
+        $response2 = new Response(200, [], 'response2');
 
         // These are legacy recordings with no index keys.
         $recordings = [
@@ -94,48 +94,17 @@ final class CassetteTest extends TestCase
     }
 
     /**
-     * Ensure also mixed cassettes are working properly, if a legacy cassette has a first entry without index (should be
-     * 0) and a second entry for the same request with incremented index (should be 1).
-     */
-    public function testPlaybackOfIdenticalRequestsFromLegacyCassetteWithIndexedRecords(): void
-    {
-        $request1 = new Request('GET', 'https://example.com');
-        $response1 = new Response('200', [], 'response1');
-
-        $request2 = new Request('GET', 'https://example.com');
-        $response2 = new Response('200', [], 'response2');
-
-        // These are legacy recordings with no index keys.
-        $recordings = [
-            [
-                'request' => $request1->toArray(),
-                'response' => $response1->toArray(),
-            ],
-            [
-                'request' => $request2->toArray(),
-                'response' => $response2->toArray(),
-                'index' => 1,
-            ],
-        ];
-
-        $cassette = $this->createCassetteWithRecordings($recordings);
-
-        $this->assertEquals($response1->toArray(), $cassette->playback($request1, 0)->toArray());
-        $this->assertEquals($response2->toArray(), $cassette->playback($request2, 1)->toArray());
-    }
-
-    /**
-     * Ensure that if a second identical request is played back from a cassette
+     * Ensure that if a second identical request is played back from an cassette
      * with indexed recordings, the response corresponding to the recording
      * index will be returned.
      */
     public function testPlaybackOfIdenticalRequests(): void
     {
         $request1 = new Request('GET', 'https://example.com');
-        $response1 = new Response('200', [], 'response1');
+        $response1 = new Response(200, [], 'response1');
 
         $request2 = new Request('GET', 'https://example.com');
-        $response2 = new Response('200', [], 'response2');
+        $response2 = new Response(200, [], 'response2');
 
         // These are recordings with index keys which support playback of
         // multiple identical requests.

--- a/tests/Unit/CassetteTest.php
+++ b/tests/Unit/CassetteTest.php
@@ -159,6 +159,9 @@ final class CassetteTest extends TestCase
         $this->assertEquals($response2->toArray(), $cassette->playback($request2, 1)->toArray());
     }
 
+    /**
+     * @param array<int,array<string,int|string|array<string,mixed>|null>> $recordings
+     */
     protected function createCassetteWithRecordings(array $recordings): Cassette
     {
         $storage = new Yaml(vfsStream::url('test/'), 'json_test');

--- a/tests/Unit/CassetteTest.php
+++ b/tests/Unit/CassetteTest.php
@@ -70,10 +70,10 @@ final class CassetteTest extends TestCase
     public function testPlaybackOfIdenticalRequestsFromLegacyCassette(): void
     {
         $request1 = new Request('GET', 'https://example.com');
-        $response1 = new Response(200, [], 'response1');
+        $response1 = new Response('200', [], 'response1');
 
         $request2 = new Request('GET', 'https://example.com');
-        $response2 = new Response(200, [], 'response2');
+        $response2 = new Response('200', [], 'response2');
 
         // These are legacy recordings with no index keys.
         $recordings = [
@@ -101,10 +101,10 @@ final class CassetteTest extends TestCase
     public function testPlaybackOfIdenticalRequests(): void
     {
         $request1 = new Request('GET', 'https://example.com');
-        $response1 = new Response(200, [], 'response1');
+        $response1 = new Response('200', [], 'response1');
 
         $request2 = new Request('GET', 'https://example.com');
-        $response2 = new Response(200, [], 'response2');
+        $response2 = new Response('200', [], 'response2');
 
         // These are recordings with index keys which support playback of
         // multiple identical requests.

--- a/tests/Unit/CassetteTest.php
+++ b/tests/Unit/CassetteTest.php
@@ -62,4 +62,26 @@ final class CassetteTest extends TestCase
 
         $this->assertTrue($this->cassette->hasResponse($request), 'Expected true if request was found.');
     }
+
+    /**
+     * Test playback of a legacy cassette which does not have an index key.
+     */
+    public function testPlaybackLegacyCassette(): void
+    {
+        $request = new Request('GET', 'https://example.com');
+        $response = new Response(200, [], 'sometest');
+
+        // Create recording array with no index key.
+        $recording = [
+            'request' => $request->toArray(),
+            'response' => $response->toArray(),
+        ];
+
+        $storage = new Storage\Yaml(vfsStream::url('test/'), 'json_test');
+        $storage->storeRecording($recording);
+        $configuration = new Configuration();
+        $cassette = new Cassette('cassette_name', $configuration, $storage);
+
+        $this->assertEquals($response->toArray(), $cassette->playback($request)->toArray());
+    }
 }

--- a/tests/Unit/VideorecorderTest.php
+++ b/tests/Unit/VideorecorderTest.php
@@ -34,10 +34,11 @@ final class VideorecorderTest extends TestCase
         $configuration->enableLibraryHooks([]);
         $videorecorder = $this->getMockBuilder('\VCR\Videorecorder')
             ->setConstructorArgs([$configuration, new HttpClient(), VCRFactory::getInstance()])
-            ->setMethods(['eject'])
+            ->setMethods(['eject', 'resetIndex'])
             ->getMock();
 
         $videorecorder->expects($this->exactly(2))->method('eject');
+        $videorecorder->expects($this->exactly(2))->method('resetIndex');
 
         $videorecorder->turnOn();
         $videorecorder->insertCassette('cassette1');


### PR DESCRIPTION
### Context

This PR is the rebased result of #270 and small fixes and is hopefully the last try to bring this feature back to the `master`. There is nothing more to say, for more information see #161 (which inspired #270) or the issue #132.

### What has been done

- Refactored/rebased the work of #161 and #270 onto the current master
- Fixed a backward compatibility issue where the cassette did not handle legacy stored records correctly, see 96721547bb50ddee25ffbfb749b4df6dae7bc6e0

### TODO

- Port this feature back to the 1.5 branch (will be done after merging this)
