### PR TITLE
fix(http): emit \r\n line terminators in cURL header strings

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -54,7 +54,7 @@ class CurlHelper
         if (isset($curlOptions[\CURLOPT_HEADERFUNCTION])) {
             $headerList = [HttpUtil::formatAsStatusString($response)];
             $headerList = array_merge($headerList, HttpUtil::formatHeadersForCurl($response->getHeaders()));
-            $headerList[] = '';
+            $headerList[] = "\r\n";
             foreach ($headerList as $header) {
                 self::callFunction($curlOptions[\CURLOPT_HEADERFUNCTION], $ch, $header);
             }

--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -94,7 +94,7 @@ class HttpUtil
      *
      * @param array<string,string|array<string,string>|null> $headers Headers as key/value pairs
      *
-     * @return string[] List of headers ['Content-Type: text/html', '...'].
+     * @return string[] List of headers ['Content-Type: text/html\r\n', '...'].
      */
     public static function formatHeadersForCurl(array $headers): array
     {
@@ -103,10 +103,10 @@ class HttpUtil
         foreach ($headers as $key => $values) {
             if (\is_array($values)) {
                 foreach ($values as $value) {
-                    $curlHeaders[] = $key.': '.$value;
+                    $curlHeaders[] = $key.': '.$value."\r\n";
                 }
             } else {
-                $curlHeaders[] = $key.': '.$values;
+                $curlHeaders[] = $key.': '.$values."\r\n";
             }
         }
 
@@ -122,7 +122,8 @@ class HttpUtil
     {
         return 'HTTP/'.$response->getHttpVersion()
             .' '.$response->getStatusCode()
-            .' '.$response->getStatusMessage();
+            .' '.$response->getStatusMessage()
+            ."\r\n";
     }
 
     /**
@@ -135,6 +136,6 @@ class HttpUtil
         $headers = self::formatHeadersForCurl($response->getHeaders());
         array_unshift($headers, self::formatAsStatusString($response));
 
-        return implode("\r\n", $headers)."\r\n\r\n";
+        return join('', $headers)."\r\n";
     }
 }

--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -136,6 +136,6 @@ class HttpUtil
         $headers = self::formatHeadersForCurl($response->getHeaders());
         array_unshift($headers, self::formatAsStatusString($response));
 
-        return join('', $headers)."\r\n";
+        return implode('', $headers)."\r\n";
     }
 }

--- a/tests/Unit/Util/CurlHelperTest.php
+++ b/tests/Unit/Util/CurlHelperTest.php
@@ -266,9 +266,9 @@ final class CurlHelperTest extends TestCase
         CurlHelper::handleOutput($response, $curlOptions, curl_init());
 
         $expected = [
-            'HTTP/1.1 200 OK',
-            'Content-Length: 0',
-            '',
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
         ];
         $this->assertEquals($expected, $actualHeaders);
     }
@@ -291,9 +291,9 @@ final class CurlHelperTest extends TestCase
         CurlHelper::handleOutput($response, $curlOptions, curl_init());
 
         $expected = [
-            'HTTP/1.1 200 OK',
-            'Content-Length: 0',
-            '',
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
         ];
         $this->assertEquals($expected, $this->headersFound);
     }
@@ -316,9 +316,9 @@ final class CurlHelperTest extends TestCase
         CurlHelper::handleOutput($response, $curlOptions, curl_init());
 
         $expected = [
-            'HTTP/1.1 200 OK',
-            'Content-Length: 0',
-            '',
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
         ];
         $this->assertEquals($expected, $this->headersFound);
     }
@@ -341,9 +341,9 @@ final class CurlHelperTest extends TestCase
         CurlHelper::handleOutput($response, $curlOptions, curl_init());
 
         $expected = [
-            'HTTP/1.1 200 OK',
-            'Content-Length: 0',
-            '',
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
         ];
         $this->assertEquals($expected, $this->headersFound);
     }


### PR DESCRIPTION
## Summary
- Header lines and status line emitted by `HttpUtil::formatHeadersForCurl`
  and `HttpUtil::formatAsStatusString` now end with `\r\n`, matching real
  cURL behaviour.
- `CurlHelper::handleOutput` reuses the same terminator for the
  end-of-headers sentinel passed to `CURLOPT_HEADERFUNCTION`.

## Background
Refs #329. Parsers such as `symfony/http-client::Response\CurlResponse`
locate the response body by the `\r\n` between header and body sections;
php-vcr emitted bare lines, breaking the replay. This adopts PR #294 by
@clemherreman (open since 2020-01).

## Notes
- The original commit (6dd0af7) is preserved with @clemherreman as
  author; cherry-pick conflicts (array-branch in `formatHeadersForCurl`,
  changed test paths) resolved in-place.
- A follow-up commit aligns the remaining unit-test expectations.
- Technically a behaviour change in `HttpUtil::formatHeadersForCurl`
  and `formatAsStatusString`, but any consumer relying on the prior
  bare-line output would already be incompatible with real cURL — we
  treat this as a bug fix rather than a BC break, suitable for the 1.9
  milestone.

## Test plan
- [x] Unit suite green: `docker compose run --rm workspace80 composer test`
- [x] phpstan/cs/ec green
- [x] Matrix sanity on PHP 8.1–8.4