### PR TITLE
Remove trailing semicolon in Content-Type header

### DIFF
--- a/src/VCR/LibraryHooks/SoapHook.php
+++ b/src/VCR/LibraryHooks/SoapHook.php
@@ -44,7 +44,7 @@ class SoapHook implements LibraryHook
         $vcrRequest = new Request('POST', $location);
 
         if (\SOAP_1_1 === $version) {
-            $vcrRequest->setHeader('Content-Type', 'text/xml; charset=utf-8;');
+            $vcrRequest->setHeader('Content-Type', 'text/xml; charset=utf-8');
             $vcrRequest->setHeader('SOAPAction', $action);
         } else { // >= SOAP_1_2
             $vcrRequest->setHeader(


### PR DESCRIPTION
### Context
One of the SOAP servers we use throws an error when it sees a trailing semicolon in the header value.

### What has been done

- Remove a trailing semicolon from "Content-Type" header in SoapHook. 

### How to test

- Unfortunately, the WSDL and the whole API is behind a firewall, so it's impossible to provide the working test case.
- Fortunately, the change is not against the HTTP specification.



