### PR TITLE
Re-roll pull/302 patch for compatibility with php-vcr 1.5.5.

### DIFF
--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -68,7 +68,7 @@ class HttpUtil
     {
         $response = str_replace("HTTP/1.1 100 Continue\r\n\r\n", '', $response);
 
-        [$rawHeader, $rawBody] = explode("\r\n\r\n", $response, 2);
+        [$rawHeader, $rawBody] = array_pad(explode("\r\n\r\n", $response, 2), 2, '');
 
         // Parse headers and status.
         $headers = self::parseRawHeader($rawHeader);

--- a/tests/Unit/Util/HttpUtilTest.php
+++ b/tests/Unit/Util/HttpUtilTest.php
@@ -42,6 +42,17 @@ class HttpUtilTest extends TestCase
         $this->assertEquals($expectedHeaders, $headers);
     }
 
+    public function testParseResponseNull() : void
+    {
+        $raw = null;
+        [$status, $headers, $body] = HttpUtil::parseResponse($raw);
+
+        $expectedHeaders = [];
+        $this->assertEquals(null, $status);
+        $this->assertEquals(null, $body);
+        $this->assertEquals($expectedHeaders, $headers);
+    }
+
     public function testParseContinuePlusResponse(): void
     {
         $raw = "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/html\r\nDate: Fri, 19 Jun 2015 16:05:18 GMT\r\nVary: Accept-Encoding\r\nContent-Length: 0\r\n\r\n";

--- a/tests/Unit/Util/HttpUtilTest.php
+++ b/tests/Unit/Util/HttpUtilTest.php
@@ -42,7 +42,7 @@ class HttpUtilTest extends TestCase
         $this->assertEquals($expectedHeaders, $headers);
     }
 
-    public function testParseResponseNull() : void
+    public function testParseResponseNull(): void
     {
         $raw = null;
         [$status, $headers, $body] = HttpUtil::parseResponse($raw);


### PR DESCRIPTION
### Context
This is a re-roll of https://github.com/php-vcr/php-vcr/pull/302 to achieve a patch that is compatible with php-vcr 1.5.5.

As mentioned in https://github.com/php-vcr/php-vcr/issues/272, it's possible for HttpUtil::parseResponse() to receive a empty `$response` argument.  In this case php-VCR emits 

```      
PHP Notice:  Undefined offset: 1 in /opt/WpsConsole/vendor/php-vcr/php-vcr/src/VCR/Util/HttpUtil.php on line 70
```
which causes a Behat test to fail.

### What has been done
Use `array_pad()` to ensure that the array created from an empty response argument has at least two empty elements.

Add HttpUtilTest::parseResponseNull() to assert correct behavior if the response is null.

### How to test
In my case I needed to create a new fixture for a [getUser()|https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetUser.html] call to AWS IAM. Doing that exposed this bug. 

### Notes
I used the same approach as https://github.com/php-vcr/php-vcr/pull/242
