### PR TITLE
Symfony HTTP Client Compatibility Issue - Let's Fix It!

### DIFF
--- a/.github/workflows/continuous integration.yml
+++ b/.github/workflows/continuous integration.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.0"
+          php-version: "8.1"
           extensions: "curl, soap"
           tools: "composer:v2"
 
@@ -60,7 +60,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.0"
+          php-version: "8.1"
           extensions: "curl, soap"
           tools: "composer:v2"
 
@@ -87,10 +87,10 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - "8.0"
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         dependencies:
           - "lowest"
           - "highest"
@@ -139,3 +139,4 @@ jobs:
         if: "always()" # always run even if the previous step fails
         with:
           cli-args: "--format=php-clover coverage.clover"
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 coverage/*
 notes.md
 tests/fixtures/cassette*
+tests/fixtures/file_put_contents
 /.php_cs
 composer.lock
 .phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,9 +5,7 @@ return (new PhpCsFixer\Config())
         '@PSR12' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        '@PHP80Migration' => true,
-        '@PHP80Migration:risky' => true,
-        '@PHPUnit84Migration:risky' => true,
+        '@PHPUnit8x4Migration:risky' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Disclaimer: Doing this in PHP is not as easy as in programming languages which s
 * Supports common http functions and extensions
   * everything using [streamWrapper](http://php.net/manual/en/class.streamwrapper.php): fopen(), fread(), file_get_contents(), ... without any modification (except `$http_response_header` see [#96](https://github.com/php-vcr/php-vcr/issues/96))
   * [SoapClient](http://www.php.net/manual/en/soapclient.soapclient.php) by adding `\VCR\VCR::turnOn();` in your `tests/bootstrap.php`
-  * curl(), by adding `\VCR\VCR::turnOn();` in your `tests/bootstrap.php`
+  * curl() and curl_multi() by adding `\VCR\VCR::turnOn();` in your `tests/bootstrap.php`
+  * **[Symfony HttpClient](https://symfony.com/doc/current/http_client.html)** (CurlHttpClient, NativeHttpClient) - see [Symfony HttpClient Support](#symfony-httpclient-support)
+  * **[Guzzle](http://guzzlephp.org/)** 6+ HTTP client
 * The same request can receive different responses in different tests -- just use different cassettes.
 * Disables all HTTP requests that you don't explicitly allow by [setting the record mode](http://php-vcr.github.io/documentation/configuration/)
 * [Request matching](http://php-vcr.github.io/documentation/configuration/) is configurable based on HTTP method, URI, host, path, body and headers, or you can easily
@@ -84,6 +86,81 @@ class VCRTest extends TestCase
     }
 }
 ```
+
+## Symfony HttpClient Support
+
+PHP-VCR fully supports Symfony HttpClient through code transformation that automatically wraps your HTTP client instances.
+
+### Automatic Wrapping (Recommended)
+
+Enable the `symfony_http_client` hook to automatically wrap all Symfony HttpClient instances:
+
+``` php
+class SymfonyHttpClientTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        \VCR\VCR::configure()
+            ->setCassettePath('tests/fixtures')
+            ->enableLibraryHooks(['symfony_http_client'])
+            ->setMode('once');
+
+        \VCR\VCR::turnOn();
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::eject();
+        \VCR\VCR::turnOff();
+    }
+
+    public function testHttpClientGet(): void
+    {
+        \VCR\VCR::insertCassette('example');
+
+        // Direct instantiation - automatically wrapped by VCR!
+        $client = new \Symfony\Component\HttpClient\CurlHttpClient();
+        $response = $client->request('GET', 'https://api.example.com/data');
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}
+```
+
+### Manual Wrapping (Alternative)
+
+You can also manually wrap your HTTP client:
+
+``` php
+use VCR\VCRHttpClient;
+use Symfony\Component\HttpClient\CurlHttpClient;
+
+$baseClient = new CurlHttpClient();
+$client = new VCRHttpClient($baseClient);
+
+// Now all requests through $client are recorded/replayed
+$response = $client->request('GET', 'https://api.example.com/data');
+```
+
+### Supported Clients
+
+- `CurlHttpClient` - Uses cURL extension
+- `NativeHttpClient` - Uses PHP streams
+- `MockHttpClient` - No interception needed
+- `TraceableHttpClient` - Wrapped transparently
+- `RetryableHttpClient` - Wrapped transparently
+
+### How It Works
+
+The Symfony HttpClient integration uses code transformation to intercept `new CurlHttpClient()` and `new NativeHttpClient()` calls and automatically wrap them with `VCRHttpClient`. This wrapper:
+
+- Intercepts all HTTP requests
+- Records requests/responses to cassette files
+- Replays recorded responses in subsequent test runs
+- Handles gzip compression/decompression automatically
+- Preserves all Symfony HttpClient features (streaming, async, etc.)
+
+See [docs/HOOK_STRATEGY.md](docs/HOOK_STRATEGY.md) for more details on the interception architecture.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "ext-soap": "*",
         "guzzlehttp/guzzle": "^7",
-        "phpunit/phpunit": "^9.5.10",
+        "phpunit/phpunit": "^9.6",
         "mikey179/vfsstream": "^1.6.10",
         "phpstan/phpstan": "^1",
         "phpstan/phpstan-beberlei-assert": "^1",
@@ -34,7 +34,8 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan-phpunit": "^1",
         "phpstan/extension-installer": "^1.1",
-        "editorconfig-checker/editorconfig-checker": "^10.3"
+        "editorconfig-checker/editorconfig-checker": "^10.3",
+        "symfony/http-client": "^6.4|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8,<8.2|>=8.2.9,<8.4",
+        "php": ">=8.1",
         "ext-curl": "*",
         "beberlei/assert": "^3.2.5",
         "symfony/yaml": "^3|^4|^5|^6|^7",

--- a/docs/HOOK_STRATEGY.md
+++ b/docs/HOOK_STRATEGY.md
@@ -1,0 +1,69 @@
+# Hook Strategy Documentation
+
+## Overview
+
+PHP-VCR uses different interception strategies (hooks) to record and replay HTTP requests. This document clarifies when to use each approach.
+
+## Hook Types
+
+### 1. High-Level Hooks (Recommended)
+
+**SymfonyHttpClientHook** - Decorator pattern for Symfony HttpClient
+
+- **Use for**: Symfony\Component\HttpClient usage
+- **How it works**: Wraps the HttpClient instance via `VCRHttpClient` decorator
+- **Benefits**:
+  - Clean separation of concerns
+  - No timing issues with async requests
+  - Proper handling of response streaming
+  - Automatic gzip decompression
+  - Works with all Symfony HttpClient implementations (CurlHttpClient, NativeHttpClient, etc.)
+
+**Recommended setup**:
+```php
+use VCR\VCRHttpClient;
+use Symfony\Component\HttpClient\CurlHttpClient;
+
+$client = new VCRHttpClient(new CurlHttpClient());
+```
+
+### 2. Low-Level Hooks (Legacy Support)
+
+**CurlHook** - Function interception for direct curl_* usage
+
+- **Use for**: Direct calls to `curl_exec()`, `curl_multi_exec()`, etc.
+- **How it works**: Intercepts curl function calls via code transformation
+- **Limitations**:
+  - Timing issues with modern async HTTP clients (see comments in CurlHook.php:80-95)
+  - Complex state management with static properties
+  - Fragile cleanup logic (potential memory leaks in tests)
+  - Does not handle gzip decompression properly for some clients
+
+**StreamWrapperHook** - Stream wrapper interception
+
+- **Use for**: `file_get_contents()`, `fopen()` for HTTP
+- **How it works**: Registers custom stream wrapper
+- **Note**: Uses `$wrapper_data` public property for `stream_get_meta_data()` compatibility
+
+## Recommendations
+
+1. **For Symfony projects**: Always use `SymfonyHttpClientHook` / `VCRHttpClient`
+2. **For Guzzle**: Use Guzzle's native handler support with VCR
+3. **For legacy code**: `CurlHook` and `StreamWrapperHook` are maintained for backward compatibility
+
+## Architecture Decision
+
+The dual-hook architecture exists because:
+
+- Modern HTTP clients (Symfony, Guzzle 6+) work better with decorator/handler patterns
+- Low-level hooks are necessary for legacy code and direct curl usage
+- Code transformation hooks have inherent fragility with complex async operations
+
+**Future direction**: Prioritize high-level hooks for better maintainability and reliability.
+
+## Related Code
+
+- `VCR\VCRHttpClient` - Main Symfony HttpClient wrapper
+- `VCR\LibraryHooks\SymfonyHttpClientHook` - Hook registration
+- `VCR\LibraryHooks\CurlHook` - Low-level curl interception (legacy)
+- `VCR\Videorecorder::enableLibraryHooks()` - Hook activation mechanism

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: src/VCR/Util/SoapClient.php
 
 		-
-			message: "#^Offset 'uri' does not exist on array\\{timed_out\\: bool, blocked\\: bool, eof\\: bool, unread_bytes\\: int, stream_type\\: string, wrapper_type\\: string, wrapper_data\\: mixed, mode\\: string, \\.\\.\\.\\}\\.$#"
-			count: 1
-			path: src/VCR/Util/StreamProcessor.php
-
-		-
 			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int given\\.$#"
 			count: 1
 			path: src/VCR/Util/StreamProcessor.php
@@ -56,7 +51,12 @@ parameters:
 			path: tests/Unit/CassetteTest.php
 
 		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) with arguments 22, array\\{url\\: string, content_type\\: string\\|null, http_code\\: int, header_size\\: int, request_size\\: int, filetime\\: int, ssl_verify_result\\: int, redirect_count\\: int, \\.\\.\\.\\} and 'curl_getinfo\\(\\)…' will always evaluate to false\\.$#"
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) with arguments 24, array\\{url\\: string, content_type\\: string\\|null, http_code\\: int, header_size\\: int, request_size\\: int, filetime\\: int, ssl_verify_result\\: int, redirect_count\\: int, \\.\\.\\.\\} and 'curl_getinfo\\(\\)…' will always evaluate to false\\.$#"
+			count: 1
+			path: tests/Unit/LibraryHooks/CurlHookTest.php
+
+		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) with 'private'#"
 			count: 1
 			path: tests/Unit/LibraryHooks/CurlHookTest.php
 

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -17,7 +17,7 @@ class Cassette
     public function __construct(
         protected string $name,
         protected Configuration $config,
-        protected Storage $storage
+        protected Storage $storage,
     ) {
     }
 

--- a/src/VCR/CodeTransform/SymfonyHttpClientCodeTransform.php
+++ b/src/VCR/CodeTransform/SymfonyHttpClientCodeTransform.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\CodeTransform;
+
+use VCR\Util\Assertion;
+
+/**
+ * Code transformation for Symfony HttpClient.
+ *
+ * Transforms instantiations of Symfony HttpClient classes to use VCR's wrapper:
+ *   new CurlHttpClient() → \VCR\LibraryHooks\SymfonyHttpClientHook::createCurl()
+ *   new NativeHttpClient() → \VCR\LibraryHooks\SymfonyHttpClientHook::createNative()
+ *   HttpClient::create() → \VCR\LibraryHooks\SymfonyHttpClientHook::create()
+ */
+class SymfonyHttpClientCodeTransform extends AbstractCodeTransform
+{
+    public const NAME = 'vcr_symfony_http_client';
+
+    /**
+     * @var array<string, string>
+     */
+    private static $patterns = [
+        // Match: \Symfony\Component\HttpClient\HttpClient::create(...) - most specific first
+        '/\b\\\?Symfony\\\Component\\\HttpClient\\\HttpClient::create\s*\(/i' => '\VCR\LibraryHooks\SymfonyHttpClientHook::create(',
+
+        // Match: new \Symfony\Component\HttpClient\CurlHttpClient(...)
+        '/\bnew\s+\\\?Symfony\\\Component\\\HttpClient\\\CurlHttpClient\s*\(/i' => '\VCR\LibraryHooks\SymfonyHttpClientHook::createCurl(',
+
+        // Match: new \Symfony\Component\HttpClient\NativeHttpClient(...)
+        '/\bnew\s+\\\?Symfony\\\Component\\\HttpClient\\\NativeHttpClient\s*\(/i' => '\VCR\LibraryHooks\SymfonyHttpClientHook::createNative(',
+
+        // Match: HttpClient::create(...) - specifically Symfony's HttpClient
+        '/\bHttpClient::create\s*\(/i' => '\VCR\LibraryHooks\SymfonyHttpClientHook::create(',
+
+        // Match: new CurlHttpClient(...) but not: $this->new, class::new, etc.
+        '/\bnew\s+CurlHttpClient\s*\(/i' => '\VCR\LibraryHooks\SymfonyHttpClientHook::createCurl(',
+
+        // Match: new NativeHttpClient(...)
+        '/\bnew\s+NativeHttpClient\s*\(/i' => '\VCR\LibraryHooks\SymfonyHttpClientHook::createNative(',
+    ];
+
+    protected function transformCode(string $code): string
+    {
+        $transformedCode = preg_replace(array_keys(self::$patterns), array_values(self::$patterns), $code);
+        Assertion::string($transformedCode);
+
+        return $transformedCode;
+    }
+}

--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -43,6 +43,7 @@ class Configuration
         'stream_wrapper' => 'VCR\LibraryHooks\StreamWrapperHook',
         'curl' => 'VCR\LibraryHooks\CurlHook',
         'soap' => 'VCR\LibraryHooks\SoapHook',
+        'symfony_http_client' => 'VCR\LibraryHooks\SymfonyHttpClientHook',
     ];
 
     /**
@@ -120,7 +121,14 @@ class Configuration
      *
      * @var string[] a blacklist is a list of paths
      */
-    private $blackList = ['src/VCR/LibraryHooks/', 'src/VCR/Util/SoapClient', 'tests/VCR/Filter'];
+    private $blackList = [
+        'src/VCR/LibraryHooks/',
+        'src/VCR/Util/SoapClient',
+        'tests/VCR/Filter',
+        'var/cache/',
+        'bootstrap/cache/',
+        'cache/',
+    ];
 
     private string $mode = VCR::MODE_NEW_EPISODES;
 

--- a/src/VCR/Event/AfterHttpRequestEvent.php
+++ b/src/VCR/Event/AfterHttpRequestEvent.php
@@ -11,7 +11,7 @@ class AfterHttpRequestEvent extends Event
 {
     public function __construct(
         protected Request $request,
-        protected Response $response
+        protected Response $response,
     ) {
     }
 

--- a/src/VCR/Event/AfterPlaybackEvent.php
+++ b/src/VCR/Event/AfterPlaybackEvent.php
@@ -13,7 +13,7 @@ class AfterPlaybackEvent extends Event
     public function __construct(
         protected Request $request,
         protected Response $response,
-        protected Cassette $cassette
+        protected Cassette $cassette,
     ) {
     }
 

--- a/src/VCR/Event/BeforeHttpRequestEvent.php
+++ b/src/VCR/Event/BeforeHttpRequestEvent.php
@@ -9,7 +9,7 @@ use VCR\Request;
 class BeforeHttpRequestEvent extends Event
 {
     public function __construct(
-        protected Request $request
+        protected Request $request,
     ) {
     }
 

--- a/src/VCR/Event/BeforePlaybackEvent.php
+++ b/src/VCR/Event/BeforePlaybackEvent.php
@@ -11,7 +11,7 @@ class BeforePlaybackEvent extends Event
 {
     public function __construct(
         protected Request $request,
-        protected Cassette $cassette
+        protected Cassette $cassette,
     ) {
     }
 

--- a/src/VCR/Event/BeforeRecordEvent.php
+++ b/src/VCR/Event/BeforeRecordEvent.php
@@ -13,7 +13,7 @@ class BeforeRecordEvent extends Event
     public function __construct(
         protected Request $request,
         protected Response $response,
-        protected Cassette $cassette
+        protected Cassette $cassette,
     ) {
     }
 

--- a/src/VCR/Http/NormalizedResponseWrapper.php
+++ b/src/VCR/Http/NormalizedResponseWrapper.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Http;
+
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Wrapper that normalizes TransportException messages from Symfony HttpClient.
+ *
+ * This wrapper catches lazy exceptions (thrown by CurlHttpClient when accessing
+ * response data) and normalizes them to remove trailing slashes from URLs.
+ */
+class NormalizedResponseWrapper implements ResponseInterface
+{
+    private ResponseInterface $response;
+    /** @var callable */
+    private $normalizer;
+
+    /**
+     * @param ResponseInterface $response   Original response to wrap
+     * @param callable          $normalizer Callable that normalizes TransportException
+     */
+    public function __construct(ResponseInterface $response, callable $normalizer)
+    {
+        $this->response = $response;
+        $this->normalizer = $normalizer;
+    }
+
+    public function getStatusCode(): int
+    {
+        try {
+            return $this->response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw \call_user_func($this->normalizer, $e);
+        }
+    }
+
+    public function getHeaders(bool $throw = true): array
+    {
+        try {
+            return $this->response->getHeaders($throw);
+        } catch (TransportExceptionInterface $e) {
+            throw \call_user_func($this->normalizer, $e);
+        }
+    }
+
+    public function getContent(bool $throw = true): string
+    {
+        try {
+            return $this->response->getContent($throw);
+        } catch (TransportExceptionInterface $e) {
+            throw \call_user_func($this->normalizer, $e);
+        }
+    }
+
+    /**
+     * @return array<string|int, mixed>
+     */
+    public function toArray(bool $throw = true): array
+    {
+        try {
+            return $this->response->toArray($throw);
+        } catch (TransportExceptionInterface $e) {
+            throw \call_user_func($this->normalizer, $e);
+        }
+    }
+
+    public function cancel(): void
+    {
+        $this->response->cancel();
+    }
+
+    public function getInfo(?string $type = null): mixed
+    {
+        return $this->response->getInfo($type);
+    }
+}

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -56,7 +56,7 @@ class CurlHook implements LibraryHook
 
     public function __construct(
         private AbstractCodeTransform $codeTransformer,
-        private StreamProcessor $processor
+        private StreamProcessor $processor,
     ) {
     }
 
@@ -106,22 +106,22 @@ class CurlHook implements LibraryHook
     /**
      * Calls the intercepted curl method if library hook is disabled, otherwise the real one.
      *
-     * @param string $method cURL method to call, example: curl_info()
-     * @param array<int,mixed> $args cURL arguments for this function
+     * @param string           $method cURL method to call, example: curl_info()
+     * @param array<int,mixed> $args   cURL arguments for this function
      *
      * @return mixed cURL function return type
      */
     public static function __callStatic(string $method, array $args)
     {
-        // Call original when disabled
         if (self::DISABLED == static::$status) {
             if ('curl_multi_exec' === $method) {
-                // curl_multi_exec expects to be called with args by reference
-                // which call_user_func_array doesn't do.
                 return curl_multi_exec($args[0], $args[1]);
             }
 
-            /** @var callable $method */
+            if (!\function_exists($method)) {
+                trigger_error("Call to undefined function {$method}()", \E_USER_ERROR);
+            }
+
             return \call_user_func_array($method, $args);
         }
 

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -77,6 +77,22 @@ class CurlHook implements LibraryHook
 
     public function disable(): void
     {
+        // Clean up handles where callbacks have been set to NULL to prevent stale state.
+        // Note: isset() returns false for null values, so we use array_key_exists().
+        foreach (self::$curlOptions as $handleId => $options) {
+            $writeIsNull = \array_key_exists(\CURLOPT_WRITEFUNCTION, $options) && null === $options[\CURLOPT_WRITEFUNCTION];
+            $headerIsNull = \array_key_exists(\CURLOPT_HEADERFUNCTION, $options) && null === $options[\CURLOPT_HEADERFUNCTION];
+            $hasNullCallbacks = $writeIsNull || $headerIsNull;
+
+            if ($hasNullCallbacks) {
+                unset(self::$requests[$handleId]);
+                unset(self::$responses[$handleId]);
+                unset(self::$curlOptions[$handleId]);
+                unset(self::$lastErrors[$handleId]);
+                unset(self::$multiReturnValues[$handleId]);
+            }
+        }
+
         self::$requestCallback = null;
 
         static::$status = self::DISABLED;
@@ -90,12 +106,12 @@ class CurlHook implements LibraryHook
     /**
      * Calls the intercepted curl method if library hook is disabled, otherwise the real one.
      *
-     * @param callable&string  $method cURL method to call, example: curl_info()
-     * @param array<int,mixed> $args   cURL arguments for this function
+     * @param string $method cURL method to call, example: curl_info()
+     * @param array<int,mixed> $args cURL arguments for this function
      *
      * @return mixed cURL function return type
      */
-    public static function __callStatic($method, array $args)
+    public static function __callStatic(string $method, array $args)
     {
         // Call original when disabled
         if (self::DISABLED == static::$status) {
@@ -105,6 +121,7 @@ class CurlHook implements LibraryHook
                 return curl_multi_exec($args[0], $args[1]);
             }
 
+            /** @var callable $method */
             return \call_user_func_array($method, $args);
         }
 
@@ -130,8 +147,10 @@ class CurlHook implements LibraryHook
     {
         $curlHandle = curl_init($url);
         if (false !== $curlHandle) {
-            self::$requests[(int) $curlHandle] = new Request('GET', $url);
-            self::$curlOptions[(int) $curlHandle] = [];
+            $handleId = (int) $curlHandle;
+
+            self::$requests[$handleId] = new Request('GET', $url);
+            self::$curlOptions[$handleId] = [];
         }
 
         return $curlHandle;
@@ -146,6 +165,33 @@ class CurlHook implements LibraryHook
         self::$requests[(int) $curlHandle] = new Request('GET', null);
         self::$curlOptions[(int) $curlHandle] = [];
         unset(self::$responses[(int) $curlHandle]);
+        unset(self::$lastErrors[(int) $curlHandle]);
+        unset(self::$multiReturnValues[(int) $curlHandle]);
+    }
+
+    /**
+     * Close a cURL handle.
+     *
+     * @see http://www.php.net/manual/en/function.curl-close.php
+     */
+    public static function curlClose(\CurlHandle $curlHandle): void
+    {
+        $handleId = (int) $curlHandle;
+
+        curl_setopt($curlHandle, \CURLOPT_WRITEFUNCTION, null);
+        curl_setopt($curlHandle, \CURLOPT_HEADERFUNCTION, null);
+
+        unset(self::$requests[$handleId]);
+        unset(self::$responses[$handleId]);
+        unset(self::$curlOptions[$handleId]);
+        unset(self::$lastErrors[$handleId]);
+        unset(self::$multiReturnValues[$handleId]);
+
+        foreach (self::$multiHandles as $multiId => $handles) {
+            unset(self::$multiHandles[$multiId][$handleId]);
+        }
+
+        curl_close($curlHandle);
     }
 
     /**
@@ -160,17 +206,34 @@ class CurlHook implements LibraryHook
     public static function curlExec(\CurlHandle $curlHandle)
     {
         try {
-            $request = self::$requests[(int) $curlHandle];
+            $handleId = (int) $curlHandle;
+
+            if (!isset(self::$requests[$handleId])) {
+                self::$requests[$handleId] = new Request('GET', null);
+            }
+
+            if (!isset(self::$curlOptions[$handleId])) {
+                self::$curlOptions[$handleId] = [];
+            }
+
+            // Snapshot curl options before execution. TraceableHttpClient may set callbacks to NULL
+            // during handleOutput, causing options to be modified mid-execution.
+            $curlOptionsSnapshot = self::$curlOptions[$handleId] ?? [];
+
+            $request = self::$requests[$handleId];
             CurlHelper::validateCurlPOSTBody($request, $curlHandle);
 
             $requestCallback = self::$requestCallback;
             Assertion::isCallable($requestCallback);
-            self::$responses[(int) $curlHandle] = $requestCallback($request);
+            self::$responses[$handleId] = $requestCallback($request);
 
+            // Use snapshot to prevent reading stale data from the real curl handle.
+            // Gzip decompression is handled in CurlHelper::handleOutput().
             return CurlHelper::handleOutput(
-                self::$responses[(int) $curlHandle],
-                self::$curlOptions[(int) $curlHandle],
-                $curlHandle
+                self::$responses[$handleId],
+                $curlOptionsSnapshot,
+                $curlHandle,
+                $curlOptionsSnapshot[\CURLOPT_PRIVATE] ?? null
             );
         } catch (CurlException $e) {
             self::$lastErrors[(int) $curlHandle] = $e;
@@ -221,6 +284,8 @@ class CurlHook implements LibraryHook
             }
         }
 
+        $stillRunning = 0;
+
         return \CURLM_OK;
     }
 
@@ -234,10 +299,17 @@ class CurlHook implements LibraryHook
     public static function curlMultiInfoRead()
     {
         if (!empty(self::$multiExecLastChs)) {
+            $handle = array_pop(self::$multiExecLastChs);
+            $result = \CURLE_OK;
+
+            if (isset(self::$lastErrors[(int) $handle])) {
+                $result = self::$lastErrors[(int) $handle]->getCode();
+            }
+
             $info = [
                 'msg' => \CURLMSG_DONE,
-                'handle' => array_pop(self::$multiExecLastChs),
-                'result' => \CURLE_OK,
+                'handle' => $handle,
+                'result' => $result,
             ];
 
             return $info;
@@ -265,16 +337,34 @@ class CurlHook implements LibraryHook
      */
     public static function curlGetinfo(\CurlHandle $curlHandle, int $option = 0): mixed
     {
-        if (isset(self::$responses[(int) $curlHandle])) {
-            return CurlHelper::getCurlOptionFromResponse(
-                self::$responses[(int) $curlHandle],
+        $handleId = (int) $curlHandle;
+
+        // Special handling for CURLINFO_PRIVATE to return the value we stored.
+        if (\CURLINFO_PRIVATE === $option
+            && isset(self::$curlOptions[$handleId])
+            && isset(self::$curlOptions[$handleId][\CURLOPT_PRIVATE])) {
+            $value = self::$curlOptions[$handleId][\CURLOPT_PRIVATE];
+
+            return $value;
+        }
+        if (isset(self::$responses[$handleId])) {
+            $result = CurlHelper::getCurlOptionFromResponse(
+                self::$responses[$handleId],
                 $option
             );
-        } elseif (isset(self::$lastErrors[(int) $curlHandle])) {
-            return self::$lastErrors[(int) $curlHandle]->getInfo();
-        } else {
-            throw new \RuntimeException('Unexpected error, could not find curl_getinfo in response or errors');
+
+            return $result;
         }
+
+        // Fallback to real curl_getinfo when no VCR response is available yet.
+        if (0 === $option) {
+            $info = curl_getinfo($curlHandle);
+
+            return $info;
+        }
+        $result = curl_getinfo($curlHandle, $option);
+
+        return $result;
     }
 
     /**
@@ -286,9 +376,22 @@ class CurlHook implements LibraryHook
      */
     public static function curlSetopt(\CurlHandle $curlHandle, int $option, $value): bool
     {
-        CurlHelper::setCurlOptionOnRequest(self::$requests[(int) $curlHandle], $option, $value);
+        $handleId = (int) $curlHandle;
 
-        static::$curlOptions[(int) $curlHandle][$option] = $value;
+        if (!isset(self::$requests[$handleId])) {
+            self::$requests[$handleId] = new Request('GET', null);
+        }
+
+        if (!isset(self::$curlOptions[$handleId])) {
+            self::$curlOptions[$handleId] = [];
+        }
+
+        // Note: Symfony HttpClient decompresses gzip responses internally based on the Accept-Encoding
+        // header it sends. When VCR replays a gzipped response, Symfony expects it already decompressed
+        // but receives it compressed, causing a mismatch. We use VCRHttpClient wrapper for proper handling.
+        CurlHelper::setCurlOptionOnRequest(self::$requests[$handleId], $option, $value);
+
+        static::$curlOptions[$handleId][$option] = $value;
 
         return curl_setopt($curlHandle, $option, $value);
     }

--- a/src/VCR/LibraryHooks/SoapHook.php
+++ b/src/VCR/LibraryHooks/SoapHook.php
@@ -21,7 +21,7 @@ class SoapHook implements LibraryHook
      */
     public function __construct(
         private AbstractCodeTransform $codeTransformer,
-        private StreamProcessor $processor
+        private StreamProcessor $processor,
     ) {
         if (!class_exists('\SoapClient')) {
             throw new \BadMethodCallException('For soap support you need to install the soap extension.');

--- a/src/VCR/LibraryHooks/StreamMetaDataProxy.php
+++ b/src/VCR/LibraryHooks/StreamMetaDataProxy.php
@@ -27,7 +27,7 @@ use VCR\LibraryHooks\StreamWrapperHook;
  */
 function stream_get_meta_data($stream): array
 {
-    $metadata = \stream_get_meta_data($stream);
+    $metadata = stream_get_meta_data($stream);
 
     // If wrapper_data is a StreamWrapperHook object, extract the actual array
     // StreamWrapperHook has a public $wrapper_data property, so no reflection needed

--- a/src/VCR/LibraryHooks/StreamMetaDataProxy.php
+++ b/src/VCR/LibraryHooks/StreamMetaDataProxy.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Stream metadata proxy functions for Symfony HttpClient compatibility.
+ *
+ * These functions are automatically used by PHP when they exist in a namespace.
+ * They wrap the global stream_get_meta_data() function to transform VCR's
+ * StreamWrapperHook object into an array for Symfony's NativeHttpClient.
+ */
+
+namespace Symfony\Component\HttpClient\Response;
+
+use VCR\LibraryHooks\StreamWrapperHook;
+
+/**
+ * Proxy for stream_get_meta_data() that handles VCR's StreamWrapperHook.
+ *
+ * When VCR intercepts streams, stream_get_meta_data() returns a StreamWrapperHook
+ * object in the 'wrapper_data' key instead of an array. This function detects
+ * this and extracts the actual array from the wrapper object.
+ *
+ * @param resource $stream
+ *
+ * @return array<string,mixed>
+ */
+function stream_get_meta_data($stream): array
+{
+    $metadata = \stream_get_meta_data($stream);
+
+    // If wrapper_data is a StreamWrapperHook object, extract the actual array
+    // StreamWrapperHook has a public $wrapper_data property, so no reflection needed
+    if (isset($metadata['wrapper_data']) && $metadata['wrapper_data'] instanceof StreamWrapperHook) {
+        $metadata['wrapper_data'] = $metadata['wrapper_data']->wrapper_data;
+    }
+
+    return $metadata;
+}

--- a/src/VCR/LibraryHooks/StreamWrapperHook.php
+++ b/src/VCR/LibraryHooks/StreamWrapperHook.php
@@ -7,6 +7,7 @@ namespace VCR\LibraryHooks;
 use VCR\Response;
 use VCR\Util\Assertion;
 use VCR\Util\CurlException;
+use VCR\Util\HttpUtil;
 use VCR\Util\StreamHelper;
 
 class StreamWrapperHook implements LibraryHook
@@ -24,9 +25,23 @@ class StreamWrapperHook implements LibraryHook
      */
     public $context;
 
+    /**
+     * @var array<int,string> HTTP response headers for stream_get_meta_data()
+     *
+     * This public property is automatically included by PHP when stream_get_meta_data()
+     * is called on this stream wrapper. Symfony NativeHttpClient relies on this to
+     * read response headers.
+     */
+    public array $wrapper_data = [];
+
     public function enable(\Closure $requestCallback): void
     {
         self::$requestCallback = $requestCallback;
+
+        // Load the stream_get_meta_data() proxy for Symfony HttpClient compatibility
+        // This must be loaded before Symfony uses it
+        require_once __DIR__.'/StreamMetaDataProxy.php';
+
         stream_wrapper_unregister('http');
         stream_wrapper_register('http', __CLASS__, \STREAM_IS_URL);
 
@@ -64,12 +79,22 @@ class StreamWrapperHook implements LibraryHook
      */
     public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
     {
-        $request = StreamHelper::createRequestFromStreamContext($this->context, $path);
-
         $requestCallback = self::$requestCallback;
-        Assertion::isCallable($requestCallback);
+        Assertion::isCallable($requestCallback, 'Request callback must be set before opening stream');
+
+        $request = StreamHelper::createRequestFromStreamContext($this->context, $path);
+        Assertion::isInstanceOf($request, \VCR\Request::class, 'StreamHelper must return a valid Request object');
+
         try {
             $this->response = $requestCallback($request);
+
+            // Populate wrapper_data for Symfony NativeHttpClient
+            // This must be in the format: ["HTTP/1.1 200 OK", "Header: value", ...]
+            $this->wrapper_data = [];
+            $this->wrapper_data[] = HttpUtil::formatAsStatusString($this->response);
+            foreach (HttpUtil::formatHeadersForCurl($this->response->getHeaders()) as $header) {
+                $this->wrapper_data[] = $header;
+            }
 
             return true;
         } catch (CurlException $e) {
@@ -198,5 +223,23 @@ class StreamWrapperHook implements LibraryHook
     public function stream_metadata(string $path, int $option, $var): bool
     {
         return false;
+    }
+
+    /**
+     * Change stream options.
+     *
+     * @see http://www.php.net/manual/en/streamwrapper.stream-set-option.php
+     *
+     * @param int      $option one of STREAM_OPTION_BLOCKING, STREAM_OPTION_READ_TIMEOUT, STREAM_OPTION_WRITE_BUFFER
+     * @param int      $arg1   depends on option
+     * @param int|null $arg2   depends on option
+     *
+     * @return bool returns TRUE on success or FALSE on failure
+     */
+    public function stream_set_option(int $option, int $arg1, ?int $arg2): bool
+    {
+        // We don't need to actually implement these options for VCR's purposes
+        // Just return true to indicate success
+        return true;
     }
 }

--- a/src/VCR/LibraryHooks/SymfonyHttpClientHook.php
+++ b/src/VCR/LibraryHooks/SymfonyHttpClientHook.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\LibraryHooks;
+
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use VCR\CodeTransform\AbstractCodeTransform;
+use VCR\Util\StreamProcessor;
+use VCR\VCRHttpClient;
+
+/**
+ * Hook for Symfony HttpClient.
+ *
+ * This hook uses code transformation to automatically wrap Symfony HttpClient
+ * instances with VCRHttpClient, avoiding timing issues with gzip decompression.
+ *
+ * When enabled, it transforms:
+ *   new CurlHttpClient() → \VCR\LibraryHooks\SymfonyHttpClientHook::createCurl()
+ */
+class SymfonyHttpClientHook implements LibraryHook
+{
+    protected static string $status = self::DISABLED;
+    protected static ?\Closure $requestCallback = null;
+
+    /**
+     * @var array<int, VCRHttpClient> Wrapped clients
+     */
+    protected static array $wrappedClients = [];
+
+    public function __construct(
+        private AbstractCodeTransform $codeTransformer,
+        private StreamProcessor $processor
+    ) {
+    }
+
+    public function enable(\Closure $requestCallback): void
+    {
+        if (self::ENABLED == static::$status) {
+            return;
+        }
+
+        $this->codeTransformer->register();
+        $this->processor->appendCodeTransformer($this->codeTransformer);
+        $this->processor->intercept();
+
+        self::$requestCallback = $requestCallback;
+        static::$status = self::ENABLED;
+    }
+
+    public function disable(): void
+    {
+        self::$requestCallback = null;
+        self::$wrappedClients = [];
+        static::$status = self::DISABLED;
+    }
+
+    public function isEnabled(): bool
+    {
+        return self::ENABLED == self::$status;
+    }
+
+    /**
+     * Get the request callback.
+     */
+    public static function getRequestCallback(): ?\Closure
+    {
+        return self::$requestCallback;
+    }
+
+    /**
+     * Create a VCR-compatible CurlHttpClient.
+     *
+     * This is a convenience method that automatically wraps the client
+     * with VCRHttpClient to avoid Symfony's inflate issues.
+     *
+     * Usage in tests:
+     *   $client = \VCR\LibraryHooks\SymfonyHttpClientHook::createCurl();
+     *
+     * @param array<string, mixed> $options HttpClient options
+     */
+    public static function createCurl(array $options = []): VCRHttpClient
+    {
+        return new VCRHttpClient(new CurlHttpClient($options));
+    }
+
+    /**
+     * Create a VCR-compatible NativeHttpClient.
+     *
+     * This is a convenience method that automatically wraps the client
+     * with VCRHttpClient to avoid Symfony's inflate issues.
+     *
+     * Usage in tests:
+     *   $client = \VCR\LibraryHooks\SymfonyHttpClientHook::createNative();
+     *
+     * @param array<string, mixed> $options HttpClient options
+     */
+    public static function createNative(array $options = []): VCRHttpClient
+    {
+        return new VCRHttpClient(new NativeHttpClient($options));
+    }
+
+    /**
+     * Create a VCR-compatible HttpClient using Symfony's factory.
+     *
+     * This wraps Symfony\Component\HttpClient\HttpClient::create() to return
+     * a VCRHttpClient instead. Works with code transformation.
+     *
+     * Usage in tests:
+     *   $client = \VCR\LibraryHooks\SymfonyHttpClientHook::create();
+     *
+     * @param array<string, mixed> $options HttpClient options
+     */
+    public static function create(array $options = []): VCRHttpClient
+    {
+        return new VCRHttpClient(\Symfony\Component\HttpClient\HttpClient::create($options));
+    }
+}

--- a/src/VCR/LibraryHooks/SymfonyHttpClientHook.php
+++ b/src/VCR/LibraryHooks/SymfonyHttpClientHook.php
@@ -31,7 +31,7 @@ class SymfonyHttpClientHook implements LibraryHook
 
     public function __construct(
         private AbstractCodeTransform $codeTransformer,
-        private StreamProcessor $processor
+        private StreamProcessor $processor,
     ) {
     }
 

--- a/src/VCR/PHPUnit/SymfonyHttpClientTestTrait.php
+++ b/src/VCR/PHPUnit/SymfonyHttpClientTestTrait.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\PHPUnit;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * PHPUnit trait to simplify Symfony HttpClient testing with VCR.
+ *
+ * This trait automatically wraps Symfony HttpClient instances with VCRHttpClient,
+ * making VCR integration transparent for tests.
+ *
+ * Usage:
+ * ```php
+ * class MyApiTest extends TestCase
+ * {
+ *     use SymfonyHttpClientTestTrait;
+ *
+ *     public function testApiCall(): void
+ *     {
+ *         $client = $this->createHttpClient(); // Automatically wrapped!
+ *         $response = $client->request('GET', 'https://api.example.com/data');
+ *         // ...
+ *     }
+ * }
+ * ```
+ */
+trait SymfonyHttpClientTestTrait
+{
+    /**
+     * Create a VCR-compatible Symfony HttpClient.
+     *
+     * @param string              $type    'curl' or 'native'
+     * @param array<string,mixed> $options HttpClient options
+     */
+    protected function createHttpClient(string $type = 'curl', array $options = []): HttpClientInterface
+    {
+        // Use SymfonyHttpClientHook factory methods for consistent behavior
+        return match ($type) {
+            'native' => \VCR\LibraryHooks\SymfonyHttpClientHook::createNative($options),
+            default => \VCR\LibraryHooks\SymfonyHttpClientHook::createCurl($options),
+        };
+    }
+
+    /**
+     * Create a CurlHttpClient wrapped for VCR.
+     *
+     * This method creates a VCR-compatible Symfony CurlHttpClient.
+     * The client is automatically wrapped to avoid Symfony's inflate issues.
+     *
+     * @param array<string,mixed> $options
+     */
+    protected function createCurlHttpClient(array $options = []): HttpClientInterface
+    {
+        return $this->createHttpClient('curl', $options);
+    }
+
+    /**
+     * Create a NativeHttpClient wrapped for VCR.
+     *
+     * This method creates a VCR-compatible Symfony NativeHttpClient.
+     * The client is automatically wrapped to avoid Symfony's inflate issues.
+     *
+     * @param array<string,mixed> $options
+     */
+    protected function createNativeHttpClient(array $options = []): HttpClientInterface
+    {
+        return $this->createHttpClient('native', $options);
+    }
+}

--- a/src/VCR/Request.php
+++ b/src/VCR/Request.php
@@ -35,7 +35,7 @@ class Request
     public function __construct(
         protected string $method,
         protected ?string $url,
-        protected array $headers = []
+        protected array $headers = [],
     ) {
         $this->method = $method;
         $this->headers = $headers;

--- a/src/VCR/Request.php
+++ b/src/VCR/Request.php
@@ -83,10 +83,16 @@ class Request
      */
     public static function fromArray(array $request): self
     {
+        Assertion::keyExists($request, 'method', 'Request array must contain "method" key');
+        Assertion::keyExists($request, 'url', 'Request array must contain "url" key');
+
+        $headers = $request['headers'] ?? [];
+        Assertion::isArray($headers, 'Request headers must be an array');
+
         $requestObject = new self(
             $request['method'],
             $request['url'],
-            $request['headers'] ?? []
+            $headers
         );
 
         if (!empty($request['post_fields']) && \is_array($request['post_fields'])) {

--- a/src/VCR/RequestMatcher.php
+++ b/src/VCR/RequestMatcher.php
@@ -24,8 +24,17 @@ class RequestMatcher
     public static function matchHeaders(Request $storedRequest, Request $request): bool
     {
         // Use array_filter to ignore headers which are null.
+        // Also ignore Accept-Encoding header for Symfony HttpClient compatibility
+        // Symfony adds this header automatically, but VCR handles decompression transparently
 
-        return array_filter($storedRequest->getHeaders()) === array_filter($request->getHeaders());
+        $normalizeHeaders = function (array $headers): array {
+            $normalized = array_filter($headers);
+            unset($normalized['Accept-Encoding']);
+
+            return $normalized;
+        };
+
+        return $normalizeHeaders($storedRequest->getHeaders()) === $normalizeHeaders($request->getHeaders());
     }
 
     public static function matchBody(Request $storedRequest, Request $request): bool

--- a/src/VCR/Response.php
+++ b/src/VCR/Response.php
@@ -82,6 +82,8 @@ class Response
     public static function fromArray(array $response): self
     {
         $body = $response['body'] ?? null;
+        $headers = $response['headers'] ?? [];
+        Assertion::isArray($headers, 'Response headers must be an array');
 
         $gzip = isset($response['headers']['Content-Type'])
             && str_contains($response['headers']['Content-Type'], 'application/x-gzip');
@@ -96,7 +98,7 @@ class Response
 
         return new static(
             $response['status'] ?? 200,
-            $response['headers'] ?? [],
+            $headers,
             $body,
             $response['curl_info'] ?? []
         );

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -13,7 +13,6 @@ class CurlHelper
      * @var array<int, string> list of cURL info constants
      */
     private static $curlInfoList = [
-        // "certinfo"?
         \CURLINFO_HTTP_CODE => 'http_code',
         \CURLINFO_EFFECTIVE_URL => 'url',
         \CURLINFO_TOTAL_TIME => 'total_time',
@@ -36,6 +35,8 @@ class CurlHelper
         \CURLINFO_CONTENT_LENGTH_UPLOAD => 'upload_content_length',
         \CURLINFO_CONTENT_TYPE => 'content_type',
         \CURLINFO_APPCONNECT_TIME => 'appconnect_time',
+        \CURLINFO_PRIVATE => 'private',
+        \CURLINFO_CERTINFO => 'certinfo',
     ];
 
     /**
@@ -47,14 +48,21 @@ class CurlHelper
      * The response header might be passed to a custom function.
      *
      * @param array<int, mixed> $curlOptions cURL options which are not stored within the Response
+     * @param string|null       $privateData CURLOPT_PRIVATE value from snapshot (prevents reading stale data from real handle)
      */
-    public static function handleOutput(Response $response, array $curlOptions, \CurlHandle $ch): ?string
+    public static function handleOutput(Response $response, array $curlOptions, \CurlHandle $ch, ?string $privateData = null): ?string
     {
         // If there is a header function set, feed the http status and headers to it.
         if (isset($curlOptions[\CURLOPT_HEADERFUNCTION])) {
-            $headerList = [HttpUtil::formatAsStatusString($response)];
-            $headerList = array_merge($headerList, HttpUtil::formatHeadersForCurl($response->getHeaders()));
-            $headerList[] = '';
+            $headerList = [HttpUtil::formatAsStatusString($response)."\r\n"];
+
+            // Get headers as-is from the response
+            // Note: For Symfony HttpClient, gzip decompression is handled in VCRHttpClient
+            foreach (HttpUtil::formatHeadersForCurl($response->getHeaders()) as $header) {
+                $headerList[] = $header."\r\n";
+            }
+            $headerList[] = "\r\n"; // Empty line to signal end of headers
+
             foreach ($headerList as $header) {
                 self::callFunction($curlOptions[\CURLOPT_HEADERFUNCTION], $ch, $header);
             }
@@ -66,7 +74,13 @@ class CurlHelper
             $body = HttpUtil::formatAsStatusWithHeadersString($response).$body;
         }
 
-        if (isset($curlOptions[\CURLOPT_WRITEFUNCTION])) {
+        // Handle Symfony HttpClient CURLOPT_PRIVATE state management
+        $noContentExpected = SymfonyHttpClientHelper::expectsNoContent($ch, $privateData);
+
+        if (isset($curlOptions[\CURLOPT_WRITEFUNCTION]) && !$noContentExpected) {
+            // Transition from Headers to Content phase for Symfony HttpClient
+            SymfonyHttpClientHelper::transitionToContentPhase($ch, $privateData);
+
             self::callFunction($curlOptions[\CURLOPT_WRITEFUNCTION], $ch, $body);
         } elseif (isset($curlOptions[\CURLOPT_RETURNTRANSFER]) && true == $curlOptions[\CURLOPT_RETURNTRANSFER]) {
             return $body;
@@ -74,7 +88,8 @@ class CurlHelper
             $fp = $curlOptions[\CURLOPT_FILE];
             fwrite($fp, $body);
             fflush($fp);
-        } else {
+        } elseif (!$noContentExpected) {
+            // Only echo if content is expected
             echo $body;
         }
 
@@ -109,6 +124,12 @@ class CurlHelper
             case \CURLPROXY_HTTPS:
             case \CURLINFO_APPCONNECT_TIME:
                 $info = '';
+                break;
+            case \CURLINFO_PRIVATE:
+                $info = $response->getCurlInfo(self::$curlInfoList[$option]) ?? false;
+                break;
+            case \CURLINFO_CERTINFO:
+                $info = $response->getCurlInfo(self::$curlInfoList[$option]) ?? [];
                 break;
             default:
                 $info = $response->getCurlInfo(self::$curlInfoList[$option]);

--- a/src/VCR/Util/HttpClient.php
+++ b/src/VCR/Util/HttpClient.php
@@ -41,12 +41,13 @@ class HttpClient
             throw CurlException::create($ch);
         }
         [$status, $headers, $body] = HttpUtil::parseResponse($result);
+        $curlInfo = curl_getinfo($ch);
 
         return new Response(
             HttpUtil::parseStatus($status),
             HttpUtil::parseHeaders($headers),
             $body,
-            curl_getinfo($ch)
+            $curlInfo
         );
     }
 }

--- a/src/VCR/Util/StreamHelper.php
+++ b/src/VCR/Util/StreamHelper.php
@@ -30,9 +30,24 @@ class StreamHelper
         }
 
         if (!empty($http['header'])) {
-            $headers = HttpUtil::parseHeaders(HttpUtil::parseRawHeader($http['header']));
+            // Handle both string and array formats
+            // Symfony NativeHttpClient may pass headers as array instead of string
+            if (\is_string($http['header'])) {
+                $headers = HttpUtil::parseHeaders(HttpUtil::parseRawHeader($http['header']));
+            } else {
+                Assertion::isArray($http['header'], 'HTTP headers must be either string or array');
+                $headers = HttpUtil::parseHeaders($http['header']);
+            }
             foreach ($headers as $key => $value) {
                 $request->setHeader($key, $value);
+            }
+
+            // Fix for NativeHttpClient DNS resolution: reconstruct URL with hostname from Host header
+            if (isset($headers['Host'])) {
+                $reconstructedUrl = UrlReconstructor::reconstructFromHostHeader($path, $headers['Host']);
+                if (null !== $reconstructedUrl) {
+                    $request->setUrl($reconstructedUrl);
+                }
             }
         }
 

--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -257,7 +257,9 @@ class StreamProcessor
             return false;
         }
 
-        if (!$this->shouldProcess(stream_get_meta_data($this->resource)['uri'])) {
+        $meta = stream_get_meta_data($this->resource);
+
+        if (!$this->shouldProcess($meta['uri'])) {
             return fstat($this->resource);
         }
 

--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -40,7 +40,7 @@ class StreamProcessor
     /**
      * @var resource|false resource for the currently opened file
      */
-    protected $resource;
+    protected $resource = false;
 
     /**
      * @see http://www.php.net/manual/en/class.streamwrapper.php#streamwrapper.props.context

--- a/src/VCR/Util/SymfonyHttpClientHelper.php
+++ b/src/VCR/Util/SymfonyHttpClientHelper.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Util;
+
+/**
+ * Helper for Symfony HttpClient-specific cURL handling.
+ *
+ * Symfony HttpClient uses CURLOPT_PRIVATE to track response state:
+ * - 'HX' = Headers phase (X is retry count)
+ * - 'CX' = Content phase
+ * - '_X' = Done phase (no content expected)
+ */
+class SymfonyHttpClientHelper
+{
+    /**
+     * Get CURLOPT_PRIVATE value from cURL handle or use provided snapshot.
+     *
+     * @param \CurlHandle $ch       cURL handle
+     * @param string|null $snapshot Optional snapshot value to avoid reading stale data
+     *
+     * @return string|null The CURLOPT_PRIVATE value, or null if not set
+     */
+    public static function getPrivateData(\CurlHandle $ch, ?string $snapshot = null): ?string
+    {
+        if (null !== $snapshot) {
+            return $snapshot;
+        }
+
+        $value = curl_getinfo($ch, \CURLINFO_PRIVATE);
+
+        // curl_getinfo returns false if CURLOPT_PRIVATE is not set
+        return \is_string($value) ? $value : null;
+    }
+
+    /**
+     * Check if Symfony HttpClient expects no content based on CURLOPT_PRIVATE state.
+     *
+     * @param \CurlHandle $ch       cURL handle
+     * @param string|null $snapshot Optional CURLOPT_PRIVATE snapshot value
+     *
+     * @return bool True if no content is expected (state is '_X')
+     */
+    public static function expectsNoContent(\CurlHandle $ch, ?string $snapshot = null): bool
+    {
+        $privateData = self::getPrivateData($ch, $snapshot);
+
+        return \is_string($privateData) && isset($privateData[0]) && '_' === $privateData[0];
+    }
+
+    /**
+     * Transition CURLOPT_PRIVATE state from Headers (H) to Content (C).
+     *
+     * This must be called before WRITEFUNCTION callback to prevent
+     * "Unsupported protocol" error in Symfony HttpClient.
+     *
+     * @param \CurlHandle $ch       cURL handle
+     * @param string|null $snapshot Optional current CURLOPT_PRIVATE snapshot value
+     */
+    public static function transitionToContentPhase(\CurlHandle $ch, ?string $snapshot = null): void
+    {
+        $privateData = self::getPrivateData($ch, $snapshot);
+
+        if (\is_string($privateData) && isset($privateData[0]) && 'H' === $privateData[0]) {
+            // Change 'H' to 'C', keep the retry counter (second character)
+            $newPrivate = 'C'.($privateData[1] ?? '0');
+            curl_setopt($ch, \CURLOPT_PRIVATE, $newPrivate);
+        }
+    }
+}

--- a/src/VCR/Util/UrlReconstructor.php
+++ b/src/VCR/Util/UrlReconstructor.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Util;
+
+/**
+ * Helper to reconstruct URLs from Host headers.
+ *
+ * Symfony NativeHttpClient resolves DNS to IP before calling fopen().
+ * Example: jsonplaceholder.typicode.com → 188.114.97.2
+ * But the original hostname is preserved in the Host header.
+ * This class reconstructs the URL with the hostname for proper VCR matching.
+ */
+class UrlReconstructor
+{
+    /**
+     * Reconstruct URL using Host header if different from parsed host (DNS resolution case).
+     *
+     * @param string $url        Original URL (may contain IP)
+     * @param string $hostHeader Host header value (contains hostname)
+     *
+     * @return string|null Reconstructed URL with hostname, or null if no reconstruction needed
+     */
+    public static function reconstructFromHostHeader(string $url, string $hostHeader): ?string
+    {
+        $parsedUrl = parse_url($url);
+
+        if (false === $parsedUrl || !isset($parsedUrl['host'])) {
+            return null;
+        }
+
+        // Check if current URL uses a different host than the Host header
+        // This indicates DNS resolution has occurred (IP vs hostname)
+        if ($hostHeader === $parsedUrl['host']) {
+            return null; // No reconstruction needed
+        }
+
+        // Reconstruct URL with hostname from Host header instead of IP
+        $scheme = $parsedUrl['scheme'] ?? 'http';
+        $newUrl = $scheme.'://'.$hostHeader;
+
+        if (isset($parsedUrl['port']) && $parsedUrl['port'] != (('https' === $scheme) ? 443 : 80)) {
+            $newUrl .= ':'.$parsedUrl['port'];
+        }
+
+        $newUrl .= ($parsedUrl['path'] ?? '/');
+
+        if (isset($parsedUrl['query'])) {
+            $newUrl .= '?'.$parsedUrl['query'];
+        }
+
+        if (isset($parsedUrl['fragment'])) {
+            $newUrl .= '#'.$parsedUrl['fragment'];
+        }
+
+        return $newUrl;
+    }
+}

--- a/src/VCR/VCRFactory.php
+++ b/src/VCR/VCRFactory.php
@@ -7,6 +7,7 @@ namespace VCR;
 use Assert\Assertion;
 use VCR\LibraryHooks\CurlHook;
 use VCR\LibraryHooks\SoapHook;
+use VCR\LibraryHooks\SymfonyHttpClientHook;
 use VCR\Storage\Storage;
 use VCR\Util\StreamProcessor;
 
@@ -69,6 +70,14 @@ class VCRFactory
     {
         return new CurlHook(
             $this->getOrCreate('VCR\CodeTransform\CurlCodeTransform'),
+            $this->getOrCreate('VCR\Util\StreamProcessor')
+        );
+    }
+
+    protected function createVCRLibraryHooksSymfonyHttpClientHook(): SymfonyHttpClientHook
+    {
+        return new SymfonyHttpClientHook(
+            $this->getOrCreate('VCR\CodeTransform\SymfonyHttpClientCodeTransform'),
             $this->getOrCreate('VCR\Util\StreamProcessor')
         );
     }

--- a/src/VCR/VCRHttpClient.php
+++ b/src/VCR/VCRHttpClient.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR;
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+use VCR\Http\NormalizedResponseWrapper;
+
+/**
+ * VCR-aware Symfony HttpClient wrapper.
+ *
+ * This client intercepts HTTP requests at the Symfony HttpClient level
+ * (instead of at the cURL level) and plays back responses from VCR cassettes.
+ *
+ * Benefits over cURL hooks:
+ * - Avoids timing issues with Symfony's async response handling
+ * - Properly handles gzip decompression
+ * - Works with all Symfony HttpClient implementations
+ *
+ * Usage:
+ *   $client = new VCRHttpClient(new CurlHttpClient());
+ */
+class VCRHttpClient implements HttpClientInterface
+{
+    private HttpClientInterface $client;
+
+    public function __construct(HttpClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        // If VCR is active, intercept the request.
+        if ($this->isVCRActive()) {
+            return $this->handleVCRRequest($method, $url, $options);
+        }
+
+        // Otherwise, pass through to the real client.
+        // Wrap the response to normalize exceptions (Symfony may throw them lazily or immediately).
+        try {
+            $response = $this->client->request($method, $url, $options);
+        } catch (\Symfony\Component\HttpClient\Exception\TransportException $e) {
+            // Some clients (like MockHttpClient) throw immediately in request()
+            throw $this->normalizeException($e);
+        }
+
+        // Wrap response to normalize exceptions when they're thrown lazily (like CurlHttpClient)
+        return new NormalizedResponseWrapper($response, [$this, 'normalizeException']);
+    }
+
+    public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
+    {
+        $responsesArray = [];
+        $responsesIterable = is_iterable($responses) ? $responses : [$responses];
+        foreach ($responsesIterable as $response) {
+            $responsesArray[] = $response;
+        }
+
+        $allMockResponses = true;
+        foreach ($responsesArray as $response) {
+            if (!($response instanceof MockResponse)) {
+                $allMockResponses = false;
+                break;
+            }
+        }
+
+        // If all responses are MockResponse (from VCR cassettes), they're already complete.
+        // We create a simple streaming generator that yields each response.
+        if ($allMockResponses) {
+            return new class($responsesArray) implements ResponseStreamInterface {
+                /** @var array<ResponseInterface> */
+                private array $responses;
+                private int $index = 0;
+
+                /**
+                 * @param array<ResponseInterface> $responses
+                 */
+                public function __construct(array $responses)
+                {
+                    $this->responses = array_values($responses); // Re-index
+                }
+
+                public function key(): ResponseInterface
+                {
+                    return $this->responses[$this->index];
+                }
+
+                public function current(): ChunkInterface
+                {
+                    // Return a "last" chunk to signal completion for this response
+                    return new class implements ChunkInterface {
+                        public function isTimeout(): bool
+                        {
+                            return false;
+                        }
+
+                        public function isFirst(): bool
+                        {
+                            return false;
+                        }
+
+                        public function isLast(): bool
+                        {
+                            return true;
+                        }
+
+                        public function getContent(): string
+                        {
+                            return '';
+                        }
+
+                        public function getOffset(): int
+                        {
+                            return 0;
+                        }
+
+                        public function getError(): ?string
+                        {
+                            return null;
+                        }
+
+                        /**
+                         * @return array<int, string>|null
+                         */
+                        public function getInformationalStatus(): ?array
+                        {
+                            return null;
+                        }
+
+                        public function didThrow(): bool
+                        {
+                            return false;
+                        }
+                    };
+                }
+
+                public function next(): void
+                {
+                    ++$this->index;
+                }
+
+                public function rewind(): void
+                {
+                    $this->index = 0;
+                }
+
+                public function valid(): bool
+                {
+                    return $this->index < \count($this->responses);
+                }
+            };
+        }
+
+        return $this->client->stream($responses, $timeout);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function withOptions(array $options): static
+    {
+        $clone = clone $this;
+        $clone->client = $this->client->withOptions($options);
+
+        return $clone;
+    }
+
+    /**
+     * Check if VCR is active and has a cassette inserted.
+     */
+    private function isVCRActive(): bool
+    {
+        try {
+            $videorecorder = VCRFactory::get(Videorecorder::class);
+
+            if (!$videorecorder || !($videorecorder instanceof Videorecorder)) {
+                return false;
+            }
+
+            return $videorecorder->hasCassette();
+        } catch (\BadMethodCallException|\RuntimeException $e) {
+            // VCR not initialized or no cassette
+            // We intentionally swallow these exceptions to gracefully handle VCR absence
+            return false;
+        }
+    }
+
+    /**
+     * Handle request through VCR.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function handleVCRRequest(string $method, string $url, array $options): ResponseInterface
+    {
+        // Store original URL for error messages (before query params are added)
+        $originalUrl = $url;
+
+        if (isset($options['query'])) {
+            $url .= (!str_contains($url, '?') ? '?' : '&').http_build_query($options['query']);
+        }
+
+        $headers = $this->normalizeHeaders($options['headers'] ?? []);
+        $request = new Request($method, $url, $headers);
+
+        if (isset($options['body'])) {
+            $body = $options['body'];
+            // Convert array body to URL-encoded string for form data
+            if (\is_array($body)) {
+                $body = http_build_query($body);
+                if (!isset($headers['Content-Type'])) {
+                    $request->setHeader('Content-Type', 'application/x-www-form-urlencoded');
+                }
+            }
+            if (\is_string($body)) {
+                $request->setBody($body);
+            }
+        }
+
+        if (isset($options['json'])) {
+            $jsonBody = json_encode($options['json']);
+            if (\is_string($jsonBody)) {
+                $request->setBody($jsonBody);
+                $request->setHeader('Content-Type', 'application/json');
+            }
+        }
+
+        if (isset($options['auth_basic'])) {
+            $auth = $options['auth_basic'];
+            if (\is_array($auth) && \count($auth) >= 2) {
+                $request->setHeader('Authorization', 'Basic '.base64_encode($auth[0].':'.$auth[1]));
+            }
+        }
+
+        try {
+            $videorecorder = VCRFactory::get(Videorecorder::class);
+        } catch (\BadMethodCallException|\RuntimeException $e) {
+            // VCR not initialized, fall back to real client
+            // We intentionally swallow these exceptions to gracefully handle VCR absence
+            return $this->client->request($method, $url, $options);
+        }
+
+        if (!$videorecorder || !($videorecorder instanceof Videorecorder)) {
+            return $this->client->request($method, $url, $options);
+        }
+
+        try {
+            $response = $videorecorder->handleRequest($request);
+        } catch (\Exception $e) {
+            // Convert any exception to Symfony TransportException for consistency
+            $message = $e->getMessage();
+
+            // Ensure the error message matches Symfony's format
+            // Symfony doesn't add trailing slash to URLs in error messages
+            // Use regex to remove trailing slash from any quoted URL
+            $message = preg_replace('#"(https?://[^"]+)/"#', '"$1"', $message) ?? $message;
+
+            // If message doesn't already have the URL formatted, add it
+            if (!str_contains($message, ' for "')) {
+                $message .= \sprintf(' for "%s".', rtrim($originalUrl, '/'));
+            }
+
+            throw new \Symfony\Component\HttpClient\Exception\TransportException($message, 0, $e);
+        }
+
+        return $this->createMockResponse($response, $method, $url, $options);
+    }
+
+    /**
+     * Normalize exception by removing trailing slashes from URLs.
+     *
+     * Public so it can be called from the anonymous Response wrapper class.
+     */
+    public function normalizeException(\Symfony\Component\HttpClient\Exception\TransportException $e): \Symfony\Component\HttpClient\Exception\TransportException
+    {
+        $message = $e->getMessage();
+        $message = preg_replace('#"(https?://[^"]+)/"#', '"$1"', $message) ?? $message;
+
+        return new \Symfony\Component\HttpClient\Exception\TransportException($message, 0, $e);
+    }
+
+    /**
+     * Normalize headers to VCR format.
+     *
+     * @param array<int|string, string|string[]> $headers
+     *
+     * @return array<string, string>
+     */
+    private function normalizeHeaders(array $headers): array
+    {
+        $normalized = [];
+
+        foreach ($headers as $key => $value) {
+            if (\is_int($key)) {
+                // Header in format "Name: Value"
+                if (\is_string($value)) {
+                    $parts = explode(':', $value, 2);
+                    if (2 === \count($parts)) {
+                        $normalized[trim($parts[0])] = trim($parts[1]);
+                    }
+                }
+            } else {
+                // Header in format "Name" => "Value" or "Name" => ["Value1", "Value2"]
+                if (\is_array($value)) {
+                    $normalized[$key] = implode(', ', $value);
+                } elseif (\is_string($value)) {
+                    $normalized[$key] = $value;
+                }
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Create a Symfony MockResponse from a VCR Response.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function createMockResponse(Response $vcrResponse, string $method, string $url, array $options): ResponseInterface
+    {
+        $body = $vcrResponse->getBody();
+        $headers = $vcrResponse->getHeaders();
+
+        // Handle gzip decompression for Symfony HttpClient compatibility
+        // Symfony's MockResponse doesn't handle gzip decompression automatically like real HttpClients do
+        // We decompress here and remove the content-encoding header so MockResponse receives plain content
+        $contentEncoding = $headers['content-encoding'] ?? $headers['Content-Encoding'] ?? null;
+        if ('gzip' === $contentEncoding && \function_exists('gzdecode')) {
+            $decompressed = @gzdecode($body);
+            if (false !== $decompressed) {
+                $body = $decompressed;
+                // Remove content-encoding header so Symfony doesn't try to decompress again
+                unset($headers['content-encoding'], $headers['Content-Encoding']);
+                // Update content-length to match decompressed size
+                $headers['content-length'] = (string) \strlen($body);
+                $headers['Content-Length'] = (string) \strlen($body);
+            }
+        }
+
+        $responseHeaders = [];
+        foreach ($headers as $name => $value) {
+            $responseHeaders[] = $name.': '.$value;
+        }
+
+        // Create MockHttpClient with response factory callback
+        // This ensures MockResponse is properly initialized by MockHttpClient
+        $mockClient = new MockHttpClient(fn () => new MockResponse($body, [
+            'http_code' => $vcrResponse->getStatusCode(),
+            'response_headers' => $responseHeaders,
+        ]));
+
+        return $mockClient->request($method, $url, $options);
+    }
+
+    /**
+     * Sets a logger instance for the wrapped client.
+     *
+     * Symfony's DI container calls this method to inject a logger.
+     * We pass it through to the wrapped client if it supports logging.
+     */
+    public function setLogger(object $logger): void
+    {
+        if (method_exists($this->client, 'setLogger')) {
+            $this->client->setLogger($logger);
+        }
+    }
+}

--- a/src/VCR/VCRHttpClient.php
+++ b/src/VCR/VCRHttpClient.php
@@ -24,7 +24,7 @@ use VCR\Http\NormalizedResponseWrapper;
  * - Works with all Symfony HttpClient implementations
  *
  * Usage:
- *   $client = new VCRHttpClient(new CurlHttpClient());
+ * $client = new VCRHttpClient(new CurlHttpClient());
  */
 class VCRHttpClient implements HttpClientInterface
 {
@@ -188,7 +188,7 @@ class VCRHttpClient implements HttpClientInterface
             }
 
             return $videorecorder->hasCassette();
-        } catch (\BadMethodCallException|\RuntimeException $e) {
+        } catch (\BadMethodCallException $e) {
             // VCR not initialized or no cassette
             // We intentionally swallow these exceptions to gracefully handle VCR absence
             return false;
@@ -243,7 +243,7 @@ class VCRHttpClient implements HttpClientInterface
 
         try {
             $videorecorder = VCRFactory::get(Videorecorder::class);
-        } catch (\BadMethodCallException|\RuntimeException $e) {
+        } catch (\BadMethodCallException $e) {
             // VCR not initialized, fall back to real client
             // We intentionally swallow these exceptions to gracefully handle VCR absence
             return $this->client->request($method, $url, $options);

--- a/src/VCR/VCRNativeHttpClient.php
+++ b/src/VCR/VCRNativeHttpClient.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR;
+
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+/**
+ * VCR-compatible replacement for NativeHttpClient.
+ *
+ * This class acts as a drop-in replacement for Symfony's NativeHttpClient
+ * when using php-vcr. It uses CurlHttpClient internally, which is fully
+ * compatible with VCR's curl hook system.
+ *
+ * Usage:
+ *   Instead of:  new NativeHttpClient($options)
+ *   Use:         new VCRNativeHttpClient($options)
+ *
+ * Why this is needed:
+ * - NativeHttpClient uses PHP streams which have fundamental limitations with VCR
+ * - PHP's stream wrappers cannot override stream_get_meta_data() behavior
+ * - This causes TypeErrors when Symfony tries to read response headers
+ *
+ * This proxy provides the same API as NativeHttpClient but uses CurlHttpClient
+ * under the hood, which works perfectly with VCR.
+ */
+class VCRNativeHttpClient implements HttpClientInterface
+{
+    private HttpClientInterface $client;
+
+    /**
+     * @param array<string,mixed> $defaultOptions     Default request options
+     * @param int                 $maxHostConnections Maximum number of connections per host
+     * @param int                 $maxPendingPushes   Maximum number of pending HTTP/2 pushes
+     */
+    public function __construct(array $defaultOptions = [], int $maxHostConnections = 6, int $maxPendingPushes = 50)
+    {
+        // Use CurlHttpClient with the same options
+        // CurlHttpClient is fully compatible with VCR
+        $this->client = new CurlHttpClient($defaultOptions, $maxHostConnections, $maxPendingPushes);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        return $this->client->request($method, $url, $options);
+    }
+
+    public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
+    {
+        return $this->client->stream($responses, $timeout);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function withOptions(array $options): static
+    {
+        $clone = clone $this;
+        $clone->client = $this->client->withOptions($options);
+
+        return $clone;
+    }
+}

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -135,6 +135,16 @@ class Videorecorder
     }
 
     /**
+     * Checks whether a cassette is currently inserted.
+     *
+     * @api
+     */
+    public function hasCassette(): bool
+    {
+        return null !== $this->cassette;
+    }
+
+    /**
      * Records, sends or plays back a intercepted request.
      *
      * If a request was already recorded on a cassette it's response is returned,
@@ -191,7 +201,10 @@ class Videorecorder
     }
 
     /**
-     * @api
+     * Disables all library hooks.
+     *
+     * Note: This method is protected to allow extension by subclasses.
+     * It is part of the internal hook management mechanism.
      */
     protected function disableLibraryHooks(): void
     {
@@ -202,7 +215,10 @@ class Videorecorder
     }
 
     /**
-     * @api
+     * Enables all library hooks.
+     *
+     * Note: This method is protected to allow extension by subclasses.
+     * It is part of the internal hook management mechanism.
      */
     protected function enableLibraryHooks(): void
     {

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -45,7 +45,7 @@ class Videorecorder
     public function __construct(
         protected Configuration $config,
         protected HttpClient $client,
-        protected VCRFactory $factory
+        protected VCRFactory $factory,
     ) {
     }
 

--- a/tests/Integration/Guzzle/AsyncTest.php
+++ b/tests/Integration/Guzzle/AsyncTest.php
@@ -10,8 +10,8 @@ use PHPUnit\Framework\TestCase;
 
 final class AsyncTest extends TestCase
 {
-    public const TEST_GET_URL = 'https://httpbin.org/get';
-    public const TEST_GET_URL_2 = 'https://httpbin.org/get?foo=42';
+    public const TEST_GET_URL = 'https://postman-echo.com/get';
+    public const TEST_GET_URL_2 = 'https://postman-echo.com/get?foo=42';
 
     protected function setUp(): void
     {

--- a/tests/Integration/Soap/ExampleSoapClient.php
+++ b/tests/Integration/Soap/ExampleSoapClient.php
@@ -15,7 +15,14 @@ class ExampleSoapClient
 
     public function call(int $number = 12): string
     {
-        $client = new \SoapClient(self::EXAMPLE_WSDL, ['soap_version' => \SOAP_1_2]);
+        $client = new \SoapClient(self::EXAMPLE_WSDL, [
+            'soap_version' => \SOAP_1_2,
+            'stream_context' => stream_context_create([
+                'socket' => [
+                    'bindto' => '0.0.0.0:0',  // Force IPv4 to avoid IPv6 timeout
+                ],
+            ]),
+        ]);
         $response = $client->NumberToWords(['ubiNum' => $number]);
 
         return trim((string) $response->NumberToWordsResult);

--- a/tests/Integration/SymfonyHttpClient/Clients/CurlHttpClientTest.php
+++ b/tests/Integration/SymfonyHttpClient/Clients/CurlHttpClientTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Clients;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+
+class CurlHttpClientTest extends TestCase
+{
+    public const TEST_GET_URL = 'https://postman-echo.com/get';
+    public const TEST_POST_URL = 'https://postman-echo.com/post';
+
+    protected function setUp(): void
+    {
+        \VCR\VCR::configure()->setCassettePath(__DIR__.'/../../../fixtures/httpclient')
+            ->enableLibraryHooks(['symfony_http_client'])
+        ;
+    }
+
+    public function testGet(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('curl-http-client.yml');
+
+        $client = new CurlHttpClient();
+        $response = $client->request('GET', self::TEST_GET_URL);
+
+        $this->assertValidGETResponse(json_decode($response->getContent(), true));
+
+        \VCR\VCR::turnOff();
+    }
+
+    public function testPostWithEmptyBody(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('curl-http-client.yml');
+
+        $client = new CurlHttpClient();
+        $response = $client->request('POST', self::TEST_POST_URL);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertValidGETResponse($data);
+        $this->assertArrayHasKey('json', $data, 'API did not return POST data');
+
+        \VCR\VCR::turnOff();
+    }
+
+    public function testPostWithJson(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('curl-http-client.yml');
+
+        $client = new CurlHttpClient();
+        $response = $client->request('POST', self::TEST_POST_URL, [
+            'json' => [
+                'test' => true,
+            ],
+        ]);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertValidGETResponse($data);
+        $this->assertArrayHasKey('json', $data, 'API did not return POST data');
+
+        \VCR\VCR::turnOff();
+    }
+
+    public function testWithCustomOptions(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('curl-http-client-options.yml');
+
+        $client = new CurlHttpClient([
+            'timeout' => 30,
+        ]);
+
+        $response = $client->request('GET', self::TEST_GET_URL, [
+            'headers' => [
+                'X-Custom-Header' => 'test-value',
+            ],
+        ]);
+
+        $this->assertValidGETResponse(json_decode($response->getContent(), true));
+
+        \VCR\VCR::turnOff();
+    }
+
+    protected function assertValidGETResponse(mixed $info): void
+    {
+        $this->assertIsArray($info, 'Response is not an array.');
+        $this->assertArrayHasKey('url', $info, 'API did not return any value.');
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Clients/NativeHttpClientTest.php
+++ b/tests/Integration/SymfonyHttpClient/Clients/NativeHttpClientTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Clients;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\NativeHttpClient;
+
+/**
+ * Tests for NativeHttpClient with VCR.
+ *
+ * NativeHttpClient is now compatible with VCR thanks to the stream_get_meta_data() proxy.
+ * The proxy function in StreamMetaDataProxy.php intercepts calls in the Symfony namespace
+ * and transforms the StreamWrapperHook object into an array.
+ */
+class NativeHttpClientTest extends TestCase
+{
+    public const TEST_GET_URL = 'https://postman-echo.com/get';
+
+    protected function setUp(): void
+    {
+        \VCR\VCR::configure()->setCassettePath(__DIR__.'/../../../fixtures/httpclient')
+            ->enableLibraryHooks(['symfony_http_client'])
+
+        ;
+    }
+
+    /**
+     * Test that NativeHttpClient works with VCR thanks to the stream_get_meta_data() proxy.
+     *
+     * The proxy function in StreamMetaDataProxy.php intercepts calls to stream_get_meta_data()
+     * in the Symfony\Component\HttpClient\Response namespace and transforms the StreamWrapperHook
+     * object into an array that Symfony expects.
+     */
+    public function testNativeHttpClientWorksWithVCR(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('native-http-client.yml');
+
+        $client = new NativeHttpClient();
+        $response = $client->request('GET', self::TEST_GET_URL);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertIsArray($data, 'Response is not an array.');
+        $this->assertArrayHasKey('url', $data, 'API did not return expected data.');
+
+        \VCR\VCR::turnOff();
+    }
+
+    /**
+     * This test verifies the documented workaround using VCRNativeHttpClient.
+     */
+    public function testWorkaroundUsingVCRNativeHttpClient(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('native-http-client-workaround.yml');
+
+        $client = new \VCR\VCRNativeHttpClient();
+        $response = $client->request('GET', self::TEST_GET_URL);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertIsArray($data, 'Response is not an array.');
+        $this->assertArrayHasKey('url', $data, 'API did not return any value.');
+
+        \VCR\VCR::turnOff();
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Clients/ScopingHttpClientTest.php
+++ b/tests/Integration/SymfonyHttpClient/Clients/ScopingHttpClientTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Clients;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Component\HttpClient\ScopingHttpClient;
+use VCR\VCR;
+
+/**
+ * Tests for ScopingHttpClient compatibility with VCR.
+ *
+ * ScopingHttpClient is a decorator that restricts requests to specific base URIs.
+ */
+class ScopingHttpClientTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        VCR::configure()
+            ->setCassettePath(__DIR__.'/../../../fixtures/symfony_httpclient')
+            ->enableLibraryHooks(['symfony_http_client'])
+            ->setMode('new_episodes');
+
+        VCR::turnOn();
+    }
+
+    protected function tearDown(): void
+    {
+        VCR::eject();
+        VCR::turnOff();
+    }
+
+    public function testScopingHttpClientWithSingleScope(): void
+    {
+        VCR::insertCassette('scoping_single.yml');
+
+        $baseClient = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $scopedClient = new ScopingHttpClient($baseClient, [
+            'https://jsonplaceholder.typicode.com' => [],
+        ]);
+
+        $response = $scopedClient->request('GET', 'https://jsonplaceholder.typicode.com/posts/1');
+        $content = $response->getContent();
+
+        $data = json_decode($content, true);
+        $this->assertIsArray($data);
+        $this->assertEquals(1, $data['id']);
+    }
+
+    public function testScopingHttpClientWithMultipleScopes(): void
+    {
+        VCR::insertCassette('scoping_multiple.yml');
+
+        $baseClient = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $scopedClient = new ScopingHttpClient($baseClient, [
+            'https://jsonplaceholder.typicode.com' => ['headers' => ['X-Scope' => 'api1']],
+            'https://postman-echo.com' => ['headers' => ['X-Scope' => 'api2']],
+        ]);
+
+        $response1 = $scopedClient->request('GET', 'https://jsonplaceholder.typicode.com/posts/1');
+        $this->assertEquals(200, $response1->getStatusCode());
+
+        $response2 = $scopedClient->request('GET', 'https://postman-echo.com/get');
+        $this->assertEquals(200, $response2->getStatusCode());
+    }
+
+    public function testScopingHttpClientWithDefaultOptions(): void
+    {
+        VCR::insertCassette('scoping_default_options.yml');
+
+        $baseClient = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $scopedClient = new ScopingHttpClient($baseClient, [
+            'https://jsonplaceholder.typicode.com' => [
+                'headers' => [
+                    'User-Agent' => 'VCR-Test-Client/1.0',
+                ],
+            ],
+        ]);
+
+        $response = $scopedClient->request('GET', 'https://jsonplaceholder.typicode.com/posts/1');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getContent();
+        $data = json_decode($content, true);
+        $this->assertIsArray($data);
+    }
+
+    public function testScopingHttpClientWithRelativeUrls(): void
+    {
+        VCR::insertCassette('scoping_relative.yml');
+
+        $baseClient = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $scopedClient = new ScopingHttpClient($baseClient, [
+            '.*' => ['base_uri' => 'https://jsonplaceholder.typicode.com'],
+        ]);
+
+        $response = $scopedClient->request('GET', 'https://jsonplaceholder.typicode.com/posts/1');
+        $content = $response->getContent();
+
+        $data = json_decode($content, true);
+        $this->assertIsArray($data);
+        $this->assertEquals(1, $data['id']);
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Clients/TraceableHttpClientTest.php
+++ b/tests/Integration/SymfonyHttpClient/Clients/TraceableHttpClientTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Clients;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\TraceableHttpClient;
+
+class TraceableHttpClientTest extends TestCase
+{
+    public const TEST_GET_URL = 'https://postman-echo.com/get';
+    public const TEST_POST_URL = 'https://postman-echo.com/post';
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'))
+            ->enableLibraryHooks(['symfony_http_client'])  // Enable code transformation hook!
+
+        ;
+    }
+
+    public function testGet(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+
+        $client = HttpClient::create();
+        $traceableClient = new TraceableHttpClient($client);
+        $response = $traceableClient->request('GET', self::TEST_GET_URL);
+
+        $this->assertValidGETResponse(json_decode($response->getContent(), true));
+
+        \VCR\VCR::turnOff();
+    }
+
+    public function testPostWithEmptyBody(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+
+        $client = HttpClient::create();
+        $traceableClient = new TraceableHttpClient($client);
+        $response = $traceableClient->request('POST', self::TEST_POST_URL);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertValidGETResponse($data);
+        $this->assertArrayHasKey('json', $data, 'API did not return POST data');
+
+        \VCR\VCR::turnOff();
+    }
+
+    public function testPostWithJson(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+
+        $client = HttpClient::create();
+        $traceableClient = new TraceableHttpClient($client);
+        $response = $traceableClient->request('POST', self::TEST_POST_URL, [
+            'json' => [
+                'test' => true,
+            ],
+        ]);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertValidGETResponse($data);
+        $this->assertArrayHasKey('json', $data, 'API did not return POST data');
+
+        \VCR\VCR::turnOff();
+    }
+
+    protected function assertValidGETResponse(mixed $info): void
+    {
+        $this->assertIsArray($info, 'Response is not an array.');
+        $this->assertArrayHasKey('url', $info, 'API did not return any value.');
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Clients/VCRNativeHttpClientTest.php
+++ b/tests/Integration/SymfonyHttpClient/Clients/VCRNativeHttpClientTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Clients;
+
+use PHPUnit\Framework\TestCase;
+use VCR\VCRNativeHttpClient;
+
+class VCRNativeHttpClientTest extends TestCase
+{
+    public const TEST_GET_URL = 'https://postman-echo.com/get';
+    public const TEST_POST_URL = 'https://postman-echo.com/post';
+
+    protected function setUp(): void
+    {
+        \VCR\VCR::configure()->setCassettePath(__DIR__.'/../../../fixtures/httpclient')
+            ->enableLibraryHooks(['symfony_http_client'])
+
+        ;
+    }
+
+    public function testGet(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('vcr-native-http-client.yml');
+
+        $client = new VCRNativeHttpClient();
+        $response = $client->request('GET', self::TEST_GET_URL);
+
+        $this->assertValidGETResponse(json_decode($response->getContent(), true));
+
+        \VCR\VCR::turnOff();
+    }
+
+    public function testPostWithEmptyBody(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('vcr-native-http-client.yml');
+
+        $client = new VCRNativeHttpClient();
+        $response = $client->request('POST', self::TEST_POST_URL);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertValidGETResponse($data);
+        $this->assertArrayHasKey('json', $data, 'API did not return POST data');
+
+        \VCR\VCR::turnOff();
+    }
+
+    public function testPostWithJson(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('vcr-native-http-client.yml');
+
+        $client = new VCRNativeHttpClient();
+        $response = $client->request('POST', self::TEST_POST_URL, [
+            'json' => [
+                'test' => true,
+            ],
+        ]);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertValidGETResponse($data);
+        $this->assertArrayHasKey('json', $data, 'API did not return POST data');
+
+        \VCR\VCR::turnOff();
+    }
+
+    public function testWithOptions(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('vcr-native-http-client-options.yml');
+
+        $client = new VCRNativeHttpClient([
+            'timeout' => 30,
+        ]);
+
+        $clientWithOptions = $client->withOptions([
+            'headers' => [
+                'X-Custom-Header' => 'test-value',
+            ],
+        ]);
+
+        $response = $clientWithOptions->request('GET', self::TEST_GET_URL);
+
+        $this->assertValidGETResponse(json_decode($response->getContent(), true));
+
+        \VCR\VCR::turnOff();
+    }
+
+    protected function assertValidGETResponse(mixed $info): void
+    {
+        $this->assertIsArray($info, 'Response is not an array.');
+        $this->assertArrayHasKey('url', $info, 'API did not return any value.');
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Features/AuthenticationTest.php
+++ b/tests/Integration/SymfonyHttpClient/Features/AuthenticationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Features;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use VCR\VCR;
+
+/**
+ * Tests for HTTP authentication with Symfony HttpClient and VCR.
+ *
+ * Tests Basic Auth, Bearer tokens, and auth options.
+ */
+class AuthenticationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        VCR::configure()
+            ->setCassettePath(__DIR__.'/../../../fixtures/symfony_httpclient')
+            ->enableLibraryHooks(['symfony_http_client'])
+            ->setMode('new_episodes');
+
+        VCR::turnOn();
+    }
+
+    protected function tearDown(): void
+    {
+        VCR::eject();
+        VCR::turnOff();
+    }
+
+    public function testBasicAuthWithCurlHttpClient(): void
+    {
+        VCR::insertCassette('auth_basic_curl.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('GET', 'https://jsonplaceholder.typicode.com/posts/1', [
+            'auth_basic' => ['user', 'passwd'],
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testBasicAuthWithNativeHttpClient(): void
+    {
+        VCR::insertCassette('auth_basic_native.yml');
+
+        $client = new NativeHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('GET', 'https://jsonplaceholder.typicode.com/posts/1', [
+            'auth_basic' => ['user', 'passwd'],
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testBasicAuthWithManualHeader(): void
+    {
+        VCR::insertCassette('auth_manual_header.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('GET', 'https://jsonplaceholder.typicode.com/posts/1', [
+            'headers' => [
+                'Authorization' => 'Basic '.base64_encode('user:passwd'),
+            ],
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testBearerTokenAuth(): void
+    {
+        VCR::insertCassette('auth_bearer.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('GET', 'https://jsonplaceholder.typicode.com/posts/1', [
+            'auth_bearer' => 'test-token-123',
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testBearerTokenWithManualHeader(): void
+    {
+        VCR::insertCassette('auth_bearer_manual.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('GET', 'https://jsonplaceholder.typicode.com/posts/1', [
+            'headers' => [
+                'Authorization' => 'Bearer test-token-456',
+            ],
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Features/ConcurrentRequestsTest.php
+++ b/tests/Integration/SymfonyHttpClient/Features/ConcurrentRequestsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Features;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * Tests concurrent/async requests with Symfony HttpClient.
+ *
+ * Similar to Guzzle's AsyncTest, this ensures VCR can handle multiple
+ * concurrent requests without locking.
+ */
+class ConcurrentRequestsTest extends TestCase
+{
+    public const TEST_GET_URL = 'https://postman-echo.com/get';
+    public const TEST_GET_URL_2 = 'https://postman-echo.com/get?foo=42';
+    public const TEST_GET_URL_3 = 'https://postman-echo.com/get?bar=123';
+
+    protected function setUp(): void
+    {
+        \VCR\VCR::configure()->setCassettePath(__DIR__.'/../../../fixtures/httpclient')
+            ->enableLibraryHooks(['symfony_http_client'])
+        ;
+    }
+
+    /**
+     * Test that multiple concurrent requests don't lock each other.
+     *
+     * This solves potential race conditions when VCR handles multiple requests.
+     *
+     * @see https://github.com/php-vcr/php-vcr/issues/211
+     */
+    public function testMultipleConcurrentRequests(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('concurrent-requests.yml');
+
+        $client = HttpClient::create();
+
+        $responses = [];
+        $responses[] = $client->request('GET', self::TEST_GET_URL);
+        $responses[] = $client->request('GET', self::TEST_GET_URL_2);
+        $responses[] = $client->request('GET', self::TEST_GET_URL_3);
+
+        foreach ($client->stream($responses) as $response => $chunk) {
+        }
+
+        $data1 = json_decode($responses[0]->getContent(), true);
+        $data2 = json_decode($responses[1]->getContent(), true);
+        $data3 = json_decode($responses[2]->getContent(), true);
+
+        $this->assertValidGETResponse($data1);
+        $this->assertValidGETResponse($data2);
+        $this->assertValidGETResponse($data3);
+
+        $this->assertStringContainsString('postman-echo.com/get', $data1['url']);
+        $this->assertStringContainsString('foo=42', $data2['url']);
+        $this->assertStringContainsString('bar=123', $data3['url']);
+
+        \VCR\VCR::turnOff();
+    }
+
+    /**
+     * Test stream() method with multiple responses.
+     */
+    public function testStreamWithMultipleResponses(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('stream-multiple.yml');
+
+        $client = HttpClient::create();
+
+        $responses = [
+            $client->request('GET', self::TEST_GET_URL),
+            $client->request('GET', self::TEST_GET_URL_2),
+        ];
+
+        $completed = 0;
+        foreach ($client->stream($responses) as $response => $chunk) {
+            if ($chunk->isLast()) {
+                ++$completed;
+            }
+        }
+
+        $this->assertEquals(2, $completed, 'Both requests should complete');
+
+        \VCR\VCR::turnOff();
+    }
+
+    protected function assertValidGETResponse(mixed $info): void
+    {
+        $this->assertIsArray($info, 'Response is not an array.');
+        $this->assertArrayHasKey('url', $info, 'API did not return any value.');
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Features/CustomOptionsTest.php
+++ b/tests/Integration/SymfonyHttpClient/Features/CustomOptionsTest.php
@@ -6,7 +6,6 @@ namespace VCR\Tests\Integration\SymfonyHttpClient\Features;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\CurlHttpClient;
-use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\NativeHttpClient;
 use VCR\VCR;
 

--- a/tests/Integration/SymfonyHttpClient/Features/CustomOptionsTest.php
+++ b/tests/Integration/SymfonyHttpClient/Features/CustomOptionsTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Features;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use VCR\VCR;
+
+/**
+ * Tests for custom Symfony HttpClient options with VCR.
+ *
+ * Tests: timeout, max_redirects, headers, user_data, etc.
+ */
+class CustomOptionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        VCR::configure()
+            ->setCassettePath(__DIR__.'/../../../fixtures/symfony_httpclient')
+            ->enableLibraryHooks(['symfony_http_client'])
+            ->setMode('new_episodes');
+
+        VCR::turnOn();
+    }
+
+    protected function tearDown(): void
+    {
+        VCR::eject();
+        VCR::turnOff();
+    }
+
+    public function testCustomHeaders(): void
+    {
+        VCR::insertCassette('options_custom_headers.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('GET', 'https://jsonplaceholder.typicode.com/posts/1', [
+            'headers' => [
+                'X-Custom-Header' => 'custom-value',
+                'User-Agent' => 'VCR-Test/1.0',
+            ],
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getContent();
+        $data = json_decode($content, true);
+
+        $this->assertIsArray($data);
+        $this->assertEquals(1, $data['id']);
+    }
+
+    public function testMaxRedirects(): void
+    {
+        VCR::insertCassette('options_max_redirects.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('GET', 'https://jsonplaceholder.typicode.com/posts/1', [
+            'max_redirects' => 5,
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testTimeoutOption(): void
+    {
+        VCR::insertCassette('options_timeout.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('GET', 'https://jsonplaceholder.typicode.com/posts/1', [
+            'timeout' => 30.0,
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getContent();
+        $this->assertNotEmpty($content);
+    }
+
+    public function testUserDataOption(): void
+    {
+        VCR::insertCassette('options_user_data.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('GET', 'https://jsonplaceholder.typicode.com/posts/1', [
+            'user_data' => ['test_id' => 123, 'test_name' => 'VCR'],
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $info = $response->getInfo();
+        $this->assertEquals(['test_id' => 123, 'test_name' => 'VCR'], $info['user_data']);
+    }
+
+    public function testQueryParameters(): void
+    {
+        VCR::insertCassette('options_query_params.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('GET', 'https://postman-echo.com/get', [
+            'query' => [
+                'foo' => 'bar',
+                'number' => 42,
+            ],
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getContent();
+        $data = json_decode($content, true);
+
+        $this->assertArrayHasKey('args', $data);
+        $this->assertEquals('bar', $data['args']['foo'] ?? '');
+        $this->assertEquals('42', $data['args']['number'] ?? '');
+    }
+
+    public function testJsonOption(): void
+    {
+        VCR::insertCassette('options_json.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('POST', 'https://jsonplaceholder.typicode.com/posts', [
+            'json' => [
+                'title' => 'Test Post',
+                'body' => 'Test Content',
+                'userId' => 1,
+            ],
+        ]);
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $content = $response->getContent();
+        $data = json_decode($content, true);
+
+        $this->assertArrayHasKey('id', $data);
+        $this->assertEquals('Test Post', $data['title'] ?? '');
+    }
+
+    public function testWithOptionsCreatesNewInstance(): void
+    {
+        VCR::insertCassette('options_with_options.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $clientWithOptions = $client->withOptions([
+            'headers' => [
+                'X-Test' => 'value',
+            ],
+        ]);
+
+        $this->assertNotSame($client, $clientWithOptions);
+
+        $response = $clientWithOptions->request('GET', 'https://jsonplaceholder.typicode.com/posts/1');
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testNativeHttpClientWithCustomOptions(): void
+    {
+        VCR::insertCassette('options_native_custom.yml');
+
+        $client = new NativeHttpClient([
+            'verify_peer' => false,
+            'verify_host' => false,
+            'timeout' => 30,
+        ]);
+
+        $response = $client->request('GET', 'https://jsonplaceholder.typicode.com/posts/1', [
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $content = $response->getContent();
+        $this->assertNotEmpty($content);
+    }
+
+    public function testMultipleOptionsInSingleRequest(): void
+    {
+        VCR::insertCassette('options_multiple.yml');
+
+        $client = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+
+        $response = $client->request('POST', 'https://jsonplaceholder.typicode.com/posts', [
+            'headers' => [
+                'X-Custom' => 'test',
+            ],
+            'json' => [
+                'title' => 'test',
+                'body' => 'test body',
+                'userId' => 1,
+            ],
+            'timeout' => 30,
+            'max_redirects' => 5,
+            'user_data' => ['id' => 1],
+        ]);
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $content = $response->getContent();
+        $data = json_decode($content, true);
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('id', $data);
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Features/ErrorTest.php
+++ b/tests/Integration/SymfonyHttpClient/Features/ErrorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Features;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\HttpClient;
+
+final class ErrorTest extends TestCase
+{
+    public const TEST_GET_URL = 'http://localhost:9959';
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'))
+            ->enableLibraryHooks(['symfony_http_client'])  // Enable code transformation hook!
+
+        ;
+    }
+
+    public function testConnectException(): void
+    {
+        $nonInstrumentedException = null;
+        try {
+            $client = HttpClient::create();
+            $response = $client->request('GET', self::TEST_GET_URL);
+            $response->getHeaders(); // Force the request to execute
+        } catch (TransportException $e) {
+            $nonInstrumentedException = $e;
+        }
+        $this->assertNotNull($nonInstrumentedException);
+        $catched = false;
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('test-cassette.yml');
+        try {
+            $client = HttpClient::create();
+            $client->request('GET', self::TEST_GET_URL);
+        } catch (TransportException $e) {
+            $catched = true;
+            $this->assertEquals($e->getMessage(), $nonInstrumentedException->getMessage());
+        }
+        $this->assertTrue($catched);
+        \VCR\VCR::turnOff();
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Hooks/CodeTransformTest.php
+++ b/tests/Integration/SymfonyHttpClient/Hooks/CodeTransformTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Hooks;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use VCR\Tests\Integration\SymfonyHttpClient\Support\JsonPlaceholderClient;
+use VCR\VCR;
+
+/**
+ * Tests that code transformation automatically wraps Symfony HttpClient.
+ */
+class CodeTransformTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        VCR::configure()
+            ->setCassettePath(__DIR__.'/../../../fixtures/symfony_httpclient')
+            ->enableLibraryHooks(['symfony_http_client'])  // Enable code transformation hook!
+            ->setMode('once');
+
+        VCR::turnOn();
+    }
+
+    protected function tearDown(): void
+    {
+        VCR::eject();
+        VCR::turnOff();
+    }
+
+    public function testCodeTransformWrapsCurlHttpClient(): void
+    {
+        VCR::insertCassette('curl_get.yml');
+
+        // Direct instantiation - should be automatically transformed to VCRHttpClient!
+        $httpClient = new CurlHttpClient([
+            'timeout' => 30,
+            'verify_peer' => false,
+            'verify_host' => false,
+        ]);
+
+        $client = new JsonPlaceholderClient($httpClient);
+        $result = $client->getPost(1);
+
+        $this->assertIsArray($result);
+        $this->assertEquals(1, $result['id']);
+        $this->assertArrayHasKey('title', $result);
+        $this->assertArrayHasKey('body', $result);
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Hooks/CurlHookOnlyTest.php
+++ b/tests/Integration/SymfonyHttpClient/Hooks/CurlHookOnlyTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Hooks;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+
+/**
+ * Test if Symfony CurlHttpClient works with ONLY the cURL hooks (no code transformation).
+ *
+ * This validates whether VCRHttpClient is actually needed or if standard cURL interception
+ * is sufficient for Symfony HttpClient support.
+ */
+class CurlHookOnlyTest extends TestCase
+{
+    public const TEST_URL = 'https://jsonplaceholder.typicode.com/posts/1';
+
+    protected function setUp(): void
+    {
+        \VCR\VCR::configure()
+            ->setCassettePath(__DIR__.'/../../../fixtures/symfony_httpclient')
+            ->enableLibraryHooks(['curl'])
+            ->setMode('once');
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::eject();
+        \VCR\VCR::turnOff();
+    }
+
+    public function testCurlHttpClientWithCurlHooksOnly(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('curl_hook_only_test.yml');
+
+        $client = new CurlHttpClient([
+            'verify_peer' => false,
+            'verify_host' => false,
+        ]);
+
+        $response = $client->request('GET', self::TEST_URL);
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('id', $data);
+        $this->assertEquals(1, $data['id']);
+    }
+
+    public function testCurlHttpClientPostWithCurlHooksOnly(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('curl_hook_only_post_test.yml');
+
+        $client = new CurlHttpClient([
+            'verify_peer' => false,
+            'verify_host' => false,
+        ]);
+
+        $response = $client->request('POST', 'https://jsonplaceholder.typicode.com/posts', [
+            'json' => [
+                'title' => 'Test Post',
+                'body' => 'Test Body',
+                'userId' => 1,
+            ],
+        ]);
+
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('id', $data);
+        $this->assertEquals('Test Post', $data['title']);
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Hooks/NativeHttpClientStreamWrapperTest.php
+++ b/tests/Integration/SymfonyHttpClient/Hooks/NativeHttpClientStreamWrapperTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Hooks;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\NativeHttpClient;
+
+/**
+ * Test if NativeHttpClient works with ONLY stream_wrapper hooks (no StreamMetaDataProxy).
+ *
+ * This validates whether StreamMetaDataProxy is actually needed or if the StreamWrapperHook
+ * already provides the correct format for stream_get_meta_data().
+ */
+class NativeHttpClientStreamWrapperTest extends TestCase
+{
+    public const TEST_URL = 'https://jsonplaceholder.typicode.com/posts/1';
+
+    protected function setUp(): void
+    {
+        \VCR\VCR::configure()
+            ->setCassettePath(__DIR__.'/../../../fixtures/symfony_httpclient')
+            ->enableLibraryHooks(['stream_wrapper'])
+            ->setMode('once');
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::eject();
+        \VCR\VCR::turnOff();
+    }
+
+    public function testNativeHttpClientWithStreamWrapperOnly(): void
+    {
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('native_stream_wrapper_test.yml');
+
+        $client = new NativeHttpClient([
+            'verify_peer' => false,
+            'verify_host' => false,
+        ]);
+
+        $response = $client->request('GET', self::TEST_URL);
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('id', $data);
+        $this->assertEquals(1, $data['id']);
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/Support/JsonPlaceholderClient.php
+++ b/tests/Integration/SymfonyHttpClient/Support/JsonPlaceholderClient.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient\Support;
+
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Client to interact with JSONPlaceholder API for testing Symfony HttpClient with VCR.
+ */
+class JsonPlaceholderClient
+{
+    private const BASE_URL = 'https://jsonplaceholder.typicode.com';
+
+    private HttpClientInterface $httpClient;
+
+    public function __construct(HttpClientInterface $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * Get a single post by ID.
+     *
+     * @return array<string, mixed>
+     *
+     * @throws \RuntimeException
+     */
+    public function getPost(int $id): array
+    {
+        try {
+            $response = $this->httpClient->request(
+                'GET',
+                self::BASE_URL.'/posts/'.$id,
+                [
+                    'headers' => [
+                        'Accept' => 'application/json',
+                    ],
+                    'timeout' => 30,
+                ]
+            );
+
+            $statusCode = $response->getStatusCode();
+
+            if (200 !== $statusCode) {
+                throw new \RuntimeException("HTTP request failed with code {$statusCode}");
+            }
+
+            return $response->toArray();
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException('Transport error: '.$e->getMessage(), 0, $e);
+        } catch (\Exception $e) {
+            throw new \RuntimeException('Request failed: '.$e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * Create a new post.
+     *
+     * @param array<string,mixed> $data
+     *
+     * @return array<string,mixed>
+     *
+     * @throws \RuntimeException
+     */
+    public function createPost(array $data): array
+    {
+        try {
+            $response = $this->httpClient->request(
+                'POST',
+                self::BASE_URL.'/posts',
+                [
+                    'headers' => [
+                        'Accept' => 'application/json',
+                        'Content-Type' => 'application/json',
+                    ],
+                    'json' => $data,
+                    'timeout' => 30,
+                ]
+            );
+
+            if (201 !== $response->getStatusCode()) {
+                throw new \RuntimeException("HTTP request failed with code {$response->getStatusCode()}");
+            }
+
+            return $response->toArray();
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException('Transport error: '.$e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * Update an existing post.
+     *
+     * @param array<string,mixed> $data
+     *
+     * @return array<string,mixed>
+     *
+     * @throws \RuntimeException
+     */
+    public function updatePost(int $id, array $data): array
+    {
+        try {
+            $response = $this->httpClient->request(
+                'PUT',
+                self::BASE_URL.'/posts/'.$id,
+                [
+                    'headers' => [
+                        'Accept' => 'application/json',
+                        'Content-Type' => 'application/json',
+                    ],
+                    'json' => $data,
+                    'timeout' => 30,
+                ]
+            );
+
+            if (200 !== $response->getStatusCode()) {
+                throw new \RuntimeException("HTTP request failed with code {$response->getStatusCode()}");
+            }
+
+            return $response->toArray();
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException('Transport error: '.$e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * Delete a post.
+     *
+     * @throws \RuntimeException
+     */
+    public function deletePost(int $id): bool
+    {
+        try {
+            $response = $this->httpClient->request(
+                'DELETE',
+                self::BASE_URL.'/posts/'.$id,
+                [
+                    'timeout' => 30,
+                ]
+            );
+
+            return 200 === $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException('Transport error: '.$e->getMessage(), 0, $e);
+        }
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/SymfonyHttpClientTest.php
+++ b/tests/Integration/SymfonyHttpClient/SymfonyHttpClientTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\SymfonyHttpClient;
+
+use Assert\Assertion;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\RetryableHttpClient;
+use Symfony\Component\HttpClient\TraceableHttpClient;
+use VCR\Tests\Integration\SymfonyHttpClient\Support\JsonPlaceholderClient;
+use VCR\VCR;
+
+/**
+ * Tests for Symfony HttpClient compatibility with VCR.
+ *
+ * This test suite validates that VCR correctly intercepts and records/replays
+ * HTTP requests made through various Symfony HttpClient implementations.
+ *
+ * Uses code transformation to automatically wrap Symfony HttpClient instances.
+ */
+class SymfonyHttpClientTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        VCR::configure()
+            ->setCassettePath(__DIR__.'/../../fixtures/symfony_httpclient')
+            ->enableLibraryHooks(['symfony_http_client'])
+            ->setMode('once');
+
+        VCR::turnOn();
+    }
+
+    protected function tearDown(): void
+    {
+        VCR::eject();
+        VCR::turnOff();
+    }
+
+    public function testCurlHttpClientGet(): void
+    {
+        VCR::insertCassette('curl_get.yml');
+
+        $httpClient = new CurlHttpClient([
+            'timeout' => 30,
+            'verify_peer' => false,
+            'verify_host' => false,
+        ]);
+
+        $client = new JsonPlaceholderClient($httpClient);
+        $result = $client->getPost(1);
+
+        $this->assertIsArray($result);
+        $this->assertEquals(1, $result['id']);
+        $this->assertArrayHasKey('title', $result);
+        $this->assertArrayHasKey('body', $result);
+    }
+
+    public function testCurlHttpClientPost(): void
+    {
+        VCR::insertCassette('curl_post.yml');
+
+        $httpClient = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $client = new JsonPlaceholderClient($httpClient);
+
+        $result = $client->createPost([
+            'title' => 'Test Post',
+            'body' => 'Testing VCR with CurlHttpClient',
+            'userId' => 1,
+        ]);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', $result);
+    }
+
+    public function testCurlHttpClientPut(): void
+    {
+        VCR::insertCassette('curl_put.yml');
+
+        $httpClient = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $client = new JsonPlaceholderClient($httpClient);
+
+        $result = $client->updatePost(1, [
+            'title' => 'Updated Post',
+            'body' => 'Updated body',
+            'userId' => 1,
+        ]);
+
+        $this->assertIsArray($result);
+        $this->assertEquals(1, $result['id']);
+    }
+
+    public function testCurlHttpClientDelete(): void
+    {
+        VCR::insertCassette('curl_delete.yml');
+
+        $httpClient = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $client = new JsonPlaceholderClient($httpClient);
+
+        $result = $client->deletePost(1);
+
+        $this->assertTrue($result);
+    }
+
+    public function testNativeHttpClientGet(): void
+    {
+        VCR::insertCassette('native_get.yml');
+
+        $httpClient = new NativeHttpClient([
+            'timeout' => 30,
+            'verify_peer' => false,
+            'verify_host' => false,
+        ]);
+
+        $client = new JsonPlaceholderClient($httpClient);
+        $result = $client->getPost(1);
+
+        $this->assertIsArray($result);
+        $this->assertEquals(1, $result['id']);
+    }
+
+    public function testNativeHttpClientPost(): void
+    {
+        VCR::insertCassette('native_post.yml');
+
+        $httpClient = new NativeHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $client = new JsonPlaceholderClient($httpClient);
+
+        $result = $client->createPost([
+            'title' => 'Test with NativeHttpClient',
+            'body' => 'Testing POST with native streams',
+            'userId' => 1,
+        ]);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', $result);
+    }
+
+    public function testNativeHttpClientPut(): void
+    {
+        VCR::insertCassette('native_put.yml');
+
+        $httpClient = new NativeHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $client = new JsonPlaceholderClient($httpClient);
+
+        $result = $client->updatePost(1, [
+            'title' => 'Updated with NativeHttpClient',
+            'body' => 'Testing PUT with native streams',
+            'userId' => 1,
+        ]);
+
+        $this->assertIsArray($result);
+    }
+
+    public function testNativeHttpClientDelete(): void
+    {
+        VCR::insertCassette('native_delete.yml');
+
+        $httpClient = new NativeHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $client = new JsonPlaceholderClient($httpClient);
+
+        $result = $client->deletePost(1);
+
+        $this->assertTrue($result);
+    }
+
+    public function testMockHttpClientGet(): void
+    {
+        VCR::turnOff();
+
+        $mockResponse = [
+            'userId' => 1,
+            'id' => 1,
+            'title' => 'Mocked Title',
+            'body' => 'Mocked Body',
+        ];
+
+        $jsonBody = json_encode($mockResponse);
+        Assertion::string($jsonBody, 'json_encode should not fail with valid array');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse($jsonBody, [
+                'http_code' => 200,
+                'response_headers' => ['Content-Type: application/json'],
+            ]),
+        ]);
+
+        $client = new JsonPlaceholderClient($httpClient);
+        $result = $client->getPost(1);
+
+        $this->assertEquals($mockResponse, $result);
+
+        VCR::turnOn();
+    }
+
+    public function testTraceableHttpClientGet(): void
+    {
+        VCR::insertCassette('traceable_get.yml');
+
+        $baseClient = new CurlHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $traceableClient = new TraceableHttpClient($baseClient);
+
+        $client = new JsonPlaceholderClient($traceableClient);
+        $result = $client->getPost(1);
+
+        $this->assertIsArray($result);
+        $this->assertEquals(1, $result['id']);
+
+        $traces = $traceableClient->getTracedRequests();
+        $this->assertNotEmpty($traces);
+    }
+}

--- a/tests/Integration/SymfonyHttpClient/SymfonyHttpClientTest.php
+++ b/tests/Integration/SymfonyHttpClient/SymfonyHttpClientTest.php
@@ -10,7 +10,6 @@ use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\NativeHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
-use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Component\HttpClient\TraceableHttpClient;
 use VCR\Tests\Integration\SymfonyHttpClient\Support\JsonPlaceholderClient;
 use VCR\VCR;

--- a/tests/Unit/CodeTransform/SymfonyHttpClientCodeTransformTest.php
+++ b/tests/Unit/CodeTransform/SymfonyHttpClientCodeTransformTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\CodeTransform;
+
+use PHPUnit\Framework\TestCase;
+use VCR\CodeTransform\SymfonyHttpClientCodeTransform;
+
+final class SymfonyHttpClientCodeTransformTest extends TestCase
+{
+    /**
+     * @dataProvider codeSnippetProvider
+     */
+    public function testTransformCode(string $expected, string $code): void
+    {
+        $codeTransform = new class extends SymfonyHttpClientCodeTransform {
+            // A proxy to access the protected transformCode method.
+            public function publicTransformCode(string $code): string
+            {
+                return $this->transformCode($code);
+            }
+        };
+
+        $this->assertEquals($expected, $codeTransform->publicTransformCode($code));
+    }
+
+    /** @return array<string[]> */
+    public function codeSnippetProvider(): array
+    {
+        return [
+            // CurlHttpClient transformations
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::createCurl(',
+                'new CurlHttpClient(',
+            ],
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::createCurl(',
+                'new CURLHTTPCLIENT(',
+            ],
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::createCurl(',
+                'new \Symfony\Component\HttpClient\CurlHttpClient(',
+            ],
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::createCurl(',
+                'new Symfony\Component\HttpClient\CurlHttpClient(',
+            ],
+
+            // NativeHttpClient transformations
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::createNative(',
+                'new NativeHttpClient(',
+            ],
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::createNative(',
+                'new NATIVEHTTPCLIENT(',
+            ],
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::createNative(',
+                'new \Symfony\Component\HttpClient\NativeHttpClient(',
+            ],
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::createNative(',
+                'new Symfony\Component\HttpClient\NativeHttpClient(',
+            ],
+
+            // HttpClient::create() transformations
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::create(',
+                'HttpClient::create(',
+            ],
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::create(',
+                'HTTPCLIENT::CREATE(',
+            ],
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::create(',
+                '\Symfony\Component\HttpClient\HttpClient::create(',
+            ],
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::create(',
+                'Symfony\Component\HttpClient\HttpClient::create(',
+            ],
+            [
+                '$client = \VCR\LibraryHooks\SymfonyHttpClientHook::create();',
+                '$client = HttpClient::create();',
+            ],
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::create([\'timeout\' => 30])',
+                'HttpClient::create([\'timeout\' => 30])',
+            ],
+
+            // Should NOT transform method calls
+            [
+                '$client->new CurlHttpClient(',
+                '$client->new CurlHttpClient(',
+            ],
+            [
+                'SomeClass::new CurlHttpClient(',
+                'SomeClass::new CurlHttpClient(',
+            ],
+
+            // Should NOT transform if not followed by opening parenthesis
+            [
+                'new CurlHttpClient',
+                'new CurlHttpClient',
+            ],
+
+            // Multiple transformations in same code
+            [
+                '$curl = \VCR\LibraryHooks\SymfonyHttpClientHook::createCurl(); $native = \VCR\LibraryHooks\SymfonyHttpClientHook::createNative();',
+                '$curl = new CurlHttpClient(); $native = new NativeHttpClient();',
+            ],
+
+            // With options
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::createCurl([\'timeout\' => 30])',
+                'new CurlHttpClient([\'timeout\' => 30])',
+            ],
+            [
+                '\VCR\LibraryHooks\SymfonyHttpClientHook::createNative([\'verify_peer\' => false])',
+                'new NativeHttpClient([\'verify_peer\' => false])',
+            ],
+
+            // Real world usage patterns
+            [
+                '$client = \VCR\LibraryHooks\SymfonyHttpClientHook::createCurl();',
+                '$client = new CurlHttpClient();',
+            ],
+            [
+                '$httpClient = \VCR\LibraryHooks\SymfonyHttpClientHook::createNative([\'timeout\' => 30, \'verify_peer\' => false]);',
+                '$httpClient = new NativeHttpClient([\'timeout\' => 30, \'verify_peer\' => false]);',
+            ],
+
+            // In class instantiation
+            [
+                'return \VCR\LibraryHooks\SymfonyHttpClientHook::createCurl();',
+                'return new CurlHttpClient();',
+            ],
+            [
+                '$this->client = \VCR\LibraryHooks\SymfonyHttpClientHook::createNative($options);',
+                '$this->client = new NativeHttpClient($options);',
+            ],
+
+            // Complex scenarios
+            [
+                '$curl = \VCR\LibraryHooks\SymfonyHttpClientHook::createCurl(); $traceable = new TraceableHttpClient($curl);',
+                '$curl = new CurlHttpClient(); $traceable = new TraceableHttpClient($curl);',
+            ],
+
+            // Should transform only the target clients, not other classes
+            [
+                'new HttpClient(); \VCR\LibraryHooks\SymfonyHttpClientHook::createCurl(); new SomeOtherClient();',
+                'new HttpClient(); new CurlHttpClient(); new SomeOtherClient();',
+            ],
+        ];
+    }
+
+    public function testGetName(): void
+    {
+        $transform = new SymfonyHttpClientCodeTransform();
+        $this->assertEquals('vcr_symfony_http_client', SymfonyHttpClientCodeTransform::NAME);
+    }
+
+    public function testTransformPreservesCodeStructure(): void
+    {
+        $codeTransform = new class extends SymfonyHttpClientCodeTransform {
+            public function publicTransformCode(string $code): string
+            {
+                return $this->transformCode($code);
+            }
+        };
+
+        $code = <<<'PHP'
+            <?php
+            namespace App;
+
+            class MyHttpClient
+            {
+                public function __construct()
+                {
+                    $this->client = new CurlHttpClient([
+                        'timeout' => 30,
+                        'verify_peer' => false,
+                    ]);
+                }
+            }
+            PHP;
+
+        $transformed = $codeTransform->publicTransformCode($code);
+
+        // Should contain the transformed call
+        $this->assertStringContainsString('\VCR\LibraryHooks\SymfonyHttpClientHook::createCurl(', $transformed);
+        // Should preserve the rest of the code structure
+        $this->assertStringContainsString('namespace App;', $transformed);
+        $this->assertStringContainsString('class MyHttpClient', $transformed);
+    }
+}

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -35,6 +35,7 @@ final class ConfigurationTest extends TestCase
                 'VCR\LibraryHooks\StreamWrapperHook',
                 'VCR\LibraryHooks\CurlHook',
                 'VCR\LibraryHooks\SoapHook',
+                'VCR\LibraryHooks\SymfonyHttpClientHook',
             ],
             $this->config->getLibraryHooks()
         );

--- a/tests/Unit/Http/NormalizedResponseWrapperTest.php
+++ b/tests/Unit/Http/NormalizedResponseWrapperTest.php
@@ -103,6 +103,7 @@ class NormalizedResponseWrapperTest extends TestCase
 
         $normalizer = function (TransportException $e) {
             $message = rtrim($e->getMessage(), '/');
+
             return new TransportException($message);
         };
 
@@ -137,6 +138,7 @@ class NormalizedResponseWrapperTest extends TestCase
 
         $normalizer = function (TransportException $e) {
             $message = str_replace('/"', '"', $e->getMessage());
+
             return new TransportException($message);
         };
 

--- a/tests/Unit/Http/NormalizedResponseWrapperTest.php
+++ b/tests/Unit/Http/NormalizedResponseWrapperTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Http;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use VCR\Http\NormalizedResponseWrapper;
+
+class NormalizedResponseWrapperTest extends TestCase
+{
+    public function testGetStatusCodePassesThrough(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $wrapper = new NormalizedResponseWrapper($mockResponse, fn ($e) => $e);
+
+        $this->assertSame(200, $wrapper->getStatusCode());
+    }
+
+    public function testGetStatusCodeNormalizesException(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->expects($this->once())
+            ->method('getStatusCode')
+            ->willThrowException(new TransportException('Failed for "http://example.com/"'));
+
+        $normalizer = function (TransportException $e) {
+            return new TransportException('Failed for "http://example.com"'); // Removed trailing slash
+        };
+
+        $wrapper = new NormalizedResponseWrapper($mockResponse, $normalizer);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Failed for "http://example.com"');
+        $wrapper->getStatusCode();
+    }
+
+    public function testGetHeadersPassesThrough(): void
+    {
+        $headers = ['content-type' => ['application/json']];
+
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->expects($this->once())
+            ->method('getHeaders')
+            ->with(true)
+            ->willReturn($headers);
+
+        $wrapper = new NormalizedResponseWrapper($mockResponse, fn ($e) => $e);
+
+        $this->assertSame($headers, $wrapper->getHeaders(true));
+    }
+
+    public function testGetHeadersNormalizesException(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->expects($this->once())
+            ->method('getHeaders')
+            ->willThrowException(new TransportException('Connection failed for "http://localhost:9959/"'));
+
+        $normalizer = function (TransportException $e) {
+            $message = preg_replace('#"(https?://[^"]+)/"#', '"$1"', $e->getMessage());
+            if (null === $message) {
+                $message = $e->getMessage();
+            }
+
+            return new TransportException($message);
+        };
+
+        $wrapper = new NormalizedResponseWrapper($mockResponse, $normalizer);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Connection failed for "http://localhost:9959"');
+        $wrapper->getHeaders();
+    }
+
+    public function testGetContentPassesThrough(): void
+    {
+        $content = '{"data": "test"}';
+
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->expects($this->once())
+            ->method('getContent')
+            ->with(true)
+            ->willReturn($content);
+
+        $wrapper = new NormalizedResponseWrapper($mockResponse, fn ($e) => $e);
+
+        $this->assertSame($content, $wrapper->getContent(true));
+    }
+
+    public function testGetContentNormalizesException(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->expects($this->once())
+            ->method('getContent')
+            ->willThrowException(new TransportException('Timeout for "http://api.example.com"'));
+
+        $normalizer = function (TransportException $e) {
+            $message = rtrim($e->getMessage(), '/');
+            return new TransportException($message);
+        };
+
+        $wrapper = new NormalizedResponseWrapper($mockResponse, $normalizer);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Timeout for "http://api.example.com"');
+        $wrapper->getContent();
+    }
+
+    public function testToArrayPassesThrough(): void
+    {
+        $data = ['id' => 1, 'name' => 'test'];
+
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->expects($this->once())
+            ->method('toArray')
+            ->with(false)
+            ->willReturn($data);
+
+        $wrapper = new NormalizedResponseWrapper($mockResponse, fn ($e) => $e);
+
+        $this->assertSame($data, $wrapper->toArray(false));
+    }
+
+    public function testToArrayNormalizesException(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->expects($this->once())
+            ->method('toArray')
+            ->willThrowException(new TransportException('Parse error for "http://test.com/"'));
+
+        $normalizer = function (TransportException $e) {
+            $message = str_replace('/"', '"', $e->getMessage());
+            return new TransportException($message);
+        };
+
+        $wrapper = new NormalizedResponseWrapper($mockResponse, $normalizer);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Parse error for "http://test.com"');
+        $wrapper->toArray();
+    }
+
+    public function testCancelPassesThrough(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->expects($this->once())
+            ->method('cancel');
+
+        $wrapper = new NormalizedResponseWrapper($mockResponse, fn ($e) => $e);
+
+        $wrapper->cancel();
+    }
+
+    public function testGetInfoPassesThrough(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->expects($this->once())
+            ->method('getInfo')
+            ->with('total_time')
+            ->willReturn(0.5);
+
+        $wrapper = new NormalizedResponseWrapper($mockResponse, fn ($e) => $e);
+
+        $this->assertSame(0.5, $wrapper->getInfo('total_time'));
+    }
+
+    public function testGetInfoWithNullTypeReturnsAllInfo(): void
+    {
+        $info = ['http_code' => 200, 'total_time' => 0.5];
+
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->expects($this->once())
+            ->method('getInfo')
+            ->with(null)
+            ->willReturn($info);
+
+        $wrapper = new NormalizedResponseWrapper($mockResponse, fn ($e) => $e);
+
+        $this->assertSame($info, $wrapper->getInfo(null));
+    }
+}

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -226,7 +226,7 @@ final class CurlHookTest extends TestCase
         curl_close($curlHandle);
 
         $this->assertIsArray($info, 'curl_getinfo() should return an array.');
-        $this->assertCount(22, $info, 'curl_getinfo() should return 22 values.');
+        $this->assertCount(24, $info, 'curl_getinfo() should return 24 values.');
         $this->curlHook->disable();
     }
 
@@ -262,6 +262,41 @@ final class CurlHookTest extends TestCase
         $this->assertArrayHasKey('upload_content_length', $info);
         $this->assertArrayHasKey('starttransfer_time', $info);
         $this->assertArrayHasKey('redirect_time', $info);
+        $this->assertArrayHasKey('private', $info);
+        $this->assertArrayHasKey('certinfo', $info);
+        $this->curlHook->disable();
+    }
+
+    public function testShouldReturnCurlInfoPrivate(): void
+    {
+        $this->curlHook->enable($this->getTestCallback('200', ['private' => 'private data']));
+
+        $curlHandle = curl_init('http://example.com');
+        Assertion::notSame($curlHandle, false);
+        curl_setopt($curlHandle, \CURLOPT_RETURNTRANSFER, true);
+        curl_exec($curlHandle);
+        $info = curl_getinfo($curlHandle, \CURLINFO_PRIVATE);
+        curl_close($curlHandle);
+
+        $this->assertEquals('private data', $info, 'CURLINFO_PRIVATE should be true');
+
+        $this->curlHook->disable();
+    }
+
+    public function testShouldReturnCurlInfoCertinfo(): void
+    {
+        $this->curlHook->enable($this->getTestCallback('200', ['certinfo' => [1, 2, 3]]));
+
+        $curlHandle = curl_init('http://example.com');
+        Assertion::notSame($curlHandle, false);
+        curl_setopt($curlHandle, \CURLOPT_RETURNTRANSFER, true);
+        curl_exec($curlHandle);
+        $info = curl_getinfo($curlHandle, \CURLINFO_CERTINFO);
+        curl_close($curlHandle);
+
+        $this->assertIsArray($info, 'CURLINFO_CERTINFO should be an array');
+        $this->assertNotEmpty($info, 'CURLINFO_CERTINFO should not be empty');
+
         $this->curlHook->disable();
     }
 
@@ -465,10 +500,13 @@ final class CurlHookTest extends TestCase
         $this->curlHook->disable();
     }
 
-    protected function getTestCallback(string $statusCode = '200'): \Closure
+    /**
+     * @param array<string, mixed> $curlInfo
+     */
+    protected function getTestCallback(string $statusCode = '200', array $curlInfo = []): \Closure
     {
         $testClass = $this;
 
-        return \Closure::fromCallable(fn () => new Response($statusCode, [], $testClass->expected));
+        return \Closure::fromCallable(fn () => new Response($statusCode, [], $testClass->expected, $curlInfo));
     }
 }

--- a/tests/Unit/LibraryHooks/SymfonyHttpClientHookTest.php
+++ b/tests/Unit/LibraryHooks/SymfonyHttpClientHookTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\LibraryHooks;
+
+use PHPUnit\Framework\TestCase;
+use VCR\CodeTransform\SymfonyHttpClientCodeTransform;
+use VCR\Configuration;
+use VCR\LibraryHooks\SymfonyHttpClientHook;
+use VCR\Response;
+use VCR\Util\StreamProcessor;
+
+final class SymfonyHttpClientHookTest extends TestCase
+{
+    protected Configuration $config;
+    protected SymfonyHttpClientHook $hook;
+
+    protected function setUp(): void
+    {
+        $this->config = new Configuration();
+        $this->hook = new SymfonyHttpClientHook(
+            new SymfonyHttpClientCodeTransform(),
+            new StreamProcessor($this->config)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->hook->disable();
+    }
+
+    public function testShouldBeDisabledInitially(): void
+    {
+        $this->assertFalse($this->hook->isEnabled(), 'Initially the SymfonyHttpClientHook should be disabled.');
+    }
+
+    public function testShouldBeEnabledAfterEnabling(): void
+    {
+        $this->assertFalse($this->hook->isEnabled(), 'Initially the SymfonyHttpClientHook should be disabled.');
+
+        $this->hook->enable($this->getTestCallback());
+        $this->assertTrue($this->hook->isEnabled(), 'After enabling the SymfonyHttpClientHook should be enabled.');
+
+        $this->hook->disable();
+        $this->assertFalse($this->hook->isEnabled(), 'After disabling the SymfonyHttpClientHook should be disabled.');
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testShouldNotThrowErrorWhenDisabledTwice(): void
+    {
+        $this->hook->disable();
+        $this->hook->disable();
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testShouldNotThrowErrorWhenEnabledTwice(): void
+    {
+        $this->hook->enable($this->getTestCallback());
+        $this->hook->enable($this->getTestCallback());
+        $this->hook->disable();
+    }
+
+    public function testGetRequestCallbackReturnsNull(): void
+    {
+        $this->assertNull(SymfonyHttpClientHook::getRequestCallback(), 'Request callback should be null when not enabled.');
+    }
+
+    public function testGetRequestCallbackReturnsCallbackWhenEnabled(): void
+    {
+        $callback = $this->getTestCallback();
+        $this->hook->enable($callback);
+
+        $this->assertSame($callback, SymfonyHttpClientHook::getRequestCallback(), 'Request callback should be set when enabled.');
+
+        $this->hook->disable();
+    }
+
+    public function testCreateCurlReturnsVCRHttpClient(): void
+    {
+        $client = SymfonyHttpClientHook::createCurl();
+
+        $this->assertInstanceOf(
+            \VCR\VCRHttpClient::class,
+            $client,
+            'createCurl() should return a VCRHttpClient instance.'
+        );
+    }
+
+    public function testCreateCurlWithOptions(): void
+    {
+        $client = SymfonyHttpClientHook::createCurl(['timeout' => 30]);
+
+        $this->assertInstanceOf(
+            \VCR\VCRHttpClient::class,
+            $client,
+            'createCurl() with options should return a VCRHttpClient instance.'
+        );
+    }
+
+    public function testCreateNativeReturnsVCRHttpClient(): void
+    {
+        $client = SymfonyHttpClientHook::createNative();
+
+        $this->assertInstanceOf(
+            \VCR\VCRHttpClient::class,
+            $client,
+            'createNative() should return a VCRHttpClient instance.'
+        );
+    }
+
+    public function testCreateNativeWithOptions(): void
+    {
+        $client = SymfonyHttpClientHook::createNative(['timeout' => 30]);
+
+        $this->assertInstanceOf(
+            \VCR\VCRHttpClient::class,
+            $client,
+            'createNative() with options should return a VCRHttpClient instance.'
+        );
+    }
+
+    public function testDisableClearsRequestCallback(): void
+    {
+        $this->hook->enable($this->getTestCallback());
+        $this->assertNotNull(SymfonyHttpClientHook::getRequestCallback(), 'Request callback should be set after enable.');
+
+        $this->hook->disable();
+        $this->assertNull(SymfonyHttpClientHook::getRequestCallback(), 'Request callback should be null after disable.');
+    }
+
+    public function testCreateCurlWrapsWithVCRHttpClient(): void
+    {
+        $client = SymfonyHttpClientHook::createCurl(['timeout' => 30]);
+
+        // Verify it's a VCRHttpClient wrapping a CurlHttpClient
+        $this->assertInstanceOf(\VCR\VCRHttpClient::class, $client);
+
+        // Test it can make requests (passthrough when VCR not active)
+        $reflection = new \ReflectionClass($client);
+        $property = $reflection->getProperty('client');
+        $property->setAccessible(true);
+        $wrappedClient = $property->getValue($client);
+
+        $this->assertInstanceOf(\Symfony\Component\HttpClient\CurlHttpClient::class, $wrappedClient);
+    }
+
+    public function testCreateNativeWrapsWithVCRHttpClient(): void
+    {
+        $client = SymfonyHttpClientHook::createNative(['timeout' => 30]);
+
+        // Verify it's a VCRHttpClient wrapping a NativeHttpClient
+        $this->assertInstanceOf(\VCR\VCRHttpClient::class, $client);
+
+        // Test it wraps the correct client type
+        $reflection = new \ReflectionClass($client);
+        $property = $reflection->getProperty('client');
+        $property->setAccessible(true);
+        $wrappedClient = $property->getValue($client);
+
+        $this->assertInstanceOf(\Symfony\Component\HttpClient\NativeHttpClient::class, $wrappedClient);
+    }
+
+    public function testEnableRegistersCodeTransformer(): void
+    {
+        $this->assertFalse($this->hook->isEnabled());
+
+        $this->hook->enable($this->getTestCallback());
+
+        $this->assertTrue($this->hook->isEnabled());
+
+        // After enabling, code transformation should be active
+        // This means new CurlHttpClient() calls will be transformed
+        $this->assertNotNull(SymfonyHttpClientHook::getRequestCallback());
+    }
+
+    public function testMultipleClientsCanBeCreated(): void
+    {
+        $client1 = SymfonyHttpClientHook::createCurl(['timeout' => 10]);
+        $client2 = SymfonyHttpClientHook::createCurl(['timeout' => 20]);
+        $client3 = SymfonyHttpClientHook::createNative(['timeout' => 30]);
+
+        $this->assertInstanceOf(\VCR\VCRHttpClient::class, $client1);
+        $this->assertInstanceOf(\VCR\VCRHttpClient::class, $client2);
+        $this->assertInstanceOf(\VCR\VCRHttpClient::class, $client3);
+
+        $this->assertNotSame($client1, $client2);
+        $this->assertNotSame($client2, $client3);
+    }
+
+    protected function getTestCallback(): \Closure
+    {
+        return \Closure::fromCallable(fn () => new Response('200', [], 'test response'));
+    }
+}

--- a/tests/Unit/Util/CurlHelperTest.php
+++ b/tests/Unit/Util/CurlHelperTest.php
@@ -266,9 +266,9 @@ final class CurlHelperTest extends TestCase
         CurlHelper::handleOutput($response, $curlOptions, curl_init());
 
         $expected = [
-            'HTTP/1.1 200 OK',
-            'Content-Length: 0',
-            '',
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
         ];
         $this->assertEquals($expected, $actualHeaders);
     }
@@ -291,9 +291,9 @@ final class CurlHelperTest extends TestCase
         CurlHelper::handleOutput($response, $curlOptions, curl_init());
 
         $expected = [
-            'HTTP/1.1 200 OK',
-            'Content-Length: 0',
-            '',
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
         ];
         $this->assertEquals($expected, $this->headersFound);
     }
@@ -316,9 +316,9 @@ final class CurlHelperTest extends TestCase
         CurlHelper::handleOutput($response, $curlOptions, curl_init());
 
         $expected = [
-            'HTTP/1.1 200 OK',
-            'Content-Length: 0',
-            '',
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
         ];
         $this->assertEquals($expected, $this->headersFound);
     }
@@ -341,9 +341,9 @@ final class CurlHelperTest extends TestCase
         CurlHelper::handleOutput($response, $curlOptions, curl_init());
 
         $expected = [
-            'HTTP/1.1 200 OK',
-            'Content-Length: 0',
-            '',
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
         ];
         $this->assertEquals($expected, $this->headersFound);
     }

--- a/tests/Unit/Util/StreamProcessorTest.php
+++ b/tests/Unit/Util/StreamProcessorTest.php
@@ -132,7 +132,7 @@ final class StreamProcessorTest extends TestCase
             int $errno,
             string $errstr,
             string $errfile = '',
-            int $errline = 0
+            int $errline = 0,
         ): void {
             throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
         }, \E_WARNING);

--- a/tests/Unit/Util/SymfonyHttpClientHelperTest.php
+++ b/tests/Unit/Util/SymfonyHttpClientHelperTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Util;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Util\SymfonyHttpClientHelper;
+
+class SymfonyHttpClientHelperTest extends TestCase
+{
+    /**
+     * @dataProvider expectsNoContentProvider
+     */
+    public function testExpectsNoContent(?string $privateData, bool $expected): void
+    {
+        $ch = curl_init('http://example.com');
+
+        if (null !== $privateData) {
+            curl_setopt($ch, \CURLOPT_PRIVATE, $privateData);
+        }
+
+        $this->assertSame($expected, SymfonyHttpClientHelper::expectsNoContent($ch));
+
+        curl_close($ch);
+    }
+
+    /**
+     * @return array<array{?string, bool}>
+     */
+    public static function expectsNoContentProvider(): array
+    {
+        return [
+            'done state with retry 0' => ['_0', true],
+            'done state with retry 1' => ['_1', true],
+            'done state with retry 9' => ['_9', true],
+            'headers state' => ['H0', false],
+            'content state' => ['C0', false],
+            'null value (not set)' => [null, false],
+            'empty string' => ['', false],
+            'invalid format' => ['invalid', false],
+            'only underscore' => ['_', true],
+        ];
+    }
+
+    public function testExpectsNoContentWithSnapshot(): void
+    {
+        $ch = curl_init('http://example.com');
+        curl_setopt($ch, \CURLOPT_PRIVATE, 'H0'); // Set to H0 on handle
+
+        // Snapshot overrides handle value
+        $this->assertTrue(SymfonyHttpClientHelper::expectsNoContent($ch, '_0'));
+        $this->assertFalse(SymfonyHttpClientHelper::expectsNoContent($ch, 'C0'));
+
+        curl_close($ch);
+    }
+
+    public function testTransitionToContentPhaseFromHeadersState(): void
+    {
+        $ch = curl_init('http://example.com');
+        curl_setopt($ch, \CURLOPT_PRIVATE, 'H0');
+
+        SymfonyHttpClientHelper::transitionToContentPhase($ch, 'H0');
+
+        $result = curl_getinfo($ch, \CURLINFO_PRIVATE);
+        $this->assertSame('C0', $result);
+
+        curl_close($ch);
+    }
+
+    public function testTransitionToContentPhaseFromHeadersStateWithRetry(): void
+    {
+        $ch = curl_init('http://example.com');
+        curl_setopt($ch, \CURLOPT_PRIVATE, 'H3');
+
+        SymfonyHttpClientHelper::transitionToContentPhase($ch, 'H3');
+
+        $result = curl_getinfo($ch, \CURLINFO_PRIVATE);
+        $this->assertSame('C3', $result);
+
+        curl_close($ch);
+    }
+
+    public function testTransitionToContentPhaseDoesNothingWhenAlreadyInContentState(): void
+    {
+        $ch = curl_init('http://example.com');
+        curl_setopt($ch, \CURLOPT_PRIVATE, 'C0');
+
+        SymfonyHttpClientHelper::transitionToContentPhase($ch, 'C0');
+
+        $result = curl_getinfo($ch, \CURLINFO_PRIVATE);
+        $this->assertSame('C0', $result);
+
+        curl_close($ch);
+    }
+
+    public function testTransitionToContentPhaseDoesNothingWhenInDoneState(): void
+    {
+        $ch = curl_init('http://example.com');
+        curl_setopt($ch, \CURLOPT_PRIVATE, '_0');
+
+        SymfonyHttpClientHelper::transitionToContentPhase($ch, '_0');
+
+        $result = curl_getinfo($ch, \CURLINFO_PRIVATE);
+        $this->assertSame('_0', $result);
+
+        curl_close($ch);
+    }
+
+    public function testTransitionToContentPhaseHandlesNotSet(): void
+    {
+        $ch = curl_init('http://example.com');
+        // Don't set CURLOPT_PRIVATE at all
+
+        SymfonyHttpClientHelper::transitionToContentPhase($ch);
+
+        // Should not crash, no transition occurs
+        $result = curl_getinfo($ch, \CURLINFO_PRIVATE);
+        $this->assertFalse($result, 'PRIVATE should remain unset');
+
+        curl_close($ch);
+    }
+
+    public function testTransitionToContentPhaseWithSnapshot(): void
+    {
+        $ch = curl_init('http://example.com');
+        curl_setopt($ch, \CURLOPT_PRIVATE, 'C0'); // Set to C0 on handle
+
+        // Snapshot says it's H2, so transition should happen
+        SymfonyHttpClientHelper::transitionToContentPhase($ch, 'H2');
+
+        $result = curl_getinfo($ch, \CURLINFO_PRIVATE);
+        $this->assertSame('C2', $result, 'Should transition based on snapshot value');
+
+        curl_close($ch);
+    }
+
+    public function testGetPrivateDataReturnsNullWhenNotSet(): void
+    {
+        $ch = curl_init('http://example.com');
+
+        $result = SymfonyHttpClientHelper::getPrivateData($ch);
+
+        $this->assertNull($result);
+
+        curl_close($ch);
+    }
+
+    public function testGetPrivateDataReturnsValueWhenSet(): void
+    {
+        $ch = curl_init('http://example.com');
+        curl_setopt($ch, \CURLOPT_PRIVATE, 'H5');
+
+        $result = SymfonyHttpClientHelper::getPrivateData($ch);
+
+        $this->assertSame('H5', $result);
+
+        curl_close($ch);
+    }
+
+    public function testGetPrivateDataPrefersSnapshot(): void
+    {
+        $ch = curl_init('http://example.com');
+        curl_setopt($ch, \CURLOPT_PRIVATE, 'C0');
+
+        $result = SymfonyHttpClientHelper::getPrivateData($ch, 'H3');
+
+        $this->assertSame('H3', $result, 'Snapshot should override handle value');
+
+        curl_close($ch);
+    }
+}

--- a/tests/Unit/Util/UrlReconstructorTest.php
+++ b/tests/Unit/Util/UrlReconstructorTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Util;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Util\UrlReconstructor;
+
+class UrlReconstructorTest extends TestCase
+{
+    public function testReconstructFromHostHeaderWhenHostDiffers(): void
+    {
+        $url = 'http://188.114.97.2/posts/1';
+        $hostHeader = 'jsonplaceholder.typicode.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertSame('http://jsonplaceholder.typicode.com/posts/1', $result);
+    }
+
+    public function testReconstructFromHostHeaderWithHttps(): void
+    {
+        $url = 'https://1.2.3.4/api/users';
+        $hostHeader = 'api.example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertSame('https://api.example.com/api/users', $result);
+    }
+
+    public function testReconstructFromHostHeaderWithNonStandardPort(): void
+    {
+        $url = 'http://127.0.0.1:8080/test';
+        $hostHeader = 'localhost';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertSame('http://localhost:8080/test', $result);
+    }
+
+    public function testReconstructFromHostHeaderWithQueryString(): void
+    {
+        $url = 'http://10.0.0.1/search?q=test&limit=10';
+        $hostHeader = 'search.example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertSame('http://search.example.com/search?q=test&limit=10', $result);
+    }
+
+    public function testReconstructFromHostHeaderWithFragment(): void
+    {
+        $url = 'http://192.168.1.1/page#section';
+        $hostHeader = 'docs.example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertSame('http://docs.example.com/page#section', $result);
+    }
+
+    public function testReconstructFromHostHeaderWithQueryAndFragment(): void
+    {
+        $url = 'https://8.8.8.8/docs?lang=en#intro';
+        $hostHeader = 'help.example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertSame('https://help.example.com/docs?lang=en#intro', $result);
+    }
+
+    public function testReconstructFromHostHeaderIgnoresStandardHttpPort80(): void
+    {
+        $url = 'http://1.2.3.4:80/api';
+        $hostHeader = 'api.example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertSame('http://api.example.com/api', $result);
+    }
+
+    public function testReconstructFromHostHeaderIgnoresStandardHttpsPort443(): void
+    {
+        $url = 'https://1.2.3.4:443/secure';
+        $hostHeader = 'secure.example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertSame('https://secure.example.com/secure', $result);
+    }
+
+    public function testReconstructFromHostHeaderWithRootPath(): void
+    {
+        $url = 'http://127.0.0.1/';
+        $hostHeader = 'example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertSame('http://example.com/', $result);
+    }
+
+    public function testReconstructFromHostHeaderWithNoPath(): void
+    {
+        $url = 'http://10.0.0.1';
+        $hostHeader = 'example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertSame('http://example.com/', $result);
+    }
+
+    public function testReconstructReturnsNullWhenHostMatches(): void
+    {
+        $url = 'http://example.com/api';
+        $hostHeader = 'example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertNull($result, 'Should return null when no reconstruction is needed');
+    }
+
+    public function testReconstructReturnsNullWhenUrlHasNoHost(): void
+    {
+        $url = '/relative/path';
+        $hostHeader = 'example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertNull($result, 'Should return null for URLs without host');
+    }
+
+    public function testReconstructReturnsNullForInvalidUrl(): void
+    {
+        $url = 'not a valid url';
+        $hostHeader = 'example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertNull($result);
+    }
+
+    public function testReconstructHandlesIPv6Address(): void
+    {
+        $url = 'http://[2001:db8::1]/api';
+        $hostHeader = 'api.example.com';
+
+        $result = UrlReconstructor::reconstructFromHostHeader($url, $hostHeader);
+
+        $this->assertSame('http://api.example.com/api', $result);
+    }
+}

--- a/tests/Unit/VCRHttpClientTest.php
+++ b/tests/Unit/VCRHttpClientTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use VCR\VCRHttpClient;
+
+final class VCRHttpClientTest extends TestCase
+{
+    public function testImplementsHttpClientInterface(): void
+    {
+        $baseClient = new MockHttpClient();
+        $client = new VCRHttpClient($baseClient);
+
+        $this->assertInstanceOf(
+            \Symfony\Contracts\HttpClient\HttpClientInterface::class,
+            $client,
+            'VCRHttpClient should implement HttpClientInterface.'
+        );
+    }
+
+    public function testRequestPassesThroughWhenVCRNotActive(): void
+    {
+        $expectedBody = 'test response';
+        $mockResponse = new MockResponse($expectedBody);
+        $baseClient = new MockHttpClient($mockResponse);
+        $client = new VCRHttpClient($baseClient);
+
+        $response = $client->request('GET', 'https://example.com');
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expectedBody, $response->getContent());
+    }
+
+    public function testWithOptionsReturnsNewInstance(): void
+    {
+        $baseClient = new MockHttpClient();
+        $client = new VCRHttpClient($baseClient);
+
+        $newClient = $client->withOptions(['timeout' => 30]);
+
+        $this->assertNotSame($client, $newClient, 'withOptions() should return a new instance.');
+        $this->assertInstanceOf(VCRHttpClient::class, $newClient);
+    }
+
+    public function testStreamPassesThroughNonMockResponses(): void
+    {
+        $mockResponse1 = new MockResponse('test1');
+        $mockResponse2 = new MockResponse('test2');
+        $baseClient = new MockHttpClient([$mockResponse1, $mockResponse2]);
+        $client = new VCRHttpClient($baseClient);
+
+        $response1 = $client->request('GET', 'https://example.com/1');
+        $response2 = $client->request('GET', 'https://example.com/2');
+        $stream = $client->stream([$response1, $response2]);
+
+        $this->assertInstanceOf(
+            \Symfony\Contracts\HttpClient\ResponseStreamInterface::class,
+            $stream,
+            'stream() should return a ResponseStreamInterface.'
+        );
+    }
+
+    public function testStreamHandlesMockResponsesDirectly(): void
+    {
+        $mockResponses = [
+            new MockResponse('response1'),
+            new MockResponse('response2'),
+        ];
+
+        $baseClient = new MockHttpClient();
+        $client = new VCRHttpClient($baseClient);
+
+        $stream = $client->stream($mockResponses);
+
+        $this->assertInstanceOf(
+            \Symfony\Contracts\HttpClient\ResponseStreamInterface::class,
+            $stream,
+            'stream() should handle array of MockResponse instances.'
+        );
+
+        // Verify the custom stream implementation works
+        $count = 0;
+        foreach ($stream as $response => $chunk) {
+            $this->assertInstanceOf(MockResponse::class, $response);
+            $this->assertTrue($chunk->isLast(), 'Chunk should be marked as last for MockResponse.');
+            ++$count;
+        }
+
+        $this->assertEquals(2, $count, 'Stream should yield all MockResponses.');
+    }
+
+    public function testNormalizeTransportExceptionRemovesTrailingSlash(): void
+    {
+        $baseClient = new MockHttpClient(function (): void {
+            throw new \Symfony\Component\HttpClient\Exception\TransportException('Failed to connect for "http://example.com/".');
+        });
+
+        $client = new VCRHttpClient($baseClient);
+
+        $this->expectException(\Symfony\Component\HttpClient\Exception\TransportException::class);
+        $this->expectExceptionMessage('Failed to connect for "http://example.com".');
+
+        $response = $client->request('GET', 'http://example.com');
+        // Force the request to execute (Symfony HttpClient is lazy)
+        $response->getHeaders();
+    }
+
+    public function testWrappingCurlHttpClient(): void
+    {
+        $curlClient = new \Symfony\Component\HttpClient\CurlHttpClient();
+        $client = new VCRHttpClient($curlClient);
+
+        $this->assertInstanceOf(VCRHttpClient::class, $client);
+    }
+
+    public function testWrappingNativeHttpClient(): void
+    {
+        $nativeClient = new \Symfony\Component\HttpClient\NativeHttpClient();
+        $client = new VCRHttpClient($nativeClient);
+
+        $this->assertInstanceOf(VCRHttpClient::class, $client);
+    }
+
+    public function testWrappingTraceableHttpClient(): void
+    {
+        $baseClient = new MockHttpClient();
+        $traceableClient = new \Symfony\Component\HttpClient\TraceableHttpClient($baseClient);
+        $client = new VCRHttpClient($traceableClient);
+
+        $this->assertInstanceOf(VCRHttpClient::class, $client);
+    }
+
+    public function testHandlesSymfonySpecificOptions(): void
+    {
+        $mockResponse = new MockResponse('test');
+        $baseClient = new MockHttpClient($mockResponse);
+        $client = new VCRHttpClient($baseClient);
+
+        // Test with Symfony-specific options
+        $response = $client->request('GET', 'https://example.com', [
+            'max_redirects' => 5,
+            'http_version' => '2.0',
+            'resolve' => ['example.com' => '127.0.0.1'],
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testChainedWithOptionsCreatesNewInstance(): void
+    {
+        $baseClient = new MockHttpClient();
+        $client = new VCRHttpClient($baseClient);
+
+        $client1 = $client->withOptions(['timeout' => 10]);
+        $client2 = $client1->withOptions(['timeout' => 20]);
+
+        $this->assertNotSame($client, $client1);
+        $this->assertNotSame($client1, $client2);
+        $this->assertInstanceOf(VCRHttpClient::class, $client2);
+    }
+}

--- a/tests/Unit/VCRNativeHttpClientTest.php
+++ b/tests/Unit/VCRNativeHttpClientTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use VCR\VCRNativeHttpClient;
+
+final class VCRNativeHttpClientTest extends TestCase
+{
+    public function testImplementsHttpClientInterface(): void
+    {
+        $client = new VCRNativeHttpClient();
+
+        $this->assertInstanceOf(
+            \Symfony\Contracts\HttpClient\HttpClientInterface::class,
+            $client,
+            'VCRNativeHttpClient should implement HttpClientInterface.'
+        );
+    }
+
+    public function testConstructorWithDefaultOptions(): void
+    {
+        $client = new VCRNativeHttpClient();
+
+        $this->assertInstanceOf(VCRNativeHttpClient::class, $client);
+    }
+
+    public function testConstructorWithOptions(): void
+    {
+        $client = new VCRNativeHttpClient(['timeout' => 30]);
+
+        $this->assertInstanceOf(VCRNativeHttpClient::class, $client);
+    }
+
+    public function testConstructorWithMaxHostConnections(): void
+    {
+        $client = new VCRNativeHttpClient([], 10);
+
+        $this->assertInstanceOf(VCRNativeHttpClient::class, $client);
+    }
+
+    public function testConstructorWithMaxPendingPushes(): void
+    {
+        $client = new VCRNativeHttpClient([], 6, 100);
+
+        $this->assertInstanceOf(VCRNativeHttpClient::class, $client);
+    }
+
+    public function testWithOptionsReturnsNewInstance(): void
+    {
+        $client = new VCRNativeHttpClient();
+        $newClient = $client->withOptions(['timeout' => 30]);
+
+        $this->assertNotSame($client, $newClient, 'withOptions() should return a new instance.');
+        $this->assertInstanceOf(VCRNativeHttpClient::class, $newClient);
+    }
+
+    /**
+     * @group uses_internet
+     */
+    public function testRequestMakesRealRequest(): void
+    {
+        $client = new VCRNativeHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $response = $client->request('GET', 'http://example.com');
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('Example Domain', $response->getContent());
+    }
+
+    /**
+     * @group uses_internet
+     */
+    public function testStreamReturnsResponseStream(): void
+    {
+        $client = new VCRNativeHttpClient(['verify_peer' => false, 'verify_host' => false]);
+        $response = $client->request('GET', 'http://example.com');
+        $stream = $client->stream([$response]);
+
+        $this->assertInstanceOf(
+            \Symfony\Contracts\HttpClient\ResponseStreamInterface::class,
+            $stream,
+            'stream() should return a ResponseStreamInterface.'
+        );
+    }
+}

--- a/tests/fixtures/httpclient/concurrent-requests.yml
+++ b/tests/fixtures/httpclient/concurrent-requests.yml
@@ -1,0 +1,181 @@
+
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:42 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '330'
+            server: nginx
+            etag: 'W/"14a-823f7YL5KEQRi57wTp6GUy3M+Ds"'
+            set-cookie: 'sails.sid=s%3AwomMduYW9w6MVhL15-LH_-c4E5FKWGhY.h%2F6z91fkSzisdU39eLQxTd28Cbt7dgF7hZQ4nkBVTqY; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853562.742\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53bfa-09c48b2e2b41f24633df78a2\",\n    \"accept\": \"*/*\"\n  },\n  \"url\": \"https://postman-echo.com/get\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 302
+            request_size: 56
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.469151
+            namelookup_time: 0.02672
+            connect_time: 0.121553
+            pretransfer_time: 0.312162
+            size_upload: 0.0
+            size_download: 330.0
+            speed_download: 703.0
+            speed_upload: 0.0
+            download_content_length: 330.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.469103
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 18.210.107.39
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 35640
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 311884
+            connect_time_us: 121553
+            namelookup_time_us: 26720
+            pretransfer_time_us: 312162
+            redirect_time_us: 0
+            starttransfer_time_us: 469103
+            total_time_us: 469151
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get?foo=42'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:43 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '356'
+            server: nginx
+            etag: 'W/"164-xujqCIlp+PinrS4SlQVTPk2c+XE"'
+            set-cookie: 'sails.sid=s%3ArBG5odceOJVREtxqb6PILb8v0KNX8Xz4.rvs7NZcmXp00T2d2rHviMIvpw%2BoYdwUA2Zhu7xAfPXk; Path=/; HttpOnly'
+        body: "{\n  \"args\": {\n    \"foo\": \"42\"\n  },\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853563.227\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53bfb-54e0064d26473de73729ac82\",\n    \"accept\": \"*/*\"\n  },\n  \"url\": \"https://postman-echo.com/get?foo=42\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get?foo=42'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 302
+            request_size: 63
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.418129
+            namelookup_time: 0.027002
+            connect_time: 0.120801
+            pretransfer_time: 0.31727
+            size_upload: 0.0
+            size_download: 356.0
+            speed_download: 851.0
+            speed_upload: 0.0
+            download_content_length: 356.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.418069
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 52.20.242.160
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 42850
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 317047
+            connect_time_us: 120801
+            namelookup_time_us: 27002
+            pretransfer_time_us: 317270
+            redirect_time_us: 0
+            starttransfer_time_us: 418069
+            total_time_us: 418129
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get?bar=123'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:43 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '358'
+            server: nginx
+            etag: 'W/"166-6G1rHzNYiR+OWLYrrXdYD7333V4"'
+            set-cookie: 'sails.sid=s%3AcI17UiRqhAx2MxkAj4cdg8dynKJ4OXEu.Nu6ttkWsjgR5FpGmST99lh5iPwrmI4CUXl%2F7ZjDSgK0; Path=/; HttpOnly'
+        body: "{\n  \"args\": {\n    \"bar\": \"123\"\n  },\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853563.645\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53bfb-64294fec0961fa9d3a159b12\",\n    \"accept\": \"*/*\"\n  },\n  \"url\": \"https://postman-echo.com/get?bar=123\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get?bar=123'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 302
+            request_size: 64
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.416978
+            namelookup_time: 0.026721
+            connect_time: 0.120723
+            pretransfer_time: 0.312006
+            size_upload: 0.0
+            size_download: 358.0
+            speed_download: 858.0
+            speed_upload: 0.0
+            download_content_length: 358.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.416937
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 54.204.252.241
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 47988
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 311831
+            connect_time_us: 120723
+            namelookup_time_us: 26721
+            pretransfer_time_us: 312006
+            redirect_time_us: 0
+            starttransfer_time_us: 416937
+            total_time_us: 416978
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/httpclient/curl-http-client-options.yml
+++ b/tests/fixtures/httpclient/curl-http-client-options.yml
@@ -1,0 +1,62 @@
+
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get'
+        headers:
+            X-Custom-Header: test-value
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:46 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '367'
+            server: nginx
+            etag: 'W/"16f-dSP3/H5+HDKP2TreyPhmRRznZcU"'
+            set-cookie: 'sails.sid=s%3Az48jYwBjaku0TxVD2GS_si-0BtCr48dm.r798L2%2FasPi2rLF40IxzzjzDMMV05KfPeQRZ9dX%2B%2BGs; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853566.441\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53bfe-16cfbfb4497797c47ed32190\",\n    \"accept\": \"*/*\",\n    \"x-custom-header\": \"test-value\"\n  },\n  \"url\": \"https://postman-echo.com/get\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 306
+            request_size: 85
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.459924
+            namelookup_time: 0.027805
+            connect_time: 0.121929
+            pretransfer_time: 0.31309
+            size_upload: 0.0
+            size_download: 367.0
+            speed_download: 797.0
+            speed_upload: 0.0
+            download_content_length: 367.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.459881
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 18.210.107.39
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 52844
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 312849
+            connect_time_us: 121929
+            namelookup_time_us: 27805
+            pretransfer_time_us: 313090
+            redirect_time_us: 0
+            starttransfer_time_us: 459881
+            total_time_us: 459924
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/httpclient/curl-http-client.yml
+++ b/tests/fixtures/httpclient/curl-http-client.yml
@@ -1,0 +1,183 @@
+
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:45 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '330'
+            server: nginx
+            etag: 'W/"14a-IT9w9h3NHLRdvS6kSWVDiZ8tK/w"'
+            set-cookie: 'sails.sid=s%3AqKeQ79eMNI8JfcwoQyH4EZ8N2_O5jtVE.PQsuQsDBEzPgEf%2BPLzVMLYB4k8BJHdTAEJCY54CEsDw; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853565.175\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53bfd-625fd7d2294faf14196a24f7\",\n    \"accept\": \"*/*\"\n  },\n  \"url\": \"https://postman-echo.com/get\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 302
+            request_size: 56
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.413283
+            namelookup_time: 0.026387
+            connect_time: 0.121016
+            pretransfer_time: 0.312541
+            size_upload: 0.0
+            size_download: 330.0
+            speed_download: 798.0
+            speed_upload: 0.0
+            download_content_length: 330.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.41323
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 3.95.46.189
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 46072
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 312323
+            connect_time_us: 121016
+            namelookup_time_us: 26387
+            pretransfer_time_us: 312541
+            redirect_time_us: 0
+            starttransfer_time_us: 413230
+            total_time_us: 413283
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0
+-
+    request:
+        method: POST
+        url: 'https://postman-echo.com/post'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:45 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '430'
+            server: nginx
+            etag: 'W/"1ae-FSOuPW04oFx0I8RTRIvBsQEEpqM"'
+            set-cookie: 'sails.sid=s%3A_NufU1RFJCujxhrPcZ_3YsMqZsqAWpuk.Lpi%2BVFWxOswEZOm6PDLZmbtbQGrdZXCCC29eWa1fEMA; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"data\": {},\n  \"files\": {},\n  \"form\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853565.594\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53bfd-60de606849bb61eb528f2129\",\n    \"accept\": \"*/*\",\n    \"content-type\": \"application/json\"\n  },\n  \"json\": null,\n  \"url\": \"https://postman-echo.com/post\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/post'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 302
+            request_size: 58
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.416302
+            namelookup_time: 0.027026
+            connect_time: 0.124017
+            pretransfer_time: 0.315309
+            size_upload: 0.0
+            size_download: 430.0
+            speed_download: 1032.0
+            speed_upload: 0.0
+            download_content_length: 430.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.416246
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 3.213.210.224
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 35616
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 315157
+            connect_time_us: 124017
+            namelookup_time_us: 27026
+            pretransfer_time_us: 315309
+            redirect_time_us: 0
+            starttransfer_time_us: 416246
+            total_time_us: 416302
+            effective_method: POST
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0
+-
+    request:
+        method: POST
+        url: 'https://postman-echo.com/post'
+        headers:
+            Host: postman-echo.com
+            Content-Type: application/json
+        body: '{"test":true}'
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:46 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '496'
+            server: nginx
+            etag: 'W/"1f0-7ouGbktQ+tGwLql/LDlBYXEtn5E"'
+            set-cookie: 'sails.sid=s%3AWI_pizRG-5Iis7f36NkXOPvPSscPzX5_.ujYnuYmhcrt0bymSVzH5iPCpb5VP%2FHUdNQR3MDy%2FAow; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"data\": {\n    \"test\": true\n  },\n  \"files\": {},\n  \"form\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853566.019\",\n    \"connection\": \"close\",\n    \"content-length\": \"13\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53bfe-736a803a512d6e4330c4833d\",\n    \"accept\": \"*/*\",\n    \"content-type\": \"application/json\"\n  },\n  \"json\": {\n    \"test\": true\n  },\n  \"url\": \"https://postman-echo.com/post\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/post'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 304
+            request_size: 123
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.413754
+            namelookup_time: 0.026774
+            connect_time: 0.121138
+            pretransfer_time: 0.314888
+            size_upload: 13.0
+            size_download: 496.0
+            speed_download: 1198.0
+            speed_upload: 31.0
+            download_content_length: 496.0
+            upload_content_length: 13.0
+            starttransfer_time: 0.413713
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 54.204.252.241
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 47990
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 314615
+            connect_time_us: 121138
+            namelookup_time_us: 26774
+            pretransfer_time_us: 314888
+            redirect_time_us: 0
+            starttransfer_time_us: 413713
+            total_time_us: 413754
+            effective_method: POST
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/httpclient/native-http-client-workaround.yml
+++ b/tests/fixtures/httpclient/native-http-client-workaround.yml
@@ -1,0 +1,61 @@
+
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:48 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '330'
+            server: nginx
+            etag: 'W/"14a-xMJOcADaNfOxZOg+LHxWarzLVJ8"'
+            set-cookie: 'sails.sid=s%3AxIVZvMpiKbn6QPUzuYsjkyhuzsXD0Fq0.XXg%2BSfnMBo6kR4kT4qa0LVomJQxHm4bCENQ4X6jeu5g; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853568.696\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53c00-4512ab554689a3111bd5f889\",\n    \"accept\": \"*/*\"\n  },\n  \"url\": \"https://postman-echo.com/get\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 302
+            request_size: 56
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.407318
+            namelookup_time: 0.026829
+            connect_time: 0.120821
+            pretransfer_time: 0.311378
+            size_upload: 0.0
+            size_download: 330.0
+            speed_download: 810.0
+            speed_upload: 0.0
+            download_content_length: 330.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.407283
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 18.210.107.39
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 52846
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 311026
+            connect_time_us: 120821
+            namelookup_time_us: 26829
+            pretransfer_time_us: 311378
+            redirect_time_us: 0
+            starttransfer_time_us: 407283
+            total_time_us: 407318
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/httpclient/native-http-client.yml
+++ b/tests/fixtures/httpclient/native-http-client.yml
@@ -1,0 +1,61 @@
+
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:48 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '330'
+            server: nginx
+            etag: 'W/"14a-eR/mnXYiBQVP5KrfWXuPTiW8dX8"'
+            set-cookie: 'sails.sid=s%3Ai2uho7LU1s2ZNCgs683yTAbnZB8Z_tDL.ktX4GNZxutZxQVxIinbsbL6I5WlIXbRWrNVdEu0myHA; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853568.282\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53c00-2bc69c3d6c14676745570857\",\n    \"accept\": \"*/*\"\n  },\n  \"url\": \"https://postman-echo.com/get\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 300
+            request_size: 56
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.413656
+            namelookup_time: 0.027561
+            connect_time: 0.121737
+            pretransfer_time: 0.314168
+            size_upload: 0.0
+            size_download: 330.0
+            speed_download: 797.0
+            speed_upload: 0.0
+            download_content_length: 330.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.413618
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 52.20.242.160
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 42886
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 313914
+            connect_time_us: 121737
+            namelookup_time_us: 27561
+            pretransfer_time_us: 314168
+            redirect_time_us: 0
+            starttransfer_time_us: 413618
+            total_time_us: 413656
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/httpclient/stream-multiple.yml
+++ b/tests/fixtures/httpclient/stream-multiple.yml
@@ -1,0 +1,121 @@
+
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:44 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '330'
+            server: nginx
+            etag: 'W/"14a-vAquYbgwb7Wm57VhmTfNF0/FxUY"'
+            set-cookie: 'sails.sid=s%3AYBxTP2twYj4LyfjVPhqdiRihleg0t66c.fE%2F7x1d7dSMecpFvZ3y%2F%2BOZLE2aOTaxHXAO8wqkixiw; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853564.074\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53bfc-7ef47e9445592d1f59e1c853\",\n    \"accept\": \"*/*\"\n  },\n  \"url\": \"https://postman-echo.com/get\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 306
+            request_size: 56
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.416038
+            namelookup_time: 0.026954
+            connect_time: 0.121366
+            pretransfer_time: 0.31296
+            size_upload: 0.0
+            size_download: 330.0
+            speed_download: 793.0
+            speed_upload: 0.0
+            download_content_length: 330.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.415975
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 52.20.242.160
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 42856
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 312711
+            connect_time_us: 121366
+            namelookup_time_us: 26954
+            pretransfer_time_us: 312960
+            redirect_time_us: 0
+            starttransfer_time_us: 415975
+            total_time_us: 416038
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get?foo=42'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:44 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '356'
+            server: nginx
+            etag: 'W/"164-cvX8/dPL1ol5krreTp9cYSTJYD4"'
+            set-cookie: 'sails.sid=s%3AYdmM2sPyB_CosEzxs5bymso_UBDM6ksS.F884lRyBfEXg5rxxqHSvD%2FbOGPJ5bs77vfY8SC0org8; Path=/; HttpOnly'
+        body: "{\n  \"args\": {\n    \"foo\": \"42\"\n  },\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853564.493\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53bfc-7fdfda576c6fc3854e2584ed\",\n    \"accept\": \"*/*\"\n  },\n  \"url\": \"https://postman-echo.com/get?foo=42\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get?foo=42'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 302
+            request_size: 63
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.41274
+            namelookup_time: 0.027645
+            connect_time: 0.122176
+            pretransfer_time: 0.315571
+            size_upload: 0.0
+            size_download: 356.0
+            speed_download: 862.0
+            speed_upload: 0.0
+            download_content_length: 356.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.412679
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 52.20.242.160
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 42870
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 315307
+            connect_time_us: 122176
+            namelookup_time_us: 27645
+            pretransfer_time_us: 315571
+            redirect_time_us: 0
+            starttransfer_time_us: 412679
+            total_time_us: 412740
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/httpclient/vcr-native-http-client-options.yml
+++ b/tests/fixtures/httpclient/vcr-native-http-client-options.yml
@@ -1,0 +1,61 @@
+
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:54 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '330'
+            server: nginx
+            etag: 'W/"14a-UqJ7q5rix/Z1wyI61b2Vc+LXerk"'
+            set-cookie: 'sails.sid=s%3Am0K_vCDiNts5p63ElJQluyLH1Geb1gm4.1CA2HtE75RnFsUy3Y8VqJi0nOvC%2F07JMmn4824S5J3I; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853573.900\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53c05-1ae967951c97ac60558572ae\",\n    \"accept\": \"*/*\"\n  },\n  \"url\": \"https://postman-echo.com/get\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 302
+            request_size: 56
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.522044
+            namelookup_time: 0.027271
+            connect_time: 0.122555
+            pretransfer_time: 0.314898
+            size_upload: 0.0
+            size_download: 330.0
+            speed_download: 632.0
+            speed_upload: 0.0
+            download_content_length: 330.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.522005
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 3.213.210.224
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 51334
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 314659
+            connect_time_us: 122555
+            namelookup_time_us: 27271
+            pretransfer_time_us: 314898
+            redirect_time_us: 0
+            starttransfer_time_us: 522005
+            total_time_us: 522044
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/httpclient/vcr-native-http-client.yml
+++ b/tests/fixtures/httpclient/vcr-native-http-client.yml
@@ -1,0 +1,183 @@
+
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:52 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '330'
+            server: nginx
+            etag: 'W/"14a-VfD5KuzuthYQqG+1dSRIDe+QceA"'
+            set-cookie: 'sails.sid=s%3Are-nhQpdnpocwxI8U9J9trsbl3RY1iKx.he8TdMm6a53EBzBhCCJp%2Fq2EJvwLr0qJlQxB1ITOuEg; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853572.638\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53c04-220ed1df6479978c389e21e7\",\n    \"accept\": \"*/*\"\n  },\n  \"url\": \"https://postman-echo.com/get\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 302
+            request_size: 56
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.410961
+            namelookup_time: 0.02924
+            connect_time: 0.123474
+            pretransfer_time: 0.314706
+            size_upload: 0.0
+            size_download: 330.0
+            speed_download: 802.0
+            speed_upload: 0.0
+            download_content_length: 330.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.410923
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 18.210.107.39
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 52866
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 314437
+            connect_time_us: 123474
+            namelookup_time_us: 29240
+            pretransfer_time_us: 314706
+            redirect_time_us: 0
+            starttransfer_time_us: 410923
+            total_time_us: 410961
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0
+-
+    request:
+        method: POST
+        url: 'https://postman-echo.com/post'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:53 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '430'
+            server: nginx
+            etag: 'W/"1ae-9lgxiZ9zrP9Q7uGdCRA0CcTIfDk"'
+            set-cookie: 'sails.sid=s%3A6fqVpHLz3vUi-uquyo7hJ98nBl0pyHP8.rfQFmuv27sXpTZfPPEHwvQeKoOzUIReAO21DMM2SonM; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"data\": {},\n  \"files\": {},\n  \"form\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853573.057\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53c05-1808687b15dc325f77877a7b\",\n    \"accept\": \"*/*\",\n    \"content-type\": \"application/json\"\n  },\n  \"json\": null,\n  \"url\": \"https://postman-echo.com/post\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/post'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 300
+            request_size: 58
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.414774
+            namelookup_time: 0.02766
+            connect_time: 0.122771
+            pretransfer_time: 0.31839
+            size_upload: 0.0
+            size_download: 430.0
+            speed_download: 1036.0
+            speed_upload: 0.0
+            download_content_length: 430.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.414712
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 54.204.252.241
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 36574
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 318129
+            connect_time_us: 122771
+            namelookup_time_us: 27660
+            pretransfer_time_us: 318390
+            redirect_time_us: 0
+            starttransfer_time_us: 414712
+            total_time_us: 414774
+            effective_method: POST
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0
+-
+    request:
+        method: POST
+        url: 'https://postman-echo.com/post'
+        headers:
+            Host: postman-echo.com
+            Content-Type: application/json
+        body: '{"test":true}'
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:53 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '496'
+            server: nginx
+            etag: 'W/"1f0-oqYZYNBwOupEEfpS19gSgywqvCI"'
+            set-cookie: 'sails.sid=s%3AHr5CxPPrxrvUdPQBKZp6KC50geoYy1Ac.ij7UIg43htZD3J1DL3npO0RKKy3HRMY7UUj%2BTlU8%2BJc; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"data\": {\n    \"test\": true\n  },\n  \"files\": {},\n  \"form\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853573.480\",\n    \"connection\": \"close\",\n    \"content-length\": \"13\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53c05-7aa014c70fbe1d3a2dec2553\",\n    \"accept\": \"*/*\",\n    \"content-type\": \"application/json\"\n  },\n  \"json\": {\n    \"test\": true\n  },\n  \"url\": \"https://postman-echo.com/post\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/post'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 304
+            request_size: 123
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.418043
+            namelookup_time: 0.033229
+            connect_time: 0.127123
+            pretransfer_time: 0.318792
+            size_upload: 13.0
+            size_download: 496.0
+            speed_download: 1186.0
+            speed_upload: 31.0
+            download_content_length: 496.0
+            upload_content_length: 13.0
+            starttransfer_time: 0.417984
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 52.20.242.160
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 36204
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 318551
+            connect_time_us: 127123
+            namelookup_time_us: 33229
+            pretransfer_time_us: 318792
+            redirect_time_us: 0
+            starttransfer_time_us: 417984
+            total_time_us: 418043
+            effective_method: POST
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/auth_basic_curl.yml
+++ b/tests/fixtures/symfony_httpclient/auth_basic_curl.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Host: jsonplaceholder.typicode.com
+            Authorization: 'Basic dXNlcjpwYXNzd2Q='
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:41 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24264'
+            cf-cache-status: HIT
+            cf-ray: 98aeae79df8311a4-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 111
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.128252
+            namelookup_time: 0.030729
+            connect_time: 0.059051
+            pretransfer_time: 0.105123
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 2276.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.128204
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 60580
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 104977
+            connect_time_us: 59051
+            namelookup_time_us: 30729
+            pretransfer_time_us: 105123
+            redirect_time_us: 0
+            starttransfer_time_us: 128204
+            total_time_us: 128252
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/auth_basic_native.yml
+++ b/tests/fixtures/symfony_httpclient/auth_basic_native.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Host: jsonplaceholder.typicode.com
+            Authorization: 'Basic dXNlcjpwYXNzd2Q='
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:41 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24264'
+            cf-cache-status: HIT
+            cf-ray: 98aeae7a6e1b3924-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 111
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.082509
+            namelookup_time: 0.001496
+            connect_time: 0.019931
+            pretransfer_time: 0.06409
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3539.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.08242
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 60592
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 63988
+            connect_time_us: 19931
+            namelookup_time_us: 1496
+            pretransfer_time_us: 64090
+            redirect_time_us: 0
+            starttransfer_time_us: 82420
+            total_time_us: 82509
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/auth_bearer.yml
+++ b/tests/fixtures/symfony_httpclient/auth_bearer.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:42 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24264'
+            cf-cache-status: HIT
+            cf-ray: 98aeae7b9d93e1ec-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 72
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.092239
+            namelookup_time: 0.001266
+            connect_time: 0.029183
+            pretransfer_time: 0.07563
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3165.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.092188
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 60594
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 75506
+            connect_time_us: 29183
+            namelookup_time_us: 1266
+            pretransfer_time_us: 75630
+            redirect_time_us: 0
+            starttransfer_time_us: 92188
+            total_time_us: 92239
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/auth_bearer_manual.yml
+++ b/tests/fixtures/symfony_httpclient/auth_bearer_manual.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Authorization: 'Bearer test-token-456'
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:42 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24264'
+            cf-cache-status: HIT
+            cf-ray: 98aeae7c1ef7e181-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 110
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.086285
+            namelookup_time: 0.000956
+            connect_time: 0.016788
+            pretransfer_time: 0.061227
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3384.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.086205
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3121::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 60492
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 61119
+            connect_time_us: 16788
+            namelookup_time_us: 956
+            pretransfer_time_us: 61227
+            redirect_time_us: 0
+            starttransfer_time_us: 86205
+            total_time_us: 86285
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/auth_manual_header.yml
+++ b/tests/fixtures/symfony_httpclient/auth_manual_header.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Authorization: 'Basic dXNlcjpwYXNzd2Q='
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:42 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24264'
+            cf-cache-status: HIT
+            cf-ray: 98aeae7af87c1221-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 111
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.078713
+            namelookup_time: 0.001536
+            connect_time: 0.017841
+            pretransfer_time: 0.059645
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3709.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.078647
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3121::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 60480
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 59538
+            connect_time_us: 17841
+            namelookup_time_us: 1536
+            pretransfer_time_us: 59645
+            redirect_time_us: 0
+            starttransfer_time_us: 78647
+            total_time_us: 78713
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/curl_delete.yml
+++ b/tests/fixtures/symfony_httpclient/curl_delete.yml
@@ -1,0 +1,77 @@
+
+-
+    request:
+        method: DELETE
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:50 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '2'
+            access-control-allow-credentials: 'true'
+            cache-control: no-cache
+            etag: 'W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=DdRXt6YVgb7ntsOqNHMekopaMVCSQldmQRlIxvefpjY%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759853570"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=DdRXt6YVgb7ntsOqNHMekopaMVCSQldmQRlIxvefpjY%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759853570"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '994'
+            x-ratelimit-reset: '1759853622'
+            cf-cache-status: DYNAMIC
+            cf-ray: 98aeaeadaebd989e-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: '{}'
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1067
+            request_size: 75
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.175972
+            namelookup_time: 0.001396
+            connect_time: 0.018652
+            pretransfer_time: 0.059275
+            size_upload: 0.0
+            size_download: 2.0
+            speed_download: 11.0
+            speed_upload: 0.0
+            download_content_length: 2.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.175914
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59286
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 59177
+            connect_time_us: 18652
+            namelookup_time_us: 1396
+            pretransfer_time_us: 59275
+            redirect_time_us: 0
+            starttransfer_time_us: 175914
+            total_time_us: 175972
+            effective_method: DELETE
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/curl_get.yml
+++ b/tests/fixtures/symfony_httpclient/curl_get.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Accept: application/json
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:42 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24264'
+            cf-cache-status: HIT
+            cf-ray: 98aeae7cbaaa2ee9-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 85
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.089813
+            namelookup_time: 0.001274
+            connect_time: 0.014773
+            pretransfer_time: 0.06152
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3251.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.089774
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3121::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 60506
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 61358
+            connect_time_us: 14773
+            namelookup_time_us: 1274
+            pretransfer_time_us: 61520
+            redirect_time_us: 0
+            starttransfer_time_us: 89774
+            total_time_us: 89813
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/curl_hook_only_post_test.yml
+++ b/tests/fixtures/symfony_httpclient/curl_hook_only_post_test.yml
@@ -1,0 +1,81 @@
+
+-
+    request:
+        method: POST
+        url: 'https://jsonplaceholder.typicode.com/posts'
+        headers:
+            Host: jsonplaceholder.typicode.com
+            Content-Type: application/json
+        body: '{"title":"Test Post","body":"Test Body","userId":1}'
+    response:
+        status:
+            code: 201
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:44 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '77'
+            location: 'https://jsonplaceholder.typicode.com/posts/101'
+            access-control-allow-credentials: 'true'
+            access-control-expose-headers: Location
+            cache-control: no-cache
+            etag: 'W/"4d-2tzwaW755wJGVro91vk4id3fvSs"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=fUMrPpYTHYqzeTwaKmqKOTGf4WMfEeaWYlenhzP3wvo%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759853564"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=fUMrPpYTHYqzeTwaKmqKOTGf4WMfEeaWYlenhzP3wvo%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759853564"'
+            server: cloudflare
+            vary: 'Origin, X-HTTP-Method-Override, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1759853622'
+            cf-cache-status: DYNAMIC
+            cf-ray: 98aeae8b5d5e44c2-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"title\": \"Test Post\",\n  \"body\": \"Test Body\",\n  \"userId\": 1,\n  \"id\": 101\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 1192
+            request_size: 174
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.169331
+            namelookup_time: 0.001427
+            connect_time: 0.014303
+            pretransfer_time: 0.05625
+            size_upload: 51.0
+            size_download: 77.0
+            speed_download: 454.0
+            speed_upload: 301.0
+            download_content_length: 77.0
+            upload_content_length: 51.0
+            starttransfer_time: 0.169244
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59172
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 56136
+            connect_time_us: 14303
+            namelookup_time_us: 1427
+            pretransfer_time_us: 56250
+            redirect_time_us: 0
+            starttransfer_time_us: 169244
+            total_time_us: 169331
+            effective_method: POST
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/curl_hook_only_test.yml
+++ b/tests/fixtures/symfony_httpclient/curl_hook_only_test.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:44 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24267'
+            cf-cache-status: HIT
+            cf-ray: 98aeae8add64be8a-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 72
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.083017
+            namelookup_time: 0.001164
+            connect_time: 0.014951
+            pretransfer_time: 0.065775
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3517.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.082973
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59170
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 65134
+            connect_time_us: 14951
+            namelookup_time_us: 1164
+            pretransfer_time_us: 65775
+            redirect_time_us: 0
+            starttransfer_time_us: 82973
+            total_time_us: 83017
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/curl_post.yml
+++ b/tests/fixtures/symfony_httpclient/curl_post.yml
@@ -1,0 +1,82 @@
+
+-
+    request:
+        method: POST
+        url: 'https://jsonplaceholder.typicode.com/posts'
+        headers:
+            Accept: application/json
+            Content-Type: application/json
+            Host: jsonplaceholder.typicode.com
+        body: '{"title":"Test Post","body":"Testing VCR with CurlHttpClient","userId":1}'
+    response:
+        status:
+            code: 201
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:49 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '99'
+            location: 'https://jsonplaceholder.typicode.com/posts/101'
+            access-control-allow-credentials: 'true'
+            access-control-expose-headers: Location
+            cache-control: no-cache
+            etag: 'W/"63-cthoACCZzRoJbtqhh9rLlEetDhA"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=Z5b5EroFrqHqcBCV3elk4AIw1eRvvCMWZpN%2BfpuI8kc%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759853569"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=Z5b5EroFrqHqcBCV3elk4AIw1eRvvCMWZpN%2BfpuI8kc%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759853569"'
+            server: cloudflare
+            vary: 'Origin, X-HTTP-Method-Override, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '996'
+            x-ratelimit-reset: '1759853622'
+            cf-cache-status: DYNAMIC
+            cf-ray: 98aeaeaa1848e1ae-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"title\": \"Test Post\",\n  \"body\": \"Testing VCR with CurlHttpClient\",\n  \"userId\": 1,\n  \"id\": 101\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 1196
+            request_size: 209
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.174128
+            namelookup_time: 0.001623
+            connect_time: 0.017818
+            pretransfer_time: 0.060525
+            size_upload: 73.0
+            size_download: 99.0
+            speed_download: 568.0
+            speed_upload: 419.0
+            download_content_length: 99.0
+            upload_content_length: 73.0
+            starttransfer_time: 0.174077
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59254
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 60410
+            connect_time_us: 17818
+            namelookup_time_us: 1623
+            pretransfer_time_us: 60525
+            redirect_time_us: 0
+            starttransfer_time_us: 174077
+            total_time_us: 174128
+            effective_method: POST
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/curl_put.yml
+++ b/tests/fixtures/symfony_httpclient/curl_put.yml
@@ -1,0 +1,80 @@
+
+-
+    request:
+        method: PUT
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Accept: application/json
+            Content-Type: application/json
+            Host: jsonplaceholder.typicode.com
+        body: '{"title":"Updated Post","body":"Updated body","userId":1}'
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:50 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '81'
+            access-control-allow-credentials: 'true'
+            cache-control: no-cache
+            etag: 'W/"51-wAErw67ESNxeD4GjV7t0AjGpenI"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=DdRXt6YVgb7ntsOqNHMekopaMVCSQldmQRlIxvefpjY%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759853570"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=DdRXt6YVgb7ntsOqNHMekopaMVCSQldmQRlIxvefpjY%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759853570"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '995'
+            x-ratelimit-reset: '1759853622'
+            cf-cache-status: DYNAMIC
+            cf-ray: 98aeaeab3b5c0d4b-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"title\": \"Updated Post\",\n  \"body\": \"Updated body\",\n  \"userId\": 1,\n  \"id\": 1\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1069
+            request_size: 194
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.381162
+            namelookup_time: 0.001325
+            connect_time: 0.015487
+            pretransfer_time: 0.058688
+            size_upload: 57.0
+            size_download: 81.0
+            speed_download: 212.0
+            speed_upload: 149.0
+            download_content_length: 81.0
+            upload_content_length: 57.0
+            starttransfer_time: 0.381112
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59270
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 58578
+            connect_time_us: 15487
+            namelookup_time_us: 1325
+            pretransfer_time_us: 58688
+            redirect_time_us: 0
+            starttransfer_time_us: 381112
+            total_time_us: 381162
+            effective_method: PUT
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/native_delete.yml
+++ b/tests/fixtures/symfony_httpclient/native_delete.yml
@@ -1,0 +1,77 @@
+
+-
+    request:
+        method: DELETE
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:50 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '2'
+            access-control-allow-credentials: 'true'
+            cache-control: no-cache
+            etag: 'W/"2-vyGp6PvFo4RvsFtPoIWeCReyIC8"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=DdRXt6YVgb7ntsOqNHMekopaMVCSQldmQRlIxvefpjY%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759853570"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=DdRXt6YVgb7ntsOqNHMekopaMVCSQldmQRlIxvefpjY%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759853570"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '991'
+            x-ratelimit-reset: '1759853622'
+            cf-cache-status: DYNAMIC
+            cf-ray: 98aeaeb18aa3e18d-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: '{}'
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1067
+            request_size: 75
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.174585
+            namelookup_time: 0.001433
+            connect_time: 0.014688
+            pretransfer_time: 0.061869
+            size_upload: 0.0
+            size_download: 2.0
+            speed_download: 11.0
+            speed_upload: 0.0
+            download_content_length: 2.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.174539
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59318
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 61762
+            connect_time_us: 14688
+            namelookup_time_us: 1433
+            pretransfer_time_us: 61869
+            redirect_time_us: 0
+            starttransfer_time_us: 174539
+            total_time_us: 174585
+            effective_method: DELETE
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/native_get.yml
+++ b/tests/fixtures/symfony_httpclient/native_get.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Accept: application/json
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:50 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24272'
+            cf-cache-status: HIT
+            cf-ray: 98aeaeaeb8380cb5-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 85
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.078336
+            namelookup_time: 0.001038
+            connect_time: 0.015392
+            pretransfer_time: 0.060193
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3727.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.078293
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3121::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 55446
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 60094
+            connect_time_us: 15392
+            namelookup_time_us: 1038
+            pretransfer_time_us: 60193
+            redirect_time_us: 0
+            starttransfer_time_us: 78293
+            total_time_us: 78336
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/native_post.yml
+++ b/tests/fixtures/symfony_httpclient/native_post.yml
@@ -1,0 +1,82 @@
+
+-
+    request:
+        method: POST
+        url: 'https://jsonplaceholder.typicode.com/posts'
+        headers:
+            Accept: application/json
+            Content-Type: application/json
+            Host: jsonplaceholder.typicode.com
+        body: '{"title":"Test with NativeHttpClient","body":"Testing POST with native streams","userId":1}'
+    response:
+        status:
+            code: 201
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:50 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '117'
+            location: 'https://jsonplaceholder.typicode.com/posts/101'
+            access-control-allow-credentials: 'true'
+            access-control-expose-headers: Location
+            cache-control: no-cache
+            etag: 'W/"75-a/6iCtAwPU+9CmrUKlkIowTlH/k"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=DdRXt6YVgb7ntsOqNHMekopaMVCSQldmQRlIxvefpjY%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759853570"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=DdRXt6YVgb7ntsOqNHMekopaMVCSQldmQRlIxvefpjY%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759853570"'
+            server: cloudflare
+            vary: 'Origin, X-HTTP-Method-Override, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '993'
+            x-ratelimit-reset: '1759853622'
+            cf-cache-status: DYNAMIC
+            cf-ray: 98aeaeaf3dc8e1ed-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"title\": \"Test with NativeHttpClient\",\n  \"body\": \"Testing POST with native streams\",\n  \"userId\": 1,\n  \"id\": 101\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 1193
+            request_size: 227
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.170076
+            namelookup_time: 0.001564
+            connect_time: 0.014913
+            pretransfer_time: 0.057305
+            size_upload: 91.0
+            size_download: 117.0
+            speed_download: 687.0
+            speed_upload: 535.0
+            download_content_length: 117.0
+            upload_content_length: 91.0
+            starttransfer_time: 0.170028
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3121::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 55452
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 57190
+            connect_time_us: 14913
+            namelookup_time_us: 1564
+            pretransfer_time_us: 57305
+            redirect_time_us: 0
+            starttransfer_time_us: 170028
+            total_time_us: 170076
+            effective_method: POST
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/native_put.yml
+++ b/tests/fixtures/symfony_httpclient/native_put.yml
@@ -1,0 +1,80 @@
+
+-
+    request:
+        method: PUT
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Accept: application/json
+            Content-Type: application/json
+            Host: jsonplaceholder.typicode.com
+        body: '{"title":"Updated with NativeHttpClient","body":"Testing PUT with native streams","userId":1}'
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:50 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '117'
+            access-control-allow-credentials: 'true'
+            cache-control: no-cache
+            etag: 'W/"75-hamOfCYBb4N/qNfb5GNn4rs3Dqo"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=DdRXt6YVgb7ntsOqNHMekopaMVCSQldmQRlIxvefpjY%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759853570"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=DdRXt6YVgb7ntsOqNHMekopaMVCSQldmQRlIxvefpjY%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759853570"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '992'
+            x-ratelimit-reset: '1759853622'
+            cf-cache-status: DYNAMIC
+            cf-ray: 98aeaeb059ece219-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"title\": \"Updated with NativeHttpClient\",\n  \"body\": \"Testing PUT with native streams\",\n  \"userId\": 1,\n  \"id\": 1\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1070
+            request_size: 230
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.179933
+            namelookup_time: 0.001369
+            connect_time: 0.014965
+            pretransfer_time: 0.062417
+            size_upload: 93.0
+            size_download: 117.0
+            speed_download: 650.0
+            speed_upload: 516.0
+            download_content_length: 117.0
+            upload_content_length: 93.0
+            starttransfer_time: 0.179887
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59302
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 62309
+            connect_time_us: 14965
+            namelookup_time_us: 1369
+            pretransfer_time_us: 62417
+            redirect_time_us: 0
+            starttransfer_time_us: 179887
+            total_time_us: 179933
+            effective_method: PUT
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/native_stream_wrapper_test.yml
+++ b/tests/fixtures/symfony_httpclient/native_stream_wrapper_test.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:47 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24270'
+            cf-cache-status: HIT
+            cf-ray: 98aeae9f5bd449c4-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 72
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.085382
+            namelookup_time: 0.001369
+            connect_time: 0.01731
+            pretransfer_time: 0.059833
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3419.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.085308
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59208
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 59735
+            connect_time_us: 17310
+            namelookup_time_us: 1369
+            pretransfer_time_us: 59833
+            redirect_time_us: 0
+            starttransfer_time_us: 85308
+            total_time_us: 85382
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/options_custom_headers.yml
+++ b/tests/fixtures/symfony_httpclient/options_custom_headers.yml
@@ -1,0 +1,80 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            X-Custom-Header: custom-value
+            User-Agent: VCR-Test/1.0
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:46 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24269'
+            cf-cache-status: HIT
+            cf-ray: 98aeae974ff7e218-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 129
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.076098
+            namelookup_time: 0.001054
+            connect_time: 0.015756
+            pretransfer_time: 0.056973
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3837.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.076053
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3121::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 55400
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 56864
+            connect_time_us: 15756
+            namelookup_time_us: 1054
+            pretransfer_time_us: 56973
+            redirect_time_us: 0
+            starttransfer_time_us: 76053
+            total_time_us: 76098
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/options_json.yml
+++ b/tests/fixtures/symfony_httpclient/options_json.yml
@@ -1,0 +1,81 @@
+
+-
+    request:
+        method: POST
+        url: 'https://jsonplaceholder.typicode.com/posts'
+        headers:
+            Host: jsonplaceholder.typicode.com
+            Content-Type: application/json
+        body: '{"title":"Test Post","body":"Test Content","userId":1}'
+    response:
+        status:
+            code: 201
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:47 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '80'
+            location: 'https://jsonplaceholder.typicode.com/posts/101'
+            access-control-allow-credentials: 'true'
+            access-control-expose-headers: Location
+            cache-control: no-cache
+            etag: 'W/"50-JEfLlONXaFZ8Kdfvj2J/HkcSIN0"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=uzhOcFP7SHUz71EN30gFgCMTsQAUJ6V98r7HyIcK1zQ%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759853567"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=uzhOcFP7SHUz71EN30gFgCMTsQAUJ6V98r7HyIcK1zQ%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759853567"'
+            server: cloudflare
+            vary: 'Origin, X-HTTP-Method-Override, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '998'
+            x-ratelimit-reset: '1759853622'
+            cf-cache-status: DYNAMIC
+            cf-ray: 98aeae9c0b1a07ea-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"title\": \"Test Post\",\n  \"body\": \"Test Content\",\n  \"userId\": 1,\n  \"id\": 101\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 1192
+            request_size: 177
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.185169
+            namelookup_time: 0.001318
+            connect_time: 0.021235
+            pretransfer_time: 0.071821
+            size_upload: 54.0
+            size_download: 80.0
+            speed_download: 432.0
+            speed_upload: 291.0
+            download_content_length: 80.0
+            upload_content_length: 54.0
+            starttransfer_time: 0.185122
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3121::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 55410
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 71684
+            connect_time_us: 21235
+            namelookup_time_us: 1318
+            pretransfer_time_us: 71821
+            redirect_time_us: 0
+            starttransfer_time_us: 185122
+            total_time_us: 185169
+            effective_method: POST
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/options_max_redirects.yml
+++ b/tests/fixtures/symfony_httpclient/options_max_redirects.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:46 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24269'
+            cf-cache-status: HIT
+            cf-ray: 98aeae97ce18dc31-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 72
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.077722
+            namelookup_time: 0.001215
+            connect_time: 0.014435
+            pretransfer_time: 0.060614
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3756.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.077664
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59184
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 60519
+            connect_time_us: 14435
+            namelookup_time_us: 1215
+            pretransfer_time_us: 60614
+            redirect_time_us: 0
+            starttransfer_time_us: 77664
+            total_time_us: 77722
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/options_multiple.yml
+++ b/tests/fixtures/symfony_httpclient/options_multiple.yml
@@ -1,0 +1,82 @@
+
+-
+    request:
+        method: POST
+        url: 'https://jsonplaceholder.typicode.com/posts'
+        headers:
+            X-Custom: test
+            Host: jsonplaceholder.typicode.com
+            Content-Type: application/json
+        body: '{"title":"test","body":"test body","userId":1}'
+    response:
+        status:
+            code: 201
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:47 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '72'
+            location: 'https://jsonplaceholder.typicode.com/posts/101'
+            access-control-allow-credentials: 'true'
+            access-control-expose-headers: Location
+            cache-control: no-cache
+            etag: 'W/"48-PG5U+UYM667S++YH6j7P0+obdEU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=uzhOcFP7SHUz71EN30gFgCMTsQAUJ6V98r7HyIcK1zQ%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759853567"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=uzhOcFP7SHUz71EN30gFgCMTsQAUJ6V98r7HyIcK1zQ%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759853567"'
+            server: cloudflare
+            vary: 'Origin, X-HTTP-Method-Override, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '997'
+            x-ratelimit-reset: '1759853622'
+            cf-cache-status: DYNAMIC
+            cf-ray: 98aeae9e2899e16b-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"title\": \"test\",\n  \"body\": \"test body\",\n  \"userId\": 1,\n  \"id\": 101\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 1192
+            request_size: 185
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.170221
+            namelookup_time: 0.001402
+            connect_time: 0.01467
+            pretransfer_time: 0.057011
+            size_upload: 46.0
+            size_download: 72.0
+            speed_download: 422.0
+            speed_upload: 270.0
+            download_content_length: 72.0
+            upload_content_length: 46.0
+            starttransfer_time: 0.170171
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3121::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 55432
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 56904
+            connect_time_us: 14670
+            namelookup_time_us: 1402
+            pretransfer_time_us: 57011
+            redirect_time_us: 0
+            starttransfer_time_us: 170171
+            total_time_us: 170221
+            effective_method: POST
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/options_native_custom.yml
+++ b/tests/fixtures/symfony_httpclient/options_native_custom.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Accept: application/json
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:47 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24270'
+            cf-cache-status: HIT
+            cf-ray: 98aeae9dafb21224-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 85
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.081578
+            namelookup_time: 0.001361
+            connect_time: 0.013479
+            pretransfer_time: 0.057978
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3579.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.081529
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3121::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 55424
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 57884
+            connect_time_us: 13479
+            namelookup_time_us: 1361
+            pretransfer_time_us: 57978
+            redirect_time_us: 0
+            starttransfer_time_us: 81529
+            total_time_us: 81578
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/options_query_params.yml
+++ b/tests/fixtures/symfony_httpclient/options_query_params.yml
@@ -1,0 +1,61 @@
+
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get?foo=bar&number=42'
+        headers:
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:47 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '388'
+            server: nginx
+            etag: 'W/"184-kCC+6AGAJ2RzuGyv8bfbsi11OgU"'
+            set-cookie: 'sails.sid=s%3A70npJ8LedwsyTrK7efNnLzuor2mHB9fB.It9E847XQLwccK8fhp9vab7TVLd6RtSzqnVDidLZX38; Path=/; HttpOnly'
+        body: "{\n  \"args\": {\n    \"foo\": \"bar\",\n    \"number\": \"42\"\n  },\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853567.233\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53bff-39159bc51ba23d86348d59bb\",\n    \"accept\": \"*/*\"\n  },\n  \"url\": \"https://postman-echo.com/get?foo=bar&number=42\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get?foo=bar&number=42'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 300
+            request_size: 74
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.417382
+            namelookup_time: 0.027936
+            connect_time: 0.123991
+            pretransfer_time: 0.319484
+            size_upload: 0.0
+            size_download: 388.0
+            speed_download: 929.0
+            speed_upload: 0.0
+            download_content_length: 388.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.417327
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 3.95.46.189
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 46074
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 319275
+            connect_time_us: 123991
+            namelookup_time_us: 27936
+            pretransfer_time_us: 319484
+            redirect_time_us: 0
+            starttransfer_time_us: 417327
+            total_time_us: 417382
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/options_timeout.yml
+++ b/tests/fixtures/symfony_httpclient/options_timeout.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:46 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24269'
+            cf-cache-status: HIT
+            cf-ray: 98aeae984cc3e28c-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 72
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.07466
+            namelookup_time: 0.001297
+            connect_time: 0.013252
+            pretransfer_time: 0.0598
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3911.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.074609
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59196
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 59693
+            connect_time_us: 13252
+            namelookup_time_us: 1297
+            pretransfer_time_us: 59800
+            redirect_time_us: 0
+            starttransfer_time_us: 74609
+            total_time_us: 74660
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/options_user_data.yml
+++ b/tests/fixtures/symfony_httpclient/options_user_data.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:46 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24269'
+            cf-cache-status: HIT
+            cf-ray: 98aeae98c836e1e8-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 72
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.079871
+            namelookup_time: 0.001196
+            connect_time: 0.016345
+            pretransfer_time: 0.06327
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3655.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.079833
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59198
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 63175
+            connect_time_us: 16345
+            namelookup_time_us: 1196
+            pretransfer_time_us: 63270
+            redirect_time_us: 0
+            starttransfer_time_us: 79833
+            total_time_us: 79871
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/options_with_options.yml
+++ b/tests/fixtures/symfony_httpclient/options_with_options.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:47 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24270'
+            cf-cache-status: HIT
+            cf-ray: 98aeae9d29844591-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 72
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.079986
+            namelookup_time: 0.001104
+            connect_time: 0.015267
+            pretransfer_time: 0.061147
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3650.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.079941
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3121::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 55420
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 61046
+            connect_time_us: 15267
+            namelookup_time_us: 1104
+            pretransfer_time_us: 61147
+            redirect_time_us: 0
+            starttransfer_time_us: 79941
+            total_time_us: 79986
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/scoping_default_options.yml
+++ b/tests/fixtures/symfony_httpclient/scoping_default_options.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1?'
+        headers:
+            User-Agent: VCR-Test-Client/1.0
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:49 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=9nD1xelvUg9AJRU7RXYBg%2B4wSrr0bi7qe6ALzzB43xA%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759838625"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=9nD1xelvUg9AJRU7RXYBg%2B4wSrr0bi7qe6ALzzB43xA%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759838625"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1759838682'
+            age: '14943'
+            cf-cache-status: HIT
+            cf-ray: 98aeaea8e8efe231-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 106
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.091558
+            namelookup_time: 0.001282
+            connect_time: 0.014892
+            pretransfer_time: 0.06069
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3189.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.091507
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59236
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 60589
+            connect_time_us: 14892
+            namelookup_time_us: 1282
+            pretransfer_time_us: 60690
+            redirect_time_us: 0
+            starttransfer_time_us: 91507
+            total_time_us: 91558
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/scoping_multiple.yml
+++ b/tests/fixtures/symfony_httpclient/scoping_multiple.yml
@@ -1,0 +1,140 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1?'
+        headers:
+            X-Scope: api1
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:48 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=9nD1xelvUg9AJRU7RXYBg%2B4wSrr0bi7qe6ALzzB43xA%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759838625"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=9nD1xelvUg9AJRU7RXYBg%2B4wSrr0bi7qe6ALzzB43xA%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759838625"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1759838682'
+            age: '14942'
+            cf-cache-status: HIT
+            cf-ray: 98aeaea599e7e1e5-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 88
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.075636
+            namelookup_time: 0.001331
+            connect_time: 0.015232
+            pretransfer_time: 0.058186
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3860.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.075526
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59224
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 58088
+            connect_time_us: 15232
+            namelookup_time_us: 1331
+            pretransfer_time_us: 58186
+            redirect_time_us: 0
+            starttransfer_time_us: 75526
+            total_time_us: 75636
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0
+-
+    request:
+        method: GET
+        url: 'https://postman-echo.com/get?'
+        headers:
+            X-Scope: api2
+            Host: postman-echo.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:49 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '354'
+            server: nginx
+            etag: 'W/"162-ktUIrpV9sYiwBHUnVbA8PThRNTY"'
+            set-cookie: 'sails.sid=s%3AS5GvYZVPZJnLVI0v-ZGI0laCE3DX4Qve.mOSQj7EV%2BLvCA7pnRslDglRNK%2Fm9zSfpRMlTl3HxbGI; Path=/; HttpOnly'
+        body: "{\n  \"args\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1759853569.298\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-68e53c01-249550770198317238dcfbc4\",\n    \"accept\": \"*/*\",\n    \"x-scope\": \"api2\"\n  },\n  \"url\": \"https://postman-echo.com/get?\"\n}"
+        curl_info:
+            url: 'https://postman-echo.com/get'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 304
+            request_size: 72
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.433084
+            namelookup_time: 0.034508
+            connect_time: 0.130186
+            pretransfer_time: 0.331455
+            size_upload: 0.0
+            size_download: 354.0
+            speed_download: 817.0
+            speed_upload: 0.0
+            download_content_length: 354.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.433042
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 3.213.210.224
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.21
+            local_port: 35626
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 331226
+            connect_time_us: 130186
+            namelookup_time_us: 34508
+            pretransfer_time_us: 331455
+            redirect_time_us: 0
+            starttransfer_time_us: 433042
+            total_time_us: 433084
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/scoping_relative.yml
+++ b/tests/fixtures/symfony_httpclient/scoping_relative.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1?'
+        headers:
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:49 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=9nD1xelvUg9AJRU7RXYBg%2B4wSrr0bi7qe6ALzzB43xA%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759838625"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=9nD1xelvUg9AJRU7RXYBg%2B4wSrr0bi7qe6ALzzB43xA%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759838625"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1759838682'
+            age: '14943'
+            cf-cache-status: HIT
+            cf-ray: 98aeaea9898c1ed5-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 73
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.0877
+            namelookup_time: 0.000974
+            connect_time: 0.022764
+            pretransfer_time: 0.067761
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3329.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.087654
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59238
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 67664
+            connect_time_us: 22764
+            namelookup_time_us: 974
+            pretransfer_time_us: 67761
+            redirect_time_us: 0
+            starttransfer_time_us: 87654
+            total_time_us: 87700
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/scoping_single.yml
+++ b/tests/fixtures/symfony_httpclient/scoping_single.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1?'
+        headers:
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:48 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=9nD1xelvUg9AJRU7RXYBg%2B4wSrr0bi7qe6ALzzB43xA%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1759838625"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=9nD1xelvUg9AJRU7RXYBg%2B4wSrr0bi7qe6ALzzB43xA%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1759838625"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1759838682'
+            age: '14942'
+            cf-cache-status: HIT
+            cf-ray: 98aeaea51e3de195-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 73
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.079768
+            namelookup_time: 0.001612
+            connect_time: 0.015298
+            pretransfer_time: 0.057886
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3660.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.079721
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3121::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 55436
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 57791
+            connect_time_us: 15298
+            namelookup_time_us: 1612
+            pretransfer_time_us: 57886
+            redirect_time_us: 0
+            starttransfer_time_us: 79721
+            total_time_us: 79768
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0

--- a/tests/fixtures/symfony_httpclient/traceable_get.yml
+++ b/tests/fixtures/symfony_httpclient/traceable_get.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: GET
+        url: 'https://jsonplaceholder.typicode.com/posts/1'
+        headers:
+            Accept: application/json
+            Host: jsonplaceholder.typicode.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            date: 'Tue, 07 Oct 2025 16:12:50 GMT'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '292'
+            access-control-allow-credentials: 'true'
+            cache-control: max-age=43200
+            etag: 'W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"'
+            expires: '-1'
+            nel: '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+            pragma: no-cache
+            report-to: '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1754072508"}],"max_age":3600}'
+            reporting-endpoints: 'heroku-nel="https://nel.heroku.com/reports?s=qmF%2B0RYtDk6ARVLbocBZfggycY9qc4JYDhd2rZIgWGs%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1754072508"'
+            server: cloudflare
+            vary: 'Origin, Accept-Encoding'
+            via: '2.0 heroku-router'
+            x-content-type-options: nosniff
+            x-powered-by: Express
+            x-ratelimit-limit: '1000'
+            x-ratelimit-remaining: '999'
+            x-ratelimit-reset: '1754072526'
+            age: '24273'
+            cf-cache-status: HIT
+            cf-ray: 98aeaeb2ae218e31-MRS
+            alt-svc: 'h3=":443"; ma=86400'
+        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+        curl_info:
+            url: 'https://jsonplaceholder.typicode.com/posts/1'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 1088
+            request_size: 85
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.086017
+            namelookup_time: 0.001424
+            connect_time: 0.02007
+            pretransfer_time: 0.063104
+            size_upload: 0.0
+            size_download: 292.0
+            speed_download: 3394.0
+            speed_upload: 0.0
+            download_content_length: 292.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.085966
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: '2a06:98c1:3120::2'
+            certinfo: {  }
+            primary_port: 443
+            local_ip: '2a01:cb1d:8000:8400:3b8e:fecd:3770:70c3'
+            local_port: 59324
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 63001
+            connect_time_us: 20070
+            namelookup_time_us: 1424
+            pretransfer_time_us: 63104
+            redirect_time_us: 0
+            starttransfer_time_us: 85966
+            total_time_us: 86017
+            effective_method: GET
+            capath: /etc/ssl/certs
+            cainfo: /etc/ssl/certs/ca-certificates.crt
+    index: 0


### PR DESCRIPTION
Hey PHP VCR team!

I hope this message finds you well! I’ve stumbled upon a compatibility issue between PHP VCR and the Symfony HTTP Client that I'd love to help resolve. Currently, I’m facing this friendly little roadblock:

```
RuntimeException: Unexpected error, could not find curl_getinfo in response or errors
```

This issue has already been raised here: [#329](https://github.com/php-vcr/php-vcr/issues/329), and I believe we can make a positive impact by addressing it!

### Why Symfony HTTP Client Rocks
The component is compatible with four distinct HTTP client abstractions: Symfony Contracts, PSR-18, HTTPlug v1/v2, and native PHP streams. This ensures seamless integration with any application that relies on these libraries.

The Symfony HTTP Client is a standout in the PHP community, known for its extensive features and wide adoption. Its interoperability with these HTTP abstractions offers significant advantages

I’ve put together a patch that enhances the extraction of cURL info in the `curlHook`. By adding these essential properties to the cURL info list:

```php
\CURLINFO_PRIVATE
\CURLINFO_CERTINFO
```

We can empower PHP VCR to effortlessly retrieve certificate information and private data when using the Symfony HTTP Client. 

I believe this contribution will significantly improve compatibility for Symfony projects, and I’m excited to collaborate with you to make it happen. Thank you for considering this fix !
