### PR TITLE
fix: replace httpbin.org dependency with self-contained local server

### DIFF
--- a/src/VCR/Util/HttpClient.php
+++ b/src/VCR/Util/HttpClient.php
@@ -24,7 +24,10 @@ class HttpClient
         Assertion::notSame($ch, false, "Could not init curl with URL '{$request->getUrl()}'");
 
         curl_setopt($ch, \CURLOPT_CUSTOMREQUEST, $request->getMethod());
-        curl_setopt($ch, \CURLOPT_HTTPHEADER, HttpUtil::formatHeadersForCurl($request->getHeaders()));
+        curl_setopt($ch, \CURLOPT_HTTPHEADER, array_map(
+            static fn (string $h): string => rtrim($h, "\r\n"),
+            HttpUtil::formatHeadersForCurl($request->getHeaders())
+        ));
         if (null !== $request->getBody()) {
             curl_setopt($ch, \CURLOPT_POSTFIELDS, $request->getBody());
         }

--- a/tests/Integration/Guzzle/AsyncTest.php
+++ b/tests/Integration/Guzzle/AsyncTest.php
@@ -7,11 +7,26 @@ namespace VCR\Tests\Integration\Guzzle;
 use GuzzleHttp\Client;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
+use VCR\Tests\Util\TestHttpServer;
 
 final class AsyncTest extends TestCase
 {
-    public const TEST_GET_URL = 'https://httpbin.org/get';
-    public const TEST_GET_URL_2 = 'https://httpbin.org/get?foo=42';
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
 
     protected function setUp(): void
     {
@@ -25,9 +40,9 @@ final class AsyncTest extends TestCase
         \VCR\VCR::insertCassette('test-cassette.yml');
 
         $client = new Client();
-        $promise = $client->getAsync(self::TEST_GET_URL);
+        $promise = $client->getAsync(self::$baseUrl.'/get');
         $response = $promise->wait();
-        $promise = $client->getAsync(self::TEST_GET_URL_2);
+        $promise = $client->getAsync(self::$baseUrl.'/get?foo=42');
         $promise->wait();
         // Let's check that we can perform 2 async request on different URLs without locking.
         // Solves https://github.com/php-vcr/php-vcr/issues/211

--- a/tests/Integration/Guzzle/ErrorTest.php
+++ b/tests/Integration/Guzzle/ErrorTest.php
@@ -37,9 +37,17 @@ final class ErrorTest extends TestCase
             $client->get(self::TEST_GET_URL);
         } catch (ConnectException $e) {
             $catched = true;
-            $this->assertEquals($e->getMessage(), $nonInstrumentedException->getMessage());
+            $this->assertEquals(
+                $this->normalizeConnectExceptionMessage($e->getMessage()),
+                $this->normalizeConnectExceptionMessage($nonInstrumentedException->getMessage())
+            );
         }
         $this->assertTrue($catched);
         \VCR\VCR::turnOff();
+    }
+
+    private function normalizeConnectExceptionMessage(string $message): string
+    {
+        return (string) preg_replace('/ after \d+ ms/', '', $message);
     }
 }

--- a/tests/Util/Server/Entrypoint.php
+++ b/tests/Util/Server/Entrypoint.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__.'/../../../vendor/autoload.php';
+
+VCR\Tests\Util\Server\Router::handle();

--- a/tests/Util/Server/Router.php
+++ b/tests/Util/Server/Router.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Util\Server;
+
+final class Router
+{
+    public static function handle(): void
+    {
+        $uri = (string) ($_SERVER['REQUEST_URI'] ?? '/');
+        $path = strtok($uri, '?') ?: '/';
+        $method = (string) ($_SERVER['REQUEST_METHOD'] ?? 'GET');
+
+        if ('GET' === $method && '/get' === $path) {
+            self::sendGetResponse($uri);
+
+            return;
+        }
+
+        http_response_code(404);
+        header('Content-Type: application/json');
+        echo json_encode(['error' => 'Not Found'], \JSON_THROW_ON_ERROR);
+    }
+
+    private static function sendGetResponse(string $uri): void
+    {
+        $queryString = (string) ($_SERVER['QUERY_STRING'] ?? '');
+        $args = [];
+        if ('' !== $queryString) {
+            parse_str($queryString, $args);
+        }
+
+        $host = (string) ($_SERVER['HTTP_HOST'] ?? '127.0.0.1');
+        $url = 'http://'.$host.$uri;
+
+        header('Content-Type: application/json');
+        /** @var array<string, mixed> $args */
+        echo json_encode(['url' => $url, 'args' => $args], \JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Util/TestHttpServer.php
+++ b/tests/Util/TestHttpServer.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Util;
+
+final class TestHttpServer
+{
+    private const STARTUP_TIMEOUT_SECONDS = 5.0;
+    private const POLL_INTERVAL_MICROSECONDS = 50000;
+
+    /** @var resource */
+    private $process;
+
+    /** @var resource */
+    private $stderrPipe;
+
+    private int $port;
+
+    private function __construct(int $port)
+    {
+        $this->port = $port;
+    }
+
+    public static function start(): self
+    {
+        $port = self::findFreePort();
+
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        /** @var array{0: resource, 1: resource, 2: resource} $pipes */
+        $pipes = [];
+        $process = proc_open(
+            ['php', '-S', "127.0.0.1:{$port}", __DIR__.'/Server/Entrypoint.php'],
+            $descriptorSpec,
+            $pipes
+        );
+
+        if (false === $process) {
+            throw new \RuntimeException('Failed to start test HTTP server.');
+        }
+
+        $instance = new self($port);
+        $instance->process = $process;
+        $instance->stderrPipe = $pipes[2];
+
+        $instance->waitForServerReady();
+
+        return $instance;
+    }
+
+    public function stop(): void
+    {
+        proc_terminate($this->process);
+        proc_close($this->process);
+    }
+
+    public function getBaseUrl(): string
+    {
+        return "http://127.0.0.1:{$this->port}";
+    }
+
+    private static function findFreePort(): int
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
+
+        if (false === $socket) {
+            throw new \RuntimeException("Could not find a free port: [{$errorCode}] {$errorMessage}");
+        }
+
+        $address = stream_socket_get_name($socket, false);
+        fclose($socket);
+
+        if (false === $address) {
+            throw new \RuntimeException('Could not determine port from socket address.');
+        }
+
+        $colonPos = strrpos($address, ':');
+
+        if (false === $colonPos) {
+            throw new \RuntimeException("Unexpected socket address format: {$address}");
+        }
+
+        return (int) substr($address, $colonPos + 1);
+    }
+
+    private function waitForServerReady(): void
+    {
+        $start = microtime(true);
+
+        while (true) {
+            $socket = @stream_socket_client(
+                "tcp://127.0.0.1:{$this->port}",
+                $errorCode,
+                $errorMessage,
+                0.1
+            );
+
+            if (false !== $socket) {
+                fclose($socket);
+
+                return;
+            }
+
+            if (microtime(true) - $start > self::STARTUP_TIMEOUT_SECONDS) {
+                $stderr = stream_get_contents($this->stderrPipe);
+                throw new \RuntimeException("Test HTTP server failed to start on port {$this->port}.".(false !== $stderr && '' !== $stderr ? " STDERR: {$stderr}" : ''));
+            }
+
+            usleep(self::POLL_INTERVAL_MICROSECONDS);
+        }
+    }
+}


### PR DESCRIPTION
### Context

Fixes #436. Two Guzzle integration tests were non-deterministic:
`AsyncTest::testAsyncLock` relied on `httpbin.org` being reachable;
`ErrorTest::testConnectException` compared curl error messages containing
a timing suffix (`"after N ms"`) which varies between calls.

Uncovers and fixes a recording regression from #433 (refs #329):
`HttpUtil::formatHeadersForCurl` appends `\r\n` for `CURLOPT_HEADERFUNCTION`
compatibility, but `HttpClient::send` also passed those strings to
`CURLOPT_HTTPHEADER` — libcurl adds its own CRLF, inserting a spurious blank
line that strict HTTP servers reject. httpbin.org (nginx) tolerated this
silently.

### What has been done

- Fixed `HttpClient::send` to strip trailing CRLF before passing headers to
  `CURLOPT_HTTPHEADER` (#433 regression, refs #329)
- Added a self-contained `php -S` based local HTTP server with `Router`,
  `Entrypoint`, and `TestHttpServer` helper for use in integration tests
- Replaced httpbin.org URLs in `AsyncTest` with the local server
- Normalised curl timing suffix in `ErrorTest` before assertion

### How to test

Verified on PHP 8.0 (workspace80) and PHP 8.4 (workspace84):

- `vendor/bin/phpunit --testsuite Integration` — 5 tests, 16 assertions, all green
- `composer phpstan` — no errors
- `composer cs` — 0 files to fix
- Tests pass without network access; httpbin.org is no longer contacted