### PR TITLE
fix(curl): read CURLINFO_PRIVATE from handle options to match real cURL

### DIFF
--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -265,12 +265,8 @@ class CurlHook implements LibraryHook
      */
     public static function curlGetinfo(\CurlHandle $curlHandle, int $option = 0): mixed
     {
-        // Workaround for CURLINFO_PRIVATE.
-        // It can be set AND read before the response is available, e.g by symfony/http-client.
-        //   - If the response is available, we read from it.
-        //   - If not, we return what was first set.
-        if ($option === \CURLINFO_PRIVATE && !in_array((int) $curlHandle, self::$responses, true)) {
-            return static::$curlOptions[(int) $curlHandle][\CURLOPT_PRIVATE];
+        if (\CURLINFO_PRIVATE === $option) {
+            return self::$curlOptions[(int) $curlHandle][\CURLOPT_PRIVATE] ?? '';
         }
 
         if (isset(self::$responses[(int) $curlHandle])) {

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -265,6 +265,14 @@ class CurlHook implements LibraryHook
      */
     public static function curlGetinfo(\CurlHandle $curlHandle, int $option = 0): mixed
     {
+        // Workaround for CURLINFO_PRIVATE.
+        // It can be set AND read before the response is available, e.g by symfony/http-client.
+        //   - If the response is available, we read from it.
+        //   - If not, we return what was first set.
+        if ($option === \CURLINFO_PRIVATE && !in_array((int) $curlHandle, self::$responses, true)) {
+            return static::$curlOptions[(int) $curlHandle][\CURLOPT_PRIVATE];
+        }
+
         if (isset(self::$responses[(int) $curlHandle])) {
             return CurlHelper::getCurlOptionFromResponse(
                 self::$responses[(int) $curlHandle],

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -533,6 +533,19 @@ final class CurlHookTest extends TestCase
         $this->curlHook->disable();
     }
 
+    public function testCurlInfoPrivateDefaultsToEmptyStringWhenNotSet(): void
+    {
+        $this->curlHook->enable($this->getTestCallback());
+
+        $curlHandle = curl_init('http://example.com');
+        Assertion::notSame($curlHandle, false);
+
+        $this->assertSame('', curl_getinfo($curlHandle, \CURLINFO_PRIVATE));
+
+        curl_close($curlHandle);
+        $this->curlHook->disable();
+    }
+
     protected function getTestCallback(string $statusCode = '200'): \Closure
     {
         $testClass = $this;

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -486,6 +486,24 @@ final class CurlHookTest extends TestCase
         $this->curlHook->disable();
     }
 
+    public function testShouldHandleCurlOptPrivate(): void
+    {
+        $this->curlHook->enable($this->getTestCallback());
+
+        $curlHandle = curl_init('http://example.com');
+        Assertion::notSame($curlHandle, false);
+        curl_setopt($curlHandle, \CURLOPT_PRIVATE, 'private');
+
+        $this->assertEquals('private', curl_getinfo($curlHandle, \CURLINFO_PRIVATE));
+
+        curl_exec($curlHandle);
+
+        $this->assertEquals('private', curl_getinfo($curlHandle, \CURLINFO_PRIVATE));
+
+        curl_close($curlHandle);
+        $this->curlHook->disable();
+    }
+
     protected function getTestCallback(string $statusCode = '200'): \Closure
     {
         $testClass = $this;

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -504,6 +504,35 @@ final class CurlHookTest extends TestCase
         $this->curlHook->disable();
     }
 
+    public function testCurlInfoPrivateReturnedBeforeExec(): void
+    {
+        $this->curlHook->enable($this->getTestCallback());
+
+        $curlHandle = curl_init('http://example.com');
+        Assertion::notSame($curlHandle, false);
+        curl_setopt($curlHandle, \CURLOPT_PRIVATE, 'tracker-token');
+
+        $this->assertSame('tracker-token', curl_getinfo($curlHandle, \CURLINFO_PRIVATE));
+
+        curl_close($curlHandle);
+        $this->curlHook->disable();
+    }
+
+    public function testCurlInfoPrivateReturnedAfterExec(): void
+    {
+        $this->curlHook->enable($this->getTestCallback());
+
+        $curlHandle = curl_init('http://example.com');
+        Assertion::notSame($curlHandle, false);
+        curl_setopt($curlHandle, \CURLOPT_PRIVATE, 'tracker-token');
+        curl_exec($curlHandle);
+
+        $this->assertSame('tracker-token', curl_getinfo($curlHandle, \CURLINFO_PRIVATE));
+
+        curl_close($curlHandle);
+        $this->curlHook->disable();
+    }
+
     protected function getTestCallback(string $statusCode = '200'): \Closure
     {
         $testClass = $this;


### PR DESCRIPTION
## Summary
- `CurlHook::curlGetinfo()` returns `CURLOPT_PRIVATE` straight from the
  handle's recorded options whenever `CURLINFO_PRIVATE` is queried,
  matching real cURL semantics.
- The lookup happens before the response/error branches, so it works
  whether or not `curl_exec()` has run.
- Defaults to `''` when `CURLOPT_PRIVATE` was never set.

## Background
Refs #329. `symfony/http-client` uses `CURLOPT_PRIVATE` to attach
request-tracking state and reads it back via `CURLINFO_PRIVATE` before
the request executes. php-vcr threw `RuntimeException("Unexpected error,
could not find curl_getinfo in response or errors")` because there was
no response yet. After `curl_exec()` the call would also have hit
`CurlHelper::getCurlOptionFromResponse()`, which has no case for
`CURLINFO_PRIVATE` and would have thrown `BadMethodCallException("Not
implemented: …")`.

History: PR #278 first attempted this in 2019 but failed for PHP <7.
PR #285 followed and has been open without review since then.

## Notes
- Adopts PR #285 by @clemherreman. The original commit (97b8bba) is
  preserved with @clemherreman as author; the cherry-pick excludes the
  unrelated whitespace-only changes from `RequestTest.php`.
- The follow-up fix commit replaces the original
  `in_array((int)$handle, self::$responses)` (which always evaluated
  truthy because the array values are `Response` objects, not integers)
  with a direct read keyed by the integer handle ID, and adds a `?? ''`
  default so PRIVATE returns `''` when never set.
- Separate test commits cover the pre-exec / post-exec / unset paths.

## Test plan
- workspace80 (PHP 8.0, highest deps): `composer test` — 295/295 OK
- workspace80 (PHP 8.0, lowest deps): `composer test` — 295/295 OK
- workspace80: `composer phpstan` — 0 errors
- workspace80: `composer cs` — 0 fixable files
- workspace80: `composer ec` — 0 errors
- workspace84 (PHP 8.4, highest deps): `composer test` — 295/295 OK
- GitHub Actions matrix (PHP 8.0–8.5 × lowest/highest) — pending