### PR TITLE
feat: allow symfony/* ^8 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         "php": "^8,<8.2|>=8.2.9,<8.6",
         "ext-curl": "*",
         "beberlei/assert": "^3.2.5",
-        "symfony/yaml": "^3|^4|^5|^6|^7",
-        "symfony/event-dispatcher": "^4|^5|^6|^7",
-        "symfony/event-dispatcher-contracts": "^1|^2|^3"
+        "symfony/yaml": "^3|^4|^5|^6|^7|^8",
+        "symfony/event-dispatcher": "^4|^5|^6|^7|^8",
+        "symfony/event-dispatcher-contracts": "^1|^2|^3|^4"
     },
     "require-dev": {
         "ext-soap": "*",


### PR DESCRIPTION
### Context

php-vcr currently constrains its Symfony dependencies to versions that exclude Symfony 8, blocking adoption in downstream projects that have moved to Symfony 8. Closes #441.

### What has been done

- Extended `symfony/yaml` constraint from `^3|^4|^5|^6|^7` to `^3|^4|^5|^6|^7|^8`
- Extended `symfony/event-dispatcher` constraint from `^4|^5|^6|^7` to `^4|^5|^6|^7|^8`
- Extended `symfony/event-dispatcher-contracts` constraint from `^1|^2|^3` to `^1|^2|^3|^4`
- Lower bounds intentionally unchanged — fully backwards-compatible

The `README.md` dependency list references `symfony/event-dispatcher` and `symfony/yaml` without version constraints (links only), so no change is required there.

### Notes

- `symfony/event-dispatcher-contracts` resolved `v3.7.0` under PHP 8.4 highest (compatible) — the `^4` constraint is additive for future use.
- The CI `highest` leg will automatically pick Symfony 8 on PHP 8.2+ once this merges.