### PR TITLE
Fix stream handler set option

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -493,14 +493,14 @@ class StreamProcessor
      *
      * @codeCoverageIgnore
      *
-     * @param int $option one of STREAM_OPTION_BLOCKING, STREAM_OPTION_READ_TIMEOUT, STREAM_OPTION_WRITE_BUFFER
-     * @param int $arg1   depending on option
-     * @param int $arg2   depending on option
+     * @param int      $option one of STREAM_OPTION_BLOCKING, STREAM_OPTION_READ_TIMEOUT, STREAM_OPTION_WRITE_BUFFER
+     * @param int      $arg1   depending on option
+     * @param int|null $arg2   depending on option
      *
      * @return bool Returns TRUE on success or FALSE on failure. If option is not implemented,
      *              FALSE should be returned.
      */
-    public function stream_set_option(int $option, int $arg1, int $arg2): bool
+    public function stream_set_option(int $option, int $arg1, ?int $arg2 = null): bool
     {
         if (false === $this->resource) {
             return false;

--- a/tests/Unit/Util/StreamProcessorTest.php
+++ b/tests/Unit/Util/StreamProcessorTest.php
@@ -34,7 +34,7 @@ final class StreamProcessorTest extends TestCase
     {
         $mock = $this->getMockBuilder('VCR\Util\StreamProcessor')
             ->disableOriginalConstructor()
-            ->setMethods(['intercept', 'restore', 'appendFiltersToStream', 'shouldProcess'])
+            ->onlyMethods(['intercept', 'restore', 'appendFiltersToStream', 'shouldProcess'])
             ->getMock();
 
         if (null !== $shouldProcess) {
@@ -109,8 +109,22 @@ final class StreamProcessorTest extends TestCase
     public function testUrlStatFileNotFound(): void
     {
         $processor = new StreamProcessor();
-        $this->expectWarning();
-        $processor->url_stat('file_not_found', 0);
+
+        set_error_handler(static function (
+            int $errno,
+            string $errstr,
+            string $errfile = '',
+            int $errline = 0
+        ): void {
+            throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+        }, \E_WARNING);
+
+        try {
+            $this->expectException(\ErrorException::class);
+            $processor->url_stat('file_not_found', 0);
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**
@@ -195,7 +209,7 @@ final class StreamProcessorTest extends TestCase
     {
         return $this->getMockBuilder(StreamProcessor::class)
             ->disableOriginalConstructor()
-            ->setMethods(['intercept', 'restore'])
+            ->onlyMethods(['intercept', 'restore'])
             ->getMock();
     }
 }

--- a/tests/Unit/Util/StreamProcessorTest.php
+++ b/tests/Unit/Util/StreamProcessorTest.php
@@ -27,6 +27,24 @@ final class StreamProcessorTest extends TestCase
         $this->assertEquals(\strlen($testData), $res);
     }
 
+    public function testSetStreamOptions(): void
+    {
+        $processor = new StreamProcessor();
+        $processor->intercept();
+
+        $handle = fopen('tests/fixtures/file_put_contents', 'w');
+
+        self::assertTrue(stream_set_blocking($handle, true));
+        self::assertFalse(stream_set_timeout($handle, 10));
+        self::assertFalse(stream_set_timeout($handle, 5, 2));
+        self::assertSame(-1, stream_set_write_buffer($handle, 0));
+        self::assertSame(0, stream_set_read_buffer($handle, 0));
+
+        fclose($handle);
+
+        $processor->restore();
+    }
+
     /**
      * @dataProvider streamOpenAppendFilterProvider
      */


### PR DESCRIPTION
### Context

`$arg2` must be nullable otherwise the stream handler fails with `TypeError: VCR\Util\StreamProcessor::stream_set_option(): Argument #3 ($arg2) must be of type int, null given`

### What has been done

- Fixes the signature of `\VCR\Util\StreamProcessor::stream_set_option`
- Fixes PHPUnit deprecations

