### PR TITLE
Add .github to export-ignore in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /docs                   export-ignore
 /tests                  export-ignore
+/.github                export-ignore
 /.gitattributes         export-ignore
 /.gitignore             export-ignore
 /.php-cs-fixer.dist.php export-ignore


### PR DESCRIPTION
### Context

currently, the archive targets other than src/ are as follows:

```
gh api repos/php-vcr/php-vcr/tarball/HEAD | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
.github/
.github/PULL_REQUEST_TEMPLATE.md
.github/workflows/
.github/workflows/continuous integration.yml
LICENSE.md
README.md
composer.json
```

- `.github/` is not required for dist.

- see https://madewithlove.com/blog/gitattributes/

### What has been done

- Add .github to export-ignore

### How to test

- With this PR, The archive targets other than src/ will be as follows:
```
gh api repos/sasezaki/php-vcr/tarball/patch-1 | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
LICENSE.md
README.md
composer.json
```

### Todo

- [ ]
- [ ]

### Notes

-
-


