### PR TITLE
Add SOAP extension requirement for running tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "symfony/event-dispatcher-contracts": "^1|^2|^3"
     },
     "require-dev": {
+        "ext-soap": "*",
         "guzzlehttp/guzzle": "^7",
         "phpunit/phpunit": "^9.5.10",
         "mikey179/vfsstream": "^1.6.10",


### PR DESCRIPTION
### Context


### What has been done

- Adding the `ext-soap` extension requirement in the `require-dev` to avoid throwing exception messages when running the `vendor/bin/phpunit` command.

### How to test

- If the `soap` extension is not installed, running the `vendor/bin/phpunit` and it will present the following messages:

```sh
~/php-vcr$ vendor/bin/phpunit
PHPUnit 9.6.11 by Sebastian Bergmann and contributors.

Error in bootstrap script: BadMethodCallException:
For soap support you need to install the soap extension.
#0 /home/localadmin/php-vcr/src/VCR/VCRFactory.php(64): VCR\LibraryHooks\SoapHook->__construct()
#1 /home/localadmin/php-vcr/src/VCR/VCRFactory.php(115): VCR\VCRFactory->createVCRLibraryHooksSoapHook()
#2 /home/localadmin/php-vcr/src/VCR/VCRFactory.php(95): VCR\VCRFactory->getOrCreate()
#3 /home/localadmin/php-vcr/src/VCR/Videorecorder.php(211): VCR\VCRFactory::get()
#4 /home/localadmin/php-vcr/src/VCR/Videorecorder.php(84): VCR\Videorecorder->enableLibraryHooks()
#5 /home/localadmin/php-vcr/src/VCR/VCR.php(46): VCR\Videorecorder->turnOn()
#6 /home/localadmin/php-vcr/tests/bootstrap.php(7): VCR\VCR::__callStatic()
#7 /home/localadmin/php-vcr/vendor/phpunit/phpunit/src/Util/FileLoader.php(66): include_once('...')
#8 /home/localadmin/php-vcr/vendor/phpunit/phpunit/src/Util/FileLoader.php(49): PHPUnit\Util\FileLoader::load()
#9 /home/localadmin/php-vcr/vendor/phpunit/phpunit/src/TextUI/Command.php(565): PHPUnit\Util\FileLoader::checkAndLoad()
#10 /home/localadmin/php-vcr/vendor/phpunit/phpunit/src/TextUI/Command.php(345): PHPUnit\TextUI\Command->handleBootstrap()
#11 /home/localadmin/php-vcr/vendor/phpunit/phpunit/src/TextUI/Command.php(112): PHPUnit\TextUI\Command->handleArguments()
#12 /home/localadmin/php-vcr/vendor/phpunit/phpunit/src/TextUI/Command.php(97): PHPUnit\TextUI\Command->run()
#13 /home/localadmin/php-vcr/vendor/phpunit/phpunit/phpunit(107): PHPUnit\TextUI\Command::main()
#14 /home/localadmin/php-vcr/vendor/bin/phpunit(123): include('...')
#15 {main}
```

### Todo

N/A

### Notes

N/A


