### PR TITLE
Add CURLINFO_APPCONNECT_TIME to CurlHelper

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -35,6 +35,7 @@ class CurlHelper
         \CURLINFO_CONTENT_LENGTH_DOWNLOAD => 'download_content_length',
         \CURLINFO_CONTENT_LENGTH_UPLOAD => 'upload_content_length',
         \CURLINFO_CONTENT_TYPE => 'content_type',
+        \CURLINFO_APPCONNECT_TIME => 'appconnect_time',
     ];
 
     /**
@@ -106,6 +107,7 @@ class CurlHelper
                 $info = mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
                 break;
             case \CURLPROXY_HTTPS:
+            case \CURLINFO_APPCONNECT_TIME:
                 $info = '';
                 break;
             default:

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -226,7 +226,7 @@ final class CurlHookTest extends TestCase
         curl_close($curlHandle);
 
         $this->assertIsArray($info, 'curl_getinfo() should return an array.');
-        $this->assertCount(21, $info, 'curl_getinfo() should return 21 values.');
+        $this->assertCount(22, $info, 'curl_getinfo() should return 22 values.');
         $this->curlHook->disable();
     }
 


### PR DESCRIPTION
Fixes #309

### Context
Using with the Laravel HTTP client in tests, I was receiving the error `ErrorException: Undefined offset: 3145761` and also `BadMethodCallException: Not implemented: CURLINFO_APPCONNECT_TIME (3145761)`

### What has been done

- Added `CURLINFO_APPCONNECT_TIME` to CurlHelper $curlInfoList array
- Added CURLINFO_APPCONNECT_TIME case to switch in CurlHelper::getCurlOptionFromResponse

### How to test

- Use the unmodified release with the laravel HTTP client, see error
- Use this branch with the laravel HTTP client, error should be resolved
