### PR TITLE
FEATURE: Add testcase

### DIFF
--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -38,9 +38,9 @@ class Videorecorder
     protected EventDispatcherInterface $eventDispatcher;
 
     /**
-     * @var array<string, int>
+     * @var Request[]
      */
-    protected array $indexTable = [];
+    protected array $handledRequests = [];
 
     public function __construct(
         protected Configuration $config,
@@ -229,16 +229,19 @@ class Videorecorder
 
     protected function iterateIndex(Request $request): int
     {
-        $hash = $request->getHash();
-        if (!isset($this->indexTable[$hash])) {
-            $this->indexTable[$hash] = -1;
+        $index = 0;
+        foreach ($this->handledRequests as $req) {
+            if ($req->matches($request, $this->config->getRequestMatchers())) {
+                ++$index;
+            }
         }
+        $this->handledRequests[] = $request;
 
-        return ++$this->indexTable[$hash];
+        return $index;
     }
 
     public function resetIndex(): void
     {
-        $this->indexTable = [];
+        $this->handledRequests = [];
     }
 }

--- a/tests/Unit/VideorecorderTest.php
+++ b/tests/Unit/VideorecorderTest.php
@@ -10,6 +10,7 @@ use VCR\Cassette;
 use VCR\Configuration;
 use VCR\Request;
 use VCR\Response;
+use VCR\Storage\Yaml;
 use VCR\Util\HttpClient;
 use VCR\VCR;
 use VCR\VCRFactory;
@@ -184,5 +185,54 @@ final class VideorecorderTest extends TestCase
         }
 
         return $cassette;
+    }
+
+    public function testPlaybackOfIdenticalRequestsAndMatcher(): void
+    {
+        $request1 = new Request('GET', 'https://example.com', ['Request-Version' => '1']);
+        $response1 = new Response('200', [], 'response');
+
+        $request2 = new Request('GET', 'https://example.com', ['Request-Version' => '2']);
+        $response2 = new Response('200', [], 'response 2');
+
+        $client = new class([$response1, $response2]) extends HttpClient {
+            private int $index = 0;
+
+            /**
+             * @param Response[] $sequence
+             */
+            public function __construct(private array $sequence)
+            {
+            }
+
+            public function send(Request $request): Response
+            {
+                return $this->sequence[$this->index++];
+            }
+        };
+
+        $configuration = new Configuration();
+        $configuration->enableLibraryHooks([]);
+        $configuration->setMode('new_episodes');
+        $configuration->enableRequestMatchers(['body']);
+
+        $videorecorder = new class($configuration, $client, VCRFactory::getInstance()) extends Videorecorder {
+            public function setCassette(Cassette $cassette): void
+            {
+                $this->cassette = $cassette;
+            }
+        };
+
+        vfsStream::setup('test');
+        $storage = new Yaml(vfsStream::url('test/'), 'json_test');
+        $cassette = new Cassette('cassette_name', $configuration, $storage);
+        $videorecorder->setCassette($cassette);
+
+        $this->assertEquals($response1, $videorecorder->handleRequest($request1));
+        $this->assertEquals($response2, $videorecorder->handleRequest($request2));
+
+        $this->assertEquals($response1->toArray(), $cassette->playback($request1, 0)?->toArray());
+        $this->assertNotEquals($response1->toArray(), $cassette->playback($request2, 1)?->toArray());
+        $this->assertEquals($response2->toArray(), $cassette->playback($request2, 1)?->toArray());
     }
 }


### PR DESCRIPTION
### Context

With this test case, I'm reproducing the problem that I'm facing. If the request matcher is ignoring some parts of the request making them the same, those requests should increment the same key in the `$indexTable`.

### What has been done

- Failing test explaining the problem that I have

### How to test

- Run the test

### Notes

If you are open for accepting it, I could submit a fix for this issue.

