### PR TITLE
TASK: Drop support for php 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8",
+        "php": "^8,<8.2",
         "ext-curl": "*",
         "beberlei/assert": "^3.2.5",
         "symfony/yaml": "^3|^4|^5|^6",


### PR DESCRIPTION
### Context

Currently, the php-vcr library does not work well with php 8.2 so we drop the support for now until it is fixed.

### What has been done

- drop support for php >= 8.2

