### PR TITLE
FIX: Initialized typed property

### DIFF
--- a/src/VCR/Response.php
+++ b/src/VCR/Response.php
@@ -25,7 +25,7 @@ class Response
      */
     protected array $curlInfo = [];
 
-    protected mixed $httpVersion;
+    protected mixed $httpVersion = null;
 
     /**
      * @param string|array<string, string> $status


### PR DESCRIPTION
### Context
With #393 i created a problem with an "maybe" uninitialized property. This PR resolves the issue opened in #393 and reported in #395

### What has been done

- initialized property with `null` by default (as before by php)


