### PR TITLE
feat(docker): add workspace85 service for PHP 8.5 local testing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,6 +50,16 @@ services:
     volumes:
       - .:/var/www/html
       - ~/.composer:/home/user/.composer
+  workspace85:
+    tty: true
+    build:
+      context: resources/docker/workspace/8.5
+      args:
+        PUID: "${PUID:-1000}"
+        PGID: "${PGID:-1000}"
+    volumes:
+      - .:/var/www/html
+      - ~/.composer:/home/user/.composer
 
 
 

--- a/resources/docker/workspace/8.5/Dockerfile
+++ b/resources/docker/workspace/8.5/Dockerfile
@@ -1,0 +1,40 @@
+FROM php:8.5-cli-alpine
+
+ARG PUID=1000
+ARG PGID=1000
+
+RUN apk add --no-cache --virtual .build-deps \
+    # for extensions
+    $PHPIZE_DEPS \
+    # for soap
+    libxml2-dev \
+    # for xdebug \
+    linux-headers \
+    && \
+    apk add --no-cache \
+    bash \
+    # for soap
+    libxml2 \
+    # for composer
+    unzip \
+    && \
+    docker-php-ext-install soap \
+    && \
+    pecl install \
+    # pcov for coverage runs
+    pcov && docker-php-ext-enable pcov \
+    && \
+    # for debugging
+    pecl install xdebug && docker-php-ext-enable xdebug \
+    && \
+    apk del .build-deps
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html
+
+# Add a non-root user to prevent files being created with root permissions on host machine.
+RUN addgroup -g ${PGID} user && \
+    adduser -u ${PUID} -G user -D user
+
+USER user


### PR DESCRIPTION
## Summary

- Add `resources/docker/workspace/8.5/Dockerfile` based on `php:8.5-cli-alpine`
- Add `workspace85` service to `docker-compose.yaml` matching the existing workspace pattern
- Uses unpinned `xdebug` (resolves to 3.5.1) since xdebug 3.4.x only supports PHP ≤ 8.4

## Why

CI already tests against PHP 8.5, but the local Docker matrix stopped at `workspace84`.
Developers had no way to reproduce PHP 8.5 test runs locally.

## Test plan

- [x] `docker compose build workspace85` succeeds
- [x] `docker compose run --rm workspace85 composer install` succeeds
- [x] `docker compose run --rm workspace85 composer test` → 288/288 tests pass on PHP 8.5.7

Closes #434