### PR TITLE
fix(curl): return [] for CURLINFO_CERTINFO when not captured

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,7 +56,7 @@ parameters:
 			path: tests/Unit/CassetteTest.php
 
 		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) with arguments 22, array\\{url\\: string, content_type\\: string\\|null, http_code\\: int, header_size\\: int, request_size\\: int, filetime\\: int, ssl_verify_result\\: int, redirect_count\\: int, \\.\\.\\.\\} and 'curl_getinfo\\(\\)…' will always evaluate to false\\.$#"
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) with arguments 23, array\\{url\\: string, content_type\\: string\\|null, http_code\\: int, header_size\\: int, request_size\\: int, filetime\\: int, ssl_verify_result\\: int, redirect_count\\: int, \\.\\.\\.\\} and 'curl_getinfo\\(\\)…' will always evaluate to false\\.$#"
 			count: 1
 			path: tests/Unit/LibraryHooks/CurlHookTest.php
 

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -110,6 +110,10 @@ class CurlHelper
             case \CURLINFO_APPCONNECT_TIME:
                 $info = '';
                 break;
+            case CURLINFO_CERTINFO:
+                $curlInfo = $response->getCurlInfo($option);
+                $info = (!is_null($curlInfo)) ? $curlInfo : [];
+                break;
             default:
                 $info = $response->getCurlInfo(self::$curlInfoList[$option]);
                 break;

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -13,7 +13,7 @@ class CurlHelper
      * @var array<int, string> list of cURL info constants
      */
     private static $curlInfoList = [
-        // "certinfo"?
+        \CURLINFO_CERTINFO => 'certinfo',
         \CURLINFO_HTTP_CODE => 'http_code',
         \CURLINFO_EFFECTIVE_URL => 'url',
         \CURLINFO_TOTAL_TIME => 'total_time',
@@ -110,9 +110,8 @@ class CurlHelper
             case \CURLINFO_APPCONNECT_TIME:
                 $info = '';
                 break;
-            case CURLINFO_CERTINFO:
-                $curlInfo = $response->getCurlInfo($option);
-                $info = (!is_null($curlInfo)) ? $curlInfo : [];
+            case \CURLINFO_CERTINFO:
+                $info = $response->getCurlInfo(self::$curlInfoList[\CURLINFO_CERTINFO]) ?? [];
                 break;
             default:
                 $info = $response->getCurlInfo(self::$curlInfoList[$option]);

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -246,7 +246,7 @@ final class CurlHookTest extends TestCase
         curl_close($curlHandle);
 
         $this->assertIsArray($info, 'curl_getinfo() should return an array.');
-        $this->assertCount(22, $info, 'curl_getinfo() should return 22 values.');
+        $this->assertCount(23, $info, 'curl_getinfo() should return 23 values.');
         $this->curlHook->disable();
     }
 
@@ -282,6 +282,7 @@ final class CurlHookTest extends TestCase
         $this->assertArrayHasKey('upload_content_length', $info);
         $this->assertArrayHasKey('starttransfer_time', $info);
         $this->assertArrayHasKey('redirect_time', $info);
+        $this->assertArrayHasKey('certinfo', $info);
         $this->curlHook->disable();
     }
 

--- a/tests/Unit/Util/CurlHelperTest.php
+++ b/tests/Unit/Util/CurlHelperTest.php
@@ -512,6 +512,20 @@ final class CurlHelperTest extends TestCase
                 \CURLINFO_HEADER_SIZE,
                 290,
             ],
+            'certinfo defaults to empty array when not recorded' => [
+                Response::fromArray(['status' => 200, 'headers' => []]),
+                \CURLINFO_CERTINFO,
+                [],
+            ],
+            'certinfo returns recorded data from cassette' => [
+                Response::fromArray([
+                    'status' => 200,
+                    'headers' => [],
+                    'curl_info' => ['certinfo' => [['Subject' => 'CN=example.com']]],
+                ]),
+                \CURLINFO_CERTINFO,
+                [['Subject' => 'CN=example.com']],
+            ],
         ];
     }
 
@@ -565,6 +579,16 @@ final class CurlHelperTest extends TestCase
     private function privateCurlHeaderFunction($ch, string $header): void
     {
         $this->headersFound[] = $header;
+    }
+
+    public function testGetCurlOptionFromResponseHandleCertinfo(): void
+    {
+        $response = new Response('200', [], 'example response');
+
+        $this->assertEquals(
+            [],
+            CurlHelper::getCurlOptionFromResponse($response, \CURLINFO_CERTINFO)
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- Register `CURLINFO_CERTINFO` in `CurlHelper::$curlInfoList`.
- Return `[]` (real cURL's default) when no certificate info was
  captured, instead of `BadMethodCallException("Not implemented: ...")`.

## Background
Refs #329. `symfony/http-client` reads CERTINFO defensively (see
`Response/CurlResponse.php` upstream). Real cURL returns `[]` unless
`CURLOPT_CERTINFO`/`CURLOPT_VERBOSE` was set; php-vcr threw instead,
breaking the response cycle.

This is the same shape of fix that closed #309 for
`CURLINFO_APPCONNECT_TIME` back in 2023.

## Notes
- Adopts PR #286 by @clemherreman (open since 2019-11). The original
  commit (476d172) is preserved with @clemherreman as author.
- A follow-up commit corrects two latent bugs in @clemherreman's patch:
  - `Response::getCurlInfo()` is keyed by the string name; the original
    passed the integer constant and would always have hit `null`.
  - The constant was missing from `$curlInfoList`, so `curl_getinfo($ch)`
    (all options) wouldn't include it.
- The unrelated "Fix PHP 5.3 compatibility" commit from PR #286 is
  intentionally not cherry-picked.

## Test plan
- [x] Unit suite green on PHP 8.0–8.4
- [x] PHPStan/CS-Fixer/EditorConfig green