### PR TITLE
FIX: Add handling for array values in response headers

### DIFF
--- a/src/VCR/Response.php
+++ b/src/VCR/Response.php
@@ -84,6 +84,7 @@ class Response
         $body = $response['body'] ?? null;
 
         $gzip = isset($response['headers']['Content-Type'])
+            && \is_string($response['headers']['Content-Type'])
             && str_contains($response['headers']['Content-Type'], 'application/x-gzip');
 
         $binary = isset($response['headers']['Content-Transfer-Encoding'])
@@ -137,10 +138,15 @@ class Response
 
     public function getContentType(): ?string
     {
-        return $this->getHeader('Content-Type');
+        $value = $this->getHeader('Content-Type');
+
+        return \is_array($value) ? current($value) : $value;
     }
 
-    public function getHeader(string $key): ?string
+    /**
+     * @return string|array|null
+     */
+    public function getHeader(string $key)
     {
         if (!isset($this->headers[$key])) {
             return null;

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -27,6 +27,40 @@ final class ResponseTest extends TestCase
         $this->assertEquals([], $response->getHeaders());
     }
 
+    public function testHandleArrayAsHeaderValue(): void
+    {
+        $value = [
+            'one',
+            'two',
+        ];
+
+        $expectedHeaders = [
+            'User-Agent' => 'Unit-Test',
+            'Host' => 'example.com',
+            'Custom-Header' => $value,
+        ];
+
+        $response = Response::fromArray(['headers' => $expectedHeaders]);
+
+        $this->assertEquals($value, $response->getHeader('Custom-Header'));
+    }
+
+    public function testHandleMalformedContentTypeHeader(): void
+    {
+        $expectedHeaders = [
+            'User-Agent' => 'Unit-Test',
+            'Host' => 'example.com',
+            'Content-Type' => [
+                'application/json; charset=utf-8',
+                'application/json; charset=utf-8',
+            ],
+        ];
+
+        $response = Response::fromArray(['headers' => $expectedHeaders]);
+
+        $this->assertEquals('application/json; charset=utf-8', $response->getContentType());
+    }
+
     public function testRestoreHeadersFromArray(): void
     {
         $headers = [


### PR DESCRIPTION
### Context
The problem exists with servers that return duplicate headers. It's true that they should fix their own stuff, but it's also of interest that this package is resilient to such edge cases that appear in production.

### What has been done
- Fixed `Response.php` so that array as a value for any header is handled without errors.
- Made sure `Response::getContentType` still works if Content-Type is received as an array. It returns the first value of the array.
- Added 2 tests.

### How to test
`composer test`