### PR TITLE
FIX: Read the whole stream and perform code transformations

### DIFF
--- a/src/VCR/CodeTransform/AbstractCodeTransform.php
+++ b/src/VCR/CodeTransform/AbstractCodeTransform.php
@@ -20,7 +20,7 @@ abstract class AbstractCodeTransform extends \php_user_filter
      */
     public function register(): void
     {
-        if (! \in_array(static::NAME, stream_get_filters(), true)) {
+        if (!\in_array(static::NAME, stream_get_filters(), true)) {
             $isRegistered = stream_filter_register(static::NAME, static::class);
             Assertion::true(
                 $isRegistered,
@@ -34,8 +34,8 @@ abstract class AbstractCodeTransform extends \php_user_filter
      *
      * @param resource $in
      * @param resource $out
-     * @param int $consumed
-     * @param bool $closing
+     * @param int      $consumed
+     * @param bool     $closing
      *
      * @return int PSFS_PASS_ON
      *

--- a/src/VCR/CodeTransform/AbstractCodeTransform.php
+++ b/src/VCR/CodeTransform/AbstractCodeTransform.php
@@ -13,14 +13,19 @@ abstract class AbstractCodeTransform extends \php_user_filter
 {
     public const NAME = 'vcr_abstract_filter';
 
+    private string $data = '';
+
     /**
      * Attaches the current filter to a stream.
      */
     public function register(): void
     {
-        if (!\in_array(static::NAME, stream_get_filters(), true)) {
+        if (! \in_array(static::NAME, stream_get_filters(), true)) {
             $isRegistered = stream_filter_register(static::NAME, static::class);
-            Assertion::true($isRegistered, sprintf('Failed registering stream filter "%s" on stream "%s"', static::class, static::NAME));
+            Assertion::true(
+                $isRegistered,
+                sprintf('Failed registering stream filter "%s" on stream "%s"', static::class, static::NAME)
+            );
         }
     }
 
@@ -29,20 +34,27 @@ abstract class AbstractCodeTransform extends \php_user_filter
      *
      * @param resource $in
      * @param resource $out
-     * @param int      $consumed
-     * @param bool     $closing
+     * @param int $consumed
+     * @param bool $closing
      *
      * @return int PSFS_PASS_ON
      *
      * @see http://www.php.net/manual/en/php-user-filter.filter.php
      */
-    public function filter($in, $out, &$consumed, $closing): int
+    public function filter($in, $out, &$consumed, bool $closing): int
     {
-        while ($bucket = stream_bucket_make_writeable($in)) {
-            $bucket->data = $this->transformCode($bucket->data);
-            $consumed += $bucket->datalen;
-            stream_bucket_append($out, $bucket);
+        while ($buffer = stream_bucket_make_writeable($in)) {
+            $this->data .= $buffer->data;
+            $consumed += $buffer->datalen;
         }
+
+        if (!$closing) {
+            return \PSFS_FEED_ME;
+        }
+
+        $bucket = stream_bucket_new($this->stream, $this->transformCode($this->data));
+        $this->data = '';
+        stream_bucket_append($out, $bucket);
 
         return \PSFS_PASS_ON;
     }

--- a/src/VCR/CodeTransform/AbstractCodeTransform.php
+++ b/src/VCR/CodeTransform/AbstractCodeTransform.php
@@ -35,7 +35,6 @@ abstract class AbstractCodeTransform extends \php_user_filter
      * @param resource $in
      * @param resource $out
      * @param int      $consumed
-     * @param bool     $closing
      *
      * @return int PSFS_PASS_ON
      *


### PR DESCRIPTION
### Context

Inspired by #269 (and fixes #268) i adapted his idea to perform code transformations on the whole file, but his patch didn't work for me or fixed my problem described here https://github.com/php-vcr/php-vcr/pull/269#issuecomment-1355137112.
I reread the [php interface doc](https://www.php.net/manual/de/php-user-filter.filter.php) for stream filters and found out, that is possible to return `PSFS_FEED_ME` until `$closing` parameter gets `true` (then return `PSFS_PASS_ON` as before) and read the stream into a local variable.
On the last iteration, when the stream gets closed and `$closing` parameter gets `true` i performed the code transformation on the local buffered and complete data and append it to the outgoing bucket.

### What has been done

- Read the stream into a local variable of the `AbstractCodeTransform` class until the `$closing` parameter of the interface function `filter` gets `true`.
- Return `PSFS_FEED_ME` until the `$closing` parameter of the `filter` function gets `true``
- Perform code transformation if `$closing` parameter was `true``
- Return `PSFS_PASS_ON` at the last iteration

### How to test

- I'm feeling really bad, but i think it is not really testable (by a unit test case). A possible solution is to write a test file, which gets split into chunks at the position where an replacement or transformation should occur. But at which point is the file really divided by the php stream buffer? In my debug sessions it seems to at 8196 bytes ... but may it change? Is there a configuration to ensure it will always happen after x bytes? Otherwise the test might return false positives or it make us feel save where we should not ...

