### PR TITLE
feat: add functional integration tests for popular PHP HTTP client libraries

### DIFF
--- a/.github/workflows/continuous integration.yml
+++ b/.github/workflows/continuous integration.yml
@@ -133,7 +133,7 @@ jobs:
         run: "vendor/bin/phpunit --testsuite Integration --coverage-php=coverage/integration.cov --log-junit=phpunit-integration.xml"
 
       - name: "Merge coverage reports"
-        run: "vendor/bin/phpcov merge --clover=coverage.clover coverage/"
+        run: "ls coverage/*.cov 2>/dev/null && vendor/bin/phpcov merge --clover=coverage.clover coverage/ || true"
         if: "always()"
 
       - name: "Publish Test Report"

--- a/.github/workflows/continuous integration.yml
+++ b/.github/workflows/continuous integration.yml
@@ -126,8 +126,11 @@ jobs:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "--prefer-dist -o"
 
-      - name: "Run PHPUnit Test"
-        run: "vendor/bin/phpunit --coverage-clover=coverage.clover --log-junit=phpunit.xml"
+      - name: "Run PHPUnit Test (Unit)"
+        run: "vendor/bin/phpunit --testsuite Unit --coverage-clover=coverage.clover --log-junit=phpunit-unit.xml"
+
+      - name: "Run PHPUnit Test (Integration)"
+        run: "vendor/bin/phpunit --testsuite Integration --log-junit=phpunit.xml"
 
       - name: "Publish Test Report"
         uses: "mikepenz/action-junit-report@v2"

--- a/.github/workflows/continuous integration.yml
+++ b/.github/workflows/continuous integration.yml
@@ -127,16 +127,20 @@ jobs:
           composer-options: "--prefer-dist -o"
 
       - name: "Run PHPUnit Test (Unit)"
-        run: "vendor/bin/phpunit --testsuite Unit --coverage-clover=coverage.clover --log-junit=phpunit-unit.xml"
+        run: "mkdir -p coverage && vendor/bin/phpunit --testsuite Unit --coverage-php=coverage/unit.cov --log-junit=phpunit-unit.xml"
 
       - name: "Run PHPUnit Test (Integration)"
-        run: "vendor/bin/phpunit --testsuite Integration --log-junit=phpunit.xml"
+        run: "vendor/bin/phpunit --testsuite Integration --coverage-php=coverage/integration.cov --log-junit=phpunit-integration.xml"
+
+      - name: "Merge coverage reports"
+        run: "vendor/bin/phpcov merge --clover=coverage.clover coverage/"
+        if: "always()"
 
       - name: "Publish Test Report"
         uses: "mikepenz/action-junit-report@v2"
         if: "always()" # always run even if the previous step fails
         with:
-          report_paths: "phpunit.xml"
+          report_paths: "phpunit-*.xml"
           check_name: "PHPUnit Test Report (${{ matrix.php }}, ${{ matrix.dependencies }}, ${{ matrix.stability }})"
 
       - name: "Publish Scrutinizer Coverage"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan-phpunit": "^1",
         "phpstan/extension-installer": "^1.1",
-        "editorconfig-checker/editorconfig-checker": "^10.3"
+        "editorconfig-checker/editorconfig-checker": "^10.3",
+        "phpunit/phpcov": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "require-dev": {
         "ext-soap": "*",
         "guzzlehttp/guzzle": "^7",
+        "symfony/http-client": "^5.4|^6.0|^7.0",
         "phpunit/phpunit": "^9.5.10|^10.5",
         "mikey179/vfsstream": "^1.6.10",
         "phpstan/phpstan": "^1",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.",
     "license": "MIT",
     "scripts": {
-        "test": "./vendor/bin/phpunit",
+        "test": "./vendor/bin/phpunit --testsuite Unit && ./vendor/bin/phpunit --testsuite Integration",
         "cs": "./vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
         "cs-fix": "./vendor/bin/php-cs-fixer fix --verbose --diff",
         "phpstan": "php -d memory_limit=-1 vendor/bin/phpstan analyse -c phpstan.neon --no-progress -vvv",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,14 +16,14 @@ parameters:
 			path: src/VCR/Util/HttpUtil.php
 
 		-
-			message: "#^Offset 'uri' does not exist on array\\{timed_out\\: bool, blocked\\: bool, eof\\: bool, unread_bytes\\: int, stream_type\\: string, wrapper_type\\: string, wrapper_data\\: mixed, mode\\: string, \\.\\.\\.\\}\\.$#"
-			count: 1
-			path: src/VCR/Util/StreamProcessor.php
-
-		-
 			message: "#^Method VCR\\\\Util\\\\SoapClient\\:\\:realDoRequest\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: src/VCR/Util/SoapClient.php
+
+		-
+			message: "#^Offset 'uri' does not exist on array\\{timed_out\\: bool, blocked\\: bool, eof\\: bool, unread_bytes\\: int, stream_type\\: string, wrapper_type\\: string, wrapper_data\\: mixed, mode\\: string, \\.\\.\\.\\}\\.$#"
+			count: 1
+			path: src/VCR/Util/StreamProcessor.php
 
 		-
 			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int given\\.$#"
@@ -49,6 +49,126 @@ parameters:
 			message: "#^Parameter \\#3 \\$cassette of class VCR\\\\Event\\\\BeforeRecordEvent constructor expects VCR\\\\Cassette, VCR\\\\Cassette\\|null given\\.$#"
 			count: 1
 			path: src/VCR/Videorecorder.php
+
+		-
+			message: "#^Method VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Curl\\\\AsyncTest\\:\\:server\\(\\) is unused\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Curl/AsyncTest.php
+
+		-
+			message: "#^Static property VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Curl\\\\AsyncTest\\:\\:\\$baseUrl is never read, only written\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Curl/AsyncTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Curl/AsyncTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 2
+			path: tests/Integration/Symfony/Curl/BasicLifecycleTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Curl/ErrorTest.php
+
+		-
+			message: "#^Method VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Curl\\\\HeadersAndStatusTest\\:\\:server\\(\\) is unused\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Curl/HeadersAndStatusTest.php
+
+		-
+			message: "#^Static property VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Curl\\\\HeadersAndStatusTest\\:\\:\\$baseUrl is never read, only written\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Curl/HeadersAndStatusTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 3
+			path: tests/Integration/Symfony/Curl/HeadersAndStatusTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 3
+			path: tests/Integration/Symfony/Curl/HttpMethodsTest.php
+
+		-
+			message: "#^Method VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Curl\\\\SequentialRequestsTest\\:\\:server\\(\\) is unused\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Curl/SequentialRequestsTest.php
+
+		-
+			message: "#^Static property VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Curl\\\\SequentialRequestsTest\\:\\:\\$baseUrl is never read, only written\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Curl/SequentialRequestsTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Curl/SequentialRequestsTest.php
+
+		-
+			message: "#^Method VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Native\\\\AsyncTest\\:\\:server\\(\\) is unused\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Native/AsyncTest.php
+
+		-
+			message: "#^Static property VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Native\\\\AsyncTest\\:\\:\\$baseUrl is never read, only written\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Native/AsyncTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Native/AsyncTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 2
+			path: tests/Integration/Symfony/Native/BasicLifecycleTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Native/ErrorTest.php
+
+		-
+			message: "#^Method VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Native\\\\HeadersAndStatusTest\\:\\:server\\(\\) is unused\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Native/HeadersAndStatusTest.php
+
+		-
+			message: "#^Static property VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Native\\\\HeadersAndStatusTest\\:\\:\\$baseUrl is never read, only written\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Native/HeadersAndStatusTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 3
+			path: tests/Integration/Symfony/Native/HeadersAndStatusTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 3
+			path: tests/Integration/Symfony/Native/HttpMethodsTest.php
+
+		-
+			message: "#^Method VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Native\\\\SequentialRequestsTest\\:\\:server\\(\\) is unused\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Native/SequentialRequestsTest.php
+
+		-
+			message: "#^Static property VCR\\\\Tests\\\\Integration\\\\Symfony\\\\Native\\\\SequentialRequestsTest\\:\\:\\$baseUrl is never read, only written\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Native/SequentialRequestsTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/Integration/Symfony/Native/SequentialRequestsTest.php
 
 		-
 			message: "#^Cannot call method toArray\\(\\) on VCR\\\\Response\\|null\\.$#"

--- a/tests/Integration/AbstractHttpServerIntegrationTestCase.php
+++ b/tests/Integration/AbstractHttpServerIntegrationTestCase.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration;
+
+use VCR\Tests\Util\TestHttpServer;
+
+abstract class AbstractHttpServerIntegrationTestCase extends AbstractIntegrationTestCase
+{
+    private static ?TestHttpServer $server = null;
+    protected static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    /**
+     * @param \Closure(): int $perform
+     */
+    protected function recordAndReplay(string $cassette, \Closure $perform, int $expectedStatus = 200): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette($cassette);
+        $statusRecord = $perform();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame($expectedStatus, $statusRecord);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette($cassette);
+        $statusReplay = $perform();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame($expectedStatus, $statusReplay);
+    }
+
+    /**
+     * @param \Closure(): int $perform
+     */
+    protected function assertPassthrough(\Closure $perform, int $expectedStatus = 200): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+        $status = $perform();
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame($expectedStatus, $status);
+    }
+}

--- a/tests/Integration/AbstractIntegrationTestCase.php
+++ b/tests/Integration/AbstractIntegrationTestCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractIntegrationTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+}

--- a/tests/Integration/Guzzle/AsyncTest.php
+++ b/tests/Integration/Guzzle/AsyncTest.php
@@ -5,35 +5,10 @@ declare(strict_types=1);
 namespace VCR\Tests\Integration\Guzzle;
 
 use GuzzleHttp\Client;
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
-final class AsyncTest extends TestCase
+final class AsyncTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
     public function testAsyncLock(): void
     {
         \VCR\VCR::turnOn();
@@ -44,12 +19,10 @@ final class AsyncTest extends TestCase
         $response = $promise->wait();
         $promise = $client->getAsync(self::$baseUrl.'/get?foo=42');
         $promise->wait();
-        // Let's check that we can perform 2 async request on different URLs without locking.
-        // Solves https://github.com/php-vcr/php-vcr/issues/211
+        // Verifies two async requests on different URLs don't deadlock.
+        // Regression for https://github.com/php-vcr/php-vcr/issues/211
 
         $this->assertValidGETResponse(\GuzzleHttp\json_decode($response->getBody()->getContents(), true));
-
-        \VCR\VCR::turnOff();
     }
 
     protected function assertValidGETResponse(mixed $info): void

--- a/tests/Integration/Guzzle/BasicLifecycleTest.php
+++ b/tests/Integration/Guzzle/BasicLifecycleTest.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace VCR\Tests\Integration\Guzzle;
 
 use GuzzleHttp\Client;
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Basic GET + POST record/replay/passthrough via CurlHook (default Guzzle handler).
@@ -22,107 +20,37 @@ use VCR\Tests\Util\TestHttpServer;
  *
  * Cassette names prefixed 'guzzle-basic-' to avoid VCRFactory cache collisions.
  */
-final class BasicLifecycleTest extends TestCase
+final class BasicLifecycleTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testGetRequestRecordAndReplay(): void
     {
         $client = new Client();
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-basic-get.yml');
-        $r1 = $client->get(self::$baseUrl.'/get');
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $r1->getStatusCode());
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-basic-get.yml');
-        $r2 = $client->get(self::$baseUrl.'/get');
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $r2->getStatusCode());
+        $this->recordAndReplay(
+            'guzzle-basic-get.yml',
+            fn (): int => $client->get(self::$baseUrl.'/get')->getStatusCode(),
+        );
     }
 
     public function testPassthroughGetRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $response = (new Client())->get(self::$baseUrl.'/get');
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertPassthrough(
+            fn (): int => (new Client())->get(self::$baseUrl.'/get')->getStatusCode(),
+        );
     }
 
     public function testPostRequestRecordAndReplay(): void
     {
         $client = new Client();
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-basic-post.yml');
-        $r1 = $client->post(self::$baseUrl.'/post', ['body' => 'hello=world']);
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $r1->getStatusCode());
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-basic-post.yml');
-        $r2 = $client->post(self::$baseUrl.'/post', ['body' => 'hello=world']);
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $r2->getStatusCode());
+        $this->recordAndReplay(
+            'guzzle-basic-post.yml',
+            fn (): int => $client->post(self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+        );
     }
 
     public function testPassthroughPostRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $response = (new Client())->post(self::$baseUrl.'/post', ['body' => 'hello=world']);
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertPassthrough(
+            fn (): int => (new Client())->post(self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+        );
     }
 }

--- a/tests/Integration/Guzzle/BasicLifecycleTest.php
+++ b/tests/Integration/Guzzle/BasicLifecycleTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Guzzle;
+
+use GuzzleHttp\Client;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Basic GET + POST record/replay/passthrough via CurlHook (default Guzzle handler).
+ *
+ * A single Client instance is shared across record and replay phases so that
+ * Guzzle reuses curl handles via curl_reset() rather than curl_init(). This is
+ * important because VCR's curlReset() clears the stale $responses entry for the
+ * handle ID, preventing curlMultiExec() from skipping the handle during replay.
+ * Without this, PHP may reuse an integer ID (spl_object_id recycling) from the
+ * previous phase and curlMultiExec() would treat the handle as already processed.
+ * See issue #432 for the underlying CurlHook bug.
+ *
+ * Cassette names prefixed 'guzzle-basic-' to avoid VCRFactory cache collisions.
+ */
+final class BasicLifecycleTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testGetRequestRecordAndReplay(): void
+    {
+        $client = new Client();
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-basic-get.yml');
+        $r1 = $client->get(self::$baseUrl.'/get');
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $r1->getStatusCode());
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-basic-get.yml');
+        $r2 = $client->get(self::$baseUrl.'/get');
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $r2->getStatusCode());
+    }
+
+    public function testPassthroughGetRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $response = (new Client())->get(self::$baseUrl.'/get');
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testPostRequestRecordAndReplay(): void
+    {
+        $client = new Client();
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-basic-post.yml');
+        $r1 = $client->post(self::$baseUrl.'/post', ['body' => 'hello=world']);
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $r1->getStatusCode());
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-basic-post.yml');
+        $r2 = $client->post(self::$baseUrl.'/post', ['body' => 'hello=world']);
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $r2->getStatusCode());
+    }
+
+    public function testPassthroughPostRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $response = (new Client())->post(self::$baseUrl.'/post', ['body' => 'hello=world']);
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame(200, $response->getStatusCode());
+    }
+}

--- a/tests/Integration/Guzzle/ErrorTest.php
+++ b/tests/Integration/Guzzle/ErrorTest.php
@@ -6,18 +6,11 @@ namespace VCR\Tests\Integration\Guzzle;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
+use VCR\Tests\Integration\AbstractIntegrationTestCase;
 
-final class ErrorTest extends TestCase
+final class ErrorTest extends AbstractIntegrationTestCase
 {
     public const TEST_GET_URL = 'http://localhost:9959';
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
 
     public function testConnectException(): void
     {
@@ -43,7 +36,6 @@ final class ErrorTest extends TestCase
             );
         }
         $this->assertTrue($catched);
-        \VCR\VCR::turnOff();
     }
 
     private function normalizeConnectExceptionMessage(string $message): string

--- a/tests/Integration/Guzzle/HeadersAndStatusTest.php
+++ b/tests/Integration/Guzzle/HeadersAndStatusTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Guzzle;
+
+use GuzzleHttp\Client;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Custom request headers and non-200 status codes record+replay via CurlHook.
+ *
+ * Uses a single Client per test method so Guzzle reuses handles via curl_reset()
+ * instead of curl_init(), avoiding the stale $responses issue in CurlHook (#432).
+ * Cassette names prefixed 'guzzle-headers-' to avoid VCRFactory cache collisions.
+ */
+final class HeadersAndStatusTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testCustomRequestHeadersRecordAndReplay(): void
+    {
+        $client = new Client();
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-headers-custom.yml');
+        $r1 = $client->get(self::$baseUrl.'/get', ['headers' => ['X-Custom-Header' => 'test-value']]);
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $r1->getStatusCode());
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-headers-custom.yml');
+        $r2 = $client->get(self::$baseUrl.'/get', ['headers' => ['X-Custom-Header' => 'test-value']]);
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $r2->getStatusCode());
+    }
+
+    public function testStatus404RecordAndReplay(): void
+    {
+        $client = new Client(['http_errors' => false]);
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-headers-404.yml');
+        $r1 = $client->get(self::$baseUrl.'/status/404');
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(404, $r1->getStatusCode());
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-headers-404.yml');
+        $r2 = $client->get(self::$baseUrl.'/status/404');
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(404, $r2->getStatusCode());
+    }
+
+    public function testStatus500RecordAndReplay(): void
+    {
+        $client = new Client(['http_errors' => false]);
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-headers-500.yml');
+        $r1 = $client->get(self::$baseUrl.'/status/500');
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(500, $r1->getStatusCode());
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-headers-500.yml');
+        $r2 = $client->get(self::$baseUrl.'/status/500');
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(500, $r2->getStatusCode());
+    }
+}

--- a/tests/Integration/Guzzle/HeadersAndStatusTest.php
+++ b/tests/Integration/Guzzle/HeadersAndStatusTest.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace VCR\Tests\Integration\Guzzle;
 
 use GuzzleHttp\Client;
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Custom request headers and non-200 status codes record+replay via CurlHook.
@@ -16,110 +14,34 @@ use VCR\Tests\Util\TestHttpServer;
  * instead of curl_init(), avoiding the stale $responses issue in CurlHook (#432).
  * Cassette names prefixed 'guzzle-headers-' to avoid VCRFactory cache collisions.
  */
-final class HeadersAndStatusTest extends TestCase
+final class HeadersAndStatusTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testCustomRequestHeadersRecordAndReplay(): void
     {
         $client = new Client();
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-headers-custom.yml');
-        $r1 = $client->get(self::$baseUrl.'/get', ['headers' => ['X-Custom-Header' => 'test-value']]);
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $r1->getStatusCode());
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-headers-custom.yml');
-        $r2 = $client->get(self::$baseUrl.'/get', ['headers' => ['X-Custom-Header' => 'test-value']]);
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $r2->getStatusCode());
+        $this->recordAndReplay(
+            'guzzle-headers-custom.yml',
+            fn (): int => $client->get(self::$baseUrl.'/get', ['headers' => ['X-Custom-Header' => 'test-value']])->getStatusCode(),
+        );
     }
 
     public function testStatus404RecordAndReplay(): void
     {
         $client = new Client(['http_errors' => false]);
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-headers-404.yml');
-        $r1 = $client->get(self::$baseUrl.'/status/404');
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(404, $r1->getStatusCode());
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-headers-404.yml');
-        $r2 = $client->get(self::$baseUrl.'/status/404');
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(404, $r2->getStatusCode());
+        $this->recordAndReplay(
+            'guzzle-headers-404.yml',
+            fn (): int => $client->get(self::$baseUrl.'/status/404')->getStatusCode(),
+            404,
+        );
     }
 
     public function testStatus500RecordAndReplay(): void
     {
         $client = new Client(['http_errors' => false]);
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-headers-500.yml');
-        $r1 = $client->get(self::$baseUrl.'/status/500');
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(500, $r1->getStatusCode());
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-headers-500.yml');
-        $r2 = $client->get(self::$baseUrl.'/status/500');
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(500, $r2->getStatusCode());
+        $this->recordAndReplay(
+            'guzzle-headers-500.yml',
+            fn (): int => $client->get(self::$baseUrl.'/status/500')->getStatusCode(),
+            500,
+        );
     }
 }

--- a/tests/Integration/Guzzle/HttpMethodsTest.php
+++ b/tests/Integration/Guzzle/HttpMethodsTest.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace VCR\Tests\Integration\Guzzle;
 
 use GuzzleHttp\Client;
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * PUT / DELETE / PATCH record+replay via CurlHook.
@@ -16,110 +14,32 @@ use VCR\Tests\Util\TestHttpServer;
  * instead of curl_init(), avoiding the stale $responses issue in CurlHook (#432).
  * Cassette names prefixed 'guzzle-methods-' to avoid VCRFactory cache collisions.
  */
-final class HttpMethodsTest extends TestCase
+final class HttpMethodsTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testPutRequestRecordAndReplay(): void
     {
         $client = new Client();
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-methods-put.yml');
-        $r1 = $client->put(self::$baseUrl.'/put', ['body' => 'data=1']);
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $r1->getStatusCode());
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-methods-put.yml');
-        $r2 = $client->put(self::$baseUrl.'/put', ['body' => 'data=1']);
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $r2->getStatusCode());
+        $this->recordAndReplay(
+            'guzzle-methods-put.yml',
+            fn (): int => $client->put(self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
+        );
     }
 
     public function testDeleteRequestRecordAndReplay(): void
     {
         $client = new Client();
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-methods-delete.yml');
-        $r1 = $client->delete(self::$baseUrl.'/delete');
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $r1->getStatusCode());
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-methods-delete.yml');
-        $r2 = $client->delete(self::$baseUrl.'/delete');
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $r2->getStatusCode());
+        $this->recordAndReplay(
+            'guzzle-methods-delete.yml',
+            fn (): int => $client->delete(self::$baseUrl.'/delete')->getStatusCode(),
+        );
     }
 
     public function testPatchRequestRecordAndReplay(): void
     {
         $client = new Client();
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-methods-patch.yml');
-        $r1 = $client->patch(self::$baseUrl.'/patch', ['body' => 'field=value']);
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $r1->getStatusCode());
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('guzzle-methods-patch.yml');
-        $r2 = $client->patch(self::$baseUrl.'/patch', ['body' => 'field=value']);
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $r2->getStatusCode());
+        $this->recordAndReplay(
+            'guzzle-methods-patch.yml',
+            fn (): int => $client->patch(self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
+        );
     }
 }

--- a/tests/Integration/Guzzle/HttpMethodsTest.php
+++ b/tests/Integration/Guzzle/HttpMethodsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Guzzle;
+
+use GuzzleHttp\Client;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * PUT / DELETE / PATCH record+replay via CurlHook.
+ *
+ * Uses a single Client per test method so Guzzle reuses handles via curl_reset()
+ * instead of curl_init(), avoiding the stale $responses issue in CurlHook (#432).
+ * Cassette names prefixed 'guzzle-methods-' to avoid VCRFactory cache collisions.
+ */
+final class HttpMethodsTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testPutRequestRecordAndReplay(): void
+    {
+        $client = new Client();
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-methods-put.yml');
+        $r1 = $client->put(self::$baseUrl.'/put', ['body' => 'data=1']);
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $r1->getStatusCode());
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-methods-put.yml');
+        $r2 = $client->put(self::$baseUrl.'/put', ['body' => 'data=1']);
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $r2->getStatusCode());
+    }
+
+    public function testDeleteRequestRecordAndReplay(): void
+    {
+        $client = new Client();
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-methods-delete.yml');
+        $r1 = $client->delete(self::$baseUrl.'/delete');
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $r1->getStatusCode());
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-methods-delete.yml');
+        $r2 = $client->delete(self::$baseUrl.'/delete');
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $r2->getStatusCode());
+    }
+
+    public function testPatchRequestRecordAndReplay(): void
+    {
+        $client = new Client();
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-methods-patch.yml');
+        $r1 = $client->patch(self::$baseUrl.'/patch', ['body' => 'field=value']);
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $r1->getStatusCode());
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-methods-patch.yml');
+        $r2 = $client->patch(self::$baseUrl.'/patch', ['body' => 'field=value']);
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $r2->getStatusCode());
+    }
+}

--- a/tests/Integration/Guzzle/SequentialRequestsTest.php
+++ b/tests/Integration/Guzzle/SequentialRequestsTest.php
@@ -5,53 +5,15 @@ declare(strict_types=1);
 namespace VCR\Tests\Integration\Guzzle;
 
 use GuzzleHttp\Client;
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Three sequential requests in one cassette — regression for issue #432
  * (stale curl handle state between sequential requests).
  * Cassette prefix 'guzzle-seq-' avoids VCRFactory cache collisions.
  */
-final class SequentialRequestsTest extends TestCase
+final class SequentialRequestsTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testSequentialRequestsRecordAndReplay(): void
     {
         $countBefore = $this->server()->getRequestCount();

--- a/tests/Integration/Guzzle/SequentialRequestsTest.php
+++ b/tests/Integration/Guzzle/SequentialRequestsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Guzzle;
+
+use GuzzleHttp\Client;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Three sequential requests in one cassette — regression for issue #432
+ * (stale curl handle state between sequential requests).
+ * Cassette prefix 'guzzle-seq-' avoids VCRFactory cache collisions.
+ */
+final class SequentialRequestsTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testSequentialRequestsRecordAndReplay(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+        $client = new Client();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-seq.yml');
+        $r1 = $client->get(self::$baseUrl.'/get');
+        $r2 = $client->get(self::$baseUrl.'/get?page=2');
+        $r3 = $client->get(self::$baseUrl.'/get?page=3');
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 3, $countAfterRecord, 'All three requests must hit the server');
+        $this->assertSame(200, $r1->getStatusCode());
+        $this->assertSame(200, $r2->getStatusCode());
+        $this->assertSame(200, $r3->getStatusCode());
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('guzzle-seq.yml');
+        $s1 = $client->get(self::$baseUrl.'/get');
+        $s2 = $client->get(self::$baseUrl.'/get?page=2');
+        $s3 = $client->get(self::$baseUrl.'/get?page=3');
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s1->getStatusCode());
+        $this->assertSame(200, $s2->getStatusCode());
+        $this->assertSame(200, $s3->getStatusCode());
+    }
+}

--- a/tests/Integration/Native/CurlTest.php
+++ b/tests/Integration/Native/CurlTest.php
@@ -4,114 +4,42 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Native;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Verifies VCR interception of bare curl_* calls via CurlHook.
  * Cassette names prefixed 'native-curl-' to avoid VCRFactory cache collisions.
  */
-final class CurlTest extends TestCase
+final class CurlTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testGetRequestRecordAndReplay(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('native-curl-get.yml');
-        $s1 = $this->curlGet(self::$baseUrl.'/get');
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('native-curl-get.yml');
-        $s2 = $this->curlGet(self::$baseUrl.'/get');
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'native-curl-get.yml',
+            fn (): int => $this->curlGet(self::$baseUrl.'/get'),
+        );
     }
 
     public function testPassthroughGetRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = $this->curlGet(self::$baseUrl.'/get');
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => $this->curlGet(self::$baseUrl.'/get'),
+        );
     }
 
     public function testPostRequestRecordAndReplay(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('native-curl-post.yml');
-        $s1 = $this->curlPost(self::$baseUrl.'/post', 'hello=world');
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('native-curl-post.yml');
-        $s2 = $this->curlPost(self::$baseUrl.'/post', 'hello=world');
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'native-curl-post.yml',
+            fn (): int => $this->curlPost(self::$baseUrl.'/post', 'hello=world'),
+        );
     }
 
     public function testPassthroughPostRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = $this->curlPost(self::$baseUrl.'/post', 'hello=world');
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => $this->curlPost(self::$baseUrl.'/post', 'hello=world'),
+        );
     }
 
     private function curlGet(string $url): int

--- a/tests/Integration/Native/CurlTest.php
+++ b/tests/Integration/Native/CurlTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Native;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Verifies VCR interception of bare curl_* calls via CurlHook.
+ * Cassette names prefixed 'native-curl-' to avoid VCRFactory cache collisions.
+ */
+final class CurlTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testGetRequestRecordAndReplay(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('native-curl-get.yml');
+        $s1 = $this->curlGet(self::$baseUrl.'/get');
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('native-curl-get.yml');
+        $s2 = $this->curlGet(self::$baseUrl.'/get');
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughGetRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = $this->curlGet(self::$baseUrl.'/get');
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame(200, $statusCode);
+    }
+
+    public function testPostRequestRecordAndReplay(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('native-curl-post.yml');
+        $s1 = $this->curlPost(self::$baseUrl.'/post', 'hello=world');
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('native-curl-post.yml');
+        $s2 = $this->curlPost(self::$baseUrl.'/post', 'hello=world');
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughPostRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = $this->curlPost(self::$baseUrl.'/post', 'hello=world');
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame(200, $statusCode);
+    }
+
+    private function curlGet(string $url): int
+    {
+        $ch = curl_init($url);
+        curl_setopt($ch, \CURLOPT_RETURNTRANSFER, true);
+        curl_exec($ch);
+        $statusCode = (int) curl_getinfo($ch, \CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        return $statusCode;
+    }
+
+    private function curlPost(string $url, string $body): int
+    {
+        $ch = curl_init($url);
+        curl_setopt($ch, \CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, \CURLOPT_POST, true);
+        curl_setopt($ch, \CURLOPT_POSTFIELDS, $body);
+        curl_exec($ch);
+        $statusCode = (int) curl_getinfo($ch, \CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        return $statusCode;
+    }
+}

--- a/tests/Integration/Native/StreamWrapperTest.php
+++ b/tests/Integration/Native/StreamWrapperTest.php
@@ -4,53 +4,15 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Native;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Verifies VCR interception of native file_get_contents / stream_context_create
  * calls via StreamWrapperHook.
  * Cassette names prefixed 'native-sw-' to avoid VCRFactory cache collisions.
  */
-final class StreamWrapperTest extends TestCase
+final class StreamWrapperTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testGetRequestRecordAndReplay(): void
     {
         $countBefore = $this->server()->getRequestCount();
@@ -76,9 +38,7 @@ final class StreamWrapperTest extends TestCase
     public function testPassthroughGetRequest(): void
     {
         $countBefore = $this->server()->getRequestCount();
-
         $body = file_get_contents(self::$baseUrl.'/get');
-
         $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
         $this->assertNotFalse($body);
     }
@@ -124,9 +84,7 @@ final class StreamWrapperTest extends TestCase
         ]);
 
         $countBefore = $this->server()->getRequestCount();
-
         $body = file_get_contents(self::$baseUrl.'/post', false, $context);
-
         $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
         $this->assertNotFalse($body);
     }

--- a/tests/Integration/Native/StreamWrapperTest.php
+++ b/tests/Integration/Native/StreamWrapperTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Native;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Verifies VCR interception of native file_get_contents / stream_context_create
+ * calls via StreamWrapperHook.
+ * Cassette names prefixed 'native-sw-' to avoid VCRFactory cache collisions.
+ */
+final class StreamWrapperTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testGetRequestRecordAndReplay(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('native-sw-get.yml');
+        $b1 = file_get_contents(self::$baseUrl.'/get');
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertNotFalse($b1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('native-sw-get.yml');
+        $b2 = file_get_contents(self::$baseUrl.'/get');
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertNotFalse($b2);
+    }
+
+    public function testPassthroughGetRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $body = file_get_contents(self::$baseUrl.'/get');
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertNotFalse($body);
+    }
+
+    public function testPostRequestRecordAndReplay(): void
+    {
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'content' => 'hello=world',
+                'header' => "Content-Type: application/x-www-form-urlencoded\r\n",
+            ],
+        ]);
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('native-sw-post.yml');
+        $b1 = file_get_contents(self::$baseUrl.'/post', false, $context);
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertNotFalse($b1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('native-sw-post.yml');
+        $b2 = file_get_contents(self::$baseUrl.'/post', false, $context);
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertNotFalse($b2);
+    }
+
+    public function testPassthroughPostRequest(): void
+    {
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'content' => 'hello=world',
+                'header' => "Content-Type: application/x-www-form-urlencoded\r\n",
+            ],
+        ]);
+
+        $countBefore = $this->server()->getRequestCount();
+
+        $body = file_get_contents(self::$baseUrl.'/post', false, $context);
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertNotFalse($body);
+    }
+}

--- a/tests/Integration/Symfony/Curl/AsyncTest.php
+++ b/tests/Integration/Symfony/Curl/AsyncTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Curl;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Concurrent lazy requests for Symfony CurlHttpClient.
+ * Record/replay skipped — same curl_getinfo limitation as #329.
+ * Cassette name prefixed 'symfony-curl-async-'.
+ */
+final class AsyncTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testConcurrentRequestsRecordAndReplay(): void
+    {
+        $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+        $client = new CurlHttpClient();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-async.yml');
+        $r1 = $client->request('GET', self::$baseUrl.'/get');
+        $r2 = $client->request('GET', self::$baseUrl.'/get?foo=42');
+        $s1 = $r1->getStatusCode();
+        $s2 = $r2->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 2, $countAfterRecord, 'Both requests must hit the server during recording');
+        $this->assertSame(200, $s1);
+        $this->assertSame(200, $s2);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-async.yml');
+        $t1 = $client->request('GET', self::$baseUrl.'/get');
+        $t2 = $client->request('GET', self::$baseUrl.'/get?foo=42');
+        $u1 = $t1->getStatusCode();
+        $u2 = $t2->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $u1);
+        $this->assertSame(200, $u2);
+    }
+}

--- a/tests/Integration/Symfony/Curl/AsyncTest.php
+++ b/tests/Integration/Symfony/Curl/AsyncTest.php
@@ -4,54 +4,16 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Curl;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\CurlHttpClient;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Concurrent lazy requests for Symfony CurlHttpClient.
  * Record/replay skipped — same curl_getinfo limitation as #329.
  * Cassette name prefixed 'symfony-curl-async-'.
  */
-final class AsyncTest extends TestCase
+final class AsyncTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testConcurrentRequestsRecordAndReplay(): void
     {
         $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');

--- a/tests/Integration/Symfony/Curl/BasicLifecycleTest.php
+++ b/tests/Integration/Symfony/Curl/BasicLifecycleTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Curl;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Basic GET + POST record/replay/passthrough for Symfony CurlHttpClient via CurlHook.
+ *
+ * Record/replay tests are skipped: VCR's CurlHook does not yet handle Symfony's
+ * curl_getinfo() call that occurs before curl_multi_exec completes (issue #329,
+ * PRs #415, #426). Remove the markTestSkipped() calls once that is fixed.
+ *
+ * Passthrough tests (no VCR) verify the library itself works correctly.
+ * Cassette names prefixed 'symfony-curl-basic-' to avoid VCRFactory cache collisions.
+ */
+final class BasicLifecycleTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testGetRequestRecordAndReplay(): void
+    {
+        $this->markTestSkipped('CurlHttpClient: curl_getinfo() called before curl_multi_exec completes. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-basic-get.yml');
+        $s1 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-basic-get.yml');
+        $s2 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughGetRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame(200, $statusCode);
+    }
+
+    public function testPostRequestRecordAndReplay(): void
+    {
+        $this->markTestSkipped('CurlHttpClient: curl_getinfo() called before curl_multi_exec completes. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-basic-post.yml');
+        $s1 = (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-basic-post.yml');
+        $s2 = (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughPostRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame(200, $statusCode);
+    }
+}

--- a/tests/Integration/Symfony/Curl/BasicLifecycleTest.php
+++ b/tests/Integration/Symfony/Curl/BasicLifecycleTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Curl;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\CurlHttpClient;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Basic GET + POST record/replay/passthrough for Symfony CurlHttpClient via CurlHook.
@@ -19,109 +17,39 @@ use VCR\Tests\Util\TestHttpServer;
  * Passthrough tests (no VCR) verify the library itself works correctly.
  * Cassette names prefixed 'symfony-curl-basic-' to avoid VCRFactory cache collisions.
  */
-final class BasicLifecycleTest extends TestCase
+final class BasicLifecycleTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testGetRequestRecordAndReplay(): void
     {
         $this->markTestSkipped('CurlHttpClient: curl_getinfo() called before curl_multi_exec completes. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-basic-get.yml');
-        $s1 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-basic-get.yml');
-        $s2 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-curl-basic-get.yml',
+            fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
+        );
     }
 
     public function testPassthroughGetRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
+        );
     }
 
     public function testPostRequestRecordAndReplay(): void
     {
         $this->markTestSkipped('CurlHttpClient: curl_getinfo() called before curl_multi_exec completes. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-basic-post.yml');
-        $s1 = (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-basic-post.yml');
-        $s2 = (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-curl-basic-post.yml',
+            fn (): int => (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+        );
     }
 
     public function testPassthroughPostRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+        );
     }
 }

--- a/tests/Integration/Symfony/Curl/ErrorTest.php
+++ b/tests/Integration/Symfony/Curl/ErrorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Curl;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * Connection-failure behaviour for Symfony CurlHttpClient.
+ * The "with VCR" test is skipped — same curl_getinfo limitation as #329.
+ */
+final class ErrorTest extends TestCase
+{
+    private const UNBOUND_URL = 'http://localhost:9959/get';
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    public function testConnectExceptionWithoutVcr(): void
+    {
+        $caught = false;
+        try {
+            $response = (new CurlHttpClient())->request('GET', self::UNBOUND_URL);
+            $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            $caught = true;
+        }
+
+        $this->assertTrue($caught, 'CurlHttpClient must throw TransportException on connection failure');
+    }
+
+    public function testConnectExceptionPassesThroughWithVcr(): void
+    {
+        $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-error.yml');
+
+        $caught = false;
+        try {
+            $response = (new CurlHttpClient())->request('GET', self::UNBOUND_URL);
+            $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            $caught = true;
+        } finally {
+            \VCR\VCR::turnOff();
+        }
+
+        $this->assertTrue($caught, 'TransportException must propagate through VCR');
+    }
+}

--- a/tests/Integration/Symfony/Curl/ErrorTest.php
+++ b/tests/Integration/Symfony/Curl/ErrorTest.php
@@ -4,29 +4,17 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Curl;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use VCR\Tests\Integration\AbstractIntegrationTestCase;
 
 /**
  * Connection-failure behaviour for Symfony CurlHttpClient.
  * The "with VCR" test is skipped — same curl_getinfo limitation as #329.
  */
-final class ErrorTest extends TestCase
+final class ErrorTest extends AbstractIntegrationTestCase
 {
     private const UNBOUND_URL = 'http://localhost:9959/get';
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
 
     public function testConnectExceptionWithoutVcr(): void
     {

--- a/tests/Integration/Symfony/Curl/HeadersAndStatusTest.php
+++ b/tests/Integration/Symfony/Curl/HeadersAndStatusTest.php
@@ -4,127 +4,47 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Curl;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\CurlHttpClient;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Custom headers and non-200 status codes for Symfony CurlHttpClient.
  * Record/replay skipped — same curl_getinfo limitation as #329.
  * Cassette names prefixed 'symfony-curl-headers-'.
  */
-final class HeadersAndStatusTest extends TestCase
+final class HeadersAndStatusTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testCustomRequestHeadersRecordAndReplay(): void
     {
         $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-headers-custom.yml');
-        $s1 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/get', [
-            'headers' => ['X-Custom-Header' => 'test-value'],
-        ])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-headers-custom.yml');
-        $s2 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/get', [
-            'headers' => ['X-Custom-Header' => 'test-value'],
-        ])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-curl-headers-custom.yml',
+            fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/get', [
+                'headers' => ['X-Custom-Header' => 'test-value'],
+            ])->getStatusCode(),
+        );
     }
 
     public function testStatus404RecordAndReplay(): void
     {
         $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-headers-404.yml');
-        $s1 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(404, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-headers-404.yml');
-        $s2 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(404, $s2);
+        $this->recordAndReplay(
+            'symfony-curl-headers-404.yml',
+            fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode(),
+            404,
+        );
     }
 
     public function testStatus500RecordAndReplay(): void
     {
         $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-headers-500.yml');
-        $s1 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(500, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-headers-500.yml');
-        $s2 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(500, $s2);
+        $this->recordAndReplay(
+            'symfony-curl-headers-500.yml',
+            fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode(),
+            500,
+        );
     }
 }

--- a/tests/Integration/Symfony/Curl/HeadersAndStatusTest.php
+++ b/tests/Integration/Symfony/Curl/HeadersAndStatusTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Curl;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Custom headers and non-200 status codes for Symfony CurlHttpClient.
+ * Record/replay skipped — same curl_getinfo limitation as #329.
+ * Cassette names prefixed 'symfony-curl-headers-'.
+ */
+final class HeadersAndStatusTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testCustomRequestHeadersRecordAndReplay(): void
+    {
+        $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-headers-custom.yml');
+        $s1 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/get', [
+            'headers' => ['X-Custom-Header' => 'test-value'],
+        ])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-headers-custom.yml');
+        $s2 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/get', [
+            'headers' => ['X-Custom-Header' => 'test-value'],
+        ])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testStatus404RecordAndReplay(): void
+    {
+        $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-headers-404.yml');
+        $s1 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(404, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-headers-404.yml');
+        $s2 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(404, $s2);
+    }
+
+    public function testStatus500RecordAndReplay(): void
+    {
+        $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-headers-500.yml');
+        $s1 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(500, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-headers-500.yml');
+        $s2 = (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(500, $s2);
+    }
+}

--- a/tests/Integration/Symfony/Curl/HttpMethodsTest.php
+++ b/tests/Integration/Symfony/Curl/HttpMethodsTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Curl;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * PUT / DELETE / PATCH record/replay/passthrough for Symfony CurlHttpClient.
+ * Record/replay skipped — same curl_getinfo limitation as #329.
+ * Cassette names prefixed 'symfony-curl-methods-'.
+ */
+final class HttpMethodsTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testPutRequestRecordAndReplay(): void
+    {
+        $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-methods-put.yml');
+        $s1 = (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-methods-put.yml');
+        $s2 = (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughPutRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount());
+        $this->assertSame(200, $statusCode);
+    }
+
+    public function testDeleteRequestRecordAndReplay(): void
+    {
+        $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-methods-delete.yml');
+        $s1 = (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-methods-delete.yml');
+        $s2 = (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughDeleteRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount());
+        $this->assertSame(200, $statusCode);
+    }
+
+    public function testPatchRequestRecordAndReplay(): void
+    {
+        $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-methods-patch.yml');
+        $s1 = (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-methods-patch.yml');
+        $s2 = (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughPatchRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount());
+        $this->assertSame(200, $statusCode);
+    }
+}

--- a/tests/Integration/Symfony/Curl/HttpMethodsTest.php
+++ b/tests/Integration/Symfony/Curl/HttpMethodsTest.php
@@ -4,153 +4,64 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Curl;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\CurlHttpClient;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * PUT / DELETE / PATCH record/replay/passthrough for Symfony CurlHttpClient.
  * Record/replay skipped — same curl_getinfo limitation as #329.
  * Cassette names prefixed 'symfony-curl-methods-'.
  */
-final class HttpMethodsTest extends TestCase
+final class HttpMethodsTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testPutRequestRecordAndReplay(): void
     {
         $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-methods-put.yml');
-        $s1 = (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-methods-put.yml');
-        $s2 = (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-curl-methods-put.yml',
+            fn (): int => (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
+        );
     }
 
     public function testPassthroughPutRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount());
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
+        );
     }
 
     public function testDeleteRequestRecordAndReplay(): void
     {
         $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-methods-delete.yml');
-        $s1 = (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-methods-delete.yml');
-        $s2 = (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-curl-methods-delete.yml',
+            fn (): int => (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
+        );
     }
 
     public function testPassthroughDeleteRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount());
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
+        );
     }
 
     public function testPatchRequestRecordAndReplay(): void
     {
         $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-methods-patch.yml');
-        $s1 = (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-curl-methods-patch.yml');
-        $s2 = (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-curl-methods-patch.yml',
+            fn (): int => (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
+        );
     }
 
     public function testPassthroughPatchRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount());
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
+        );
     }
 }

--- a/tests/Integration/Symfony/Curl/SequentialRequestsTest.php
+++ b/tests/Integration/Symfony/Curl/SequentialRequestsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Curl;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Sequential multi-request record/replay for Symfony CurlHttpClient.
+ * Record/replay skipped — same curl_getinfo limitation as #329.
+ * Cassette name prefixed 'symfony-curl-seq-'.
+ */
+final class SequentialRequestsTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testSequentialRequestsRecordAndReplay(): void
+    {
+        $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+        $client = new CurlHttpClient();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-seq.yml');
+        $s1 = $client->request('GET', self::$baseUrl.'/get')->getStatusCode();
+        $s2 = $client->request('GET', self::$baseUrl.'/get?page=2')->getStatusCode();
+        $s3 = $client->request('GET', self::$baseUrl.'/get?page=3')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 3, $countAfterRecord, 'All three requests must hit the server');
+        $this->assertSame(200, $s1);
+        $this->assertSame(200, $s2);
+        $this->assertSame(200, $s3);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-curl-seq.yml');
+        $t1 = $client->request('GET', self::$baseUrl.'/get')->getStatusCode();
+        $t2 = $client->request('GET', self::$baseUrl.'/get?page=2')->getStatusCode();
+        $t3 = $client->request('GET', self::$baseUrl.'/get?page=3')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $t1);
+        $this->assertSame(200, $t2);
+        $this->assertSame(200, $t3);
+    }
+}

--- a/tests/Integration/Symfony/Curl/SequentialRequestsTest.php
+++ b/tests/Integration/Symfony/Curl/SequentialRequestsTest.php
@@ -4,54 +4,16 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Curl;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\CurlHttpClient;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Sequential multi-request record/replay for Symfony CurlHttpClient.
  * Record/replay skipped — same curl_getinfo limitation as #329.
  * Cassette name prefixed 'symfony-curl-seq-'.
  */
-final class SequentialRequestsTest extends TestCase
+final class SequentialRequestsTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testSequentialRequestsRecordAndReplay(): void
     {
         $this->markTestSkipped('CurlHttpClient: curl_getinfo() before curl_multi_exec. See #329.');

--- a/tests/Integration/Symfony/Native/AsyncTest.php
+++ b/tests/Integration/Symfony/Native/AsyncTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Native;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Concurrent lazy requests for Symfony NativeHttpClient.
+ * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
+ * Cassette name prefixed 'symfony-native-async-'.
+ */
+final class AsyncTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testConcurrentRequestsRecordAndReplay(): void
+    {
+        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+        $client = new NativeHttpClient();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-async.yml');
+        $r1 = $client->request('GET', self::$baseUrl.'/get');
+        $r2 = $client->request('GET', self::$baseUrl.'/get?foo=42');
+        $s1 = $r1->getStatusCode();
+        $s2 = $r2->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 2, $countAfterRecord, 'Both requests must hit the server during recording');
+        $this->assertSame(200, $s1);
+        $this->assertSame(200, $s2);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-async.yml');
+        $t1 = $client->request('GET', self::$baseUrl.'/get');
+        $t2 = $client->request('GET', self::$baseUrl.'/get?foo=42');
+        $u1 = $t1->getStatusCode();
+        $u2 = $t2->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $u1);
+        $this->assertSame(200, $u2);
+    }
+}

--- a/tests/Integration/Symfony/Native/AsyncTest.php
+++ b/tests/Integration/Symfony/Native/AsyncTest.php
@@ -4,54 +4,16 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Native;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\NativeHttpClient;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Concurrent lazy requests for Symfony NativeHttpClient.
  * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
  * Cassette name prefixed 'symfony-native-async-'.
  */
-final class AsyncTest extends TestCase
+final class AsyncTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testConcurrentRequestsRecordAndReplay(): void
     {
         $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');

--- a/tests/Integration/Symfony/Native/BasicLifecycleTest.php
+++ b/tests/Integration/Symfony/Native/BasicLifecycleTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Native;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\NativeHttpClient;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Basic GET + POST record/replay/passthrough for Symfony NativeHttpClient via StreamWrapperHook.
@@ -20,111 +18,39 @@ use VCR\Tests\Util\TestHttpServer;
  * Passthrough tests (no VCR) verify that NativeHttpClient can reach the test server.
  * Cassette names prefixed 'symfony-native-basic-' to avoid VCRFactory cache collisions.
  */
-final class BasicLifecycleTest extends TestCase
+final class BasicLifecycleTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testGetRequestRecordAndReplay(): void
     {
-        // See tests/Integration/Guzzle/BasicLifecycleTest.php for the pattern to restore.
         $this->markTestSkipped('NativeHttpClient: headers as array in stream context; parseRawHeader() requires string. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-basic-get.yml');
-        $s1 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-basic-get.yml');
-        $s2 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-native-basic-get.yml',
+            fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
+        );
     }
 
     public function testPassthroughGetRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
+        );
     }
 
     public function testPostRequestRecordAndReplay(): void
     {
-        // See tests/Integration/Guzzle/BasicLifecycleTest.php for the pattern to restore.
         $this->markTestSkipped('NativeHttpClient: headers as array in stream context; parseRawHeader() requires string. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-basic-post.yml');
-        $s1 = (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-basic-post.yml');
-        $s2 = (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-native-basic-post.yml',
+            fn (): int => (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+        );
     }
 
     public function testPassthroughPostRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+        );
     }
 }

--- a/tests/Integration/Symfony/Native/BasicLifecycleTest.php
+++ b/tests/Integration/Symfony/Native/BasicLifecycleTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Native;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Basic GET + POST record/replay/passthrough for Symfony NativeHttpClient via StreamWrapperHook.
+ *
+ * Record/replay tests are skipped: NativeHttpClient passes HTTP headers as an array in
+ * the PHP stream context, but VCR's StreamHelper::createRequestFromStreamContext() calls
+ * HttpUtil::parseRawHeader() which requires a string. Remove the markTestSkipped() calls
+ * once that is fixed.
+ *
+ * Passthrough tests (no VCR) verify that NativeHttpClient can reach the test server.
+ * Cassette names prefixed 'symfony-native-basic-' to avoid VCRFactory cache collisions.
+ */
+final class BasicLifecycleTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testGetRequestRecordAndReplay(): void
+    {
+        // See tests/Integration/Guzzle/BasicLifecycleTest.php for the pattern to restore.
+        $this->markTestSkipped('NativeHttpClient: headers as array in stream context; parseRawHeader() requires string. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-basic-get.yml');
+        $s1 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-basic-get.yml');
+        $s2 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughGetRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode();
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame(200, $statusCode);
+    }
+
+    public function testPostRequestRecordAndReplay(): void
+    {
+        // See tests/Integration/Guzzle/BasicLifecycleTest.php for the pattern to restore.
+        $this->markTestSkipped('NativeHttpClient: headers as array in stream context; parseRawHeader() requires string. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-basic-post.yml');
+        $s1 = (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-basic-post.yml');
+        $s2 = (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughPostRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode();
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame(200, $statusCode);
+    }
+}

--- a/tests/Integration/Symfony/Native/ErrorTest.php
+++ b/tests/Integration/Symfony/Native/ErrorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Native;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * Connection-failure behaviour for Symfony NativeHttpClient.
+ * The "with VCR" test is skipped — same headers-as-array limitation as #329.
+ */
+final class ErrorTest extends TestCase
+{
+    private const UNBOUND_URL = 'http://localhost:9959/get';
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    public function testConnectExceptionWithoutVcr(): void
+    {
+        $caught = false;
+        try {
+            $response = (new NativeHttpClient())->request('GET', self::UNBOUND_URL);
+            $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            $caught = true;
+        }
+
+        $this->assertTrue($caught, 'NativeHttpClient must throw TransportException on connection failure');
+    }
+
+    public function testConnectExceptionPassesThroughWithVcr(): void
+    {
+        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-error.yml');
+
+        $caught = false;
+        try {
+            $response = (new NativeHttpClient())->request('GET', self::UNBOUND_URL);
+            $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            $caught = true;
+        } finally {
+            \VCR\VCR::turnOff();
+        }
+
+        $this->assertTrue($caught, 'TransportException must propagate through VCR');
+    }
+}

--- a/tests/Integration/Symfony/Native/ErrorTest.php
+++ b/tests/Integration/Symfony/Native/ErrorTest.php
@@ -4,29 +4,17 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Native;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\NativeHttpClient;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use VCR\Tests\Integration\AbstractIntegrationTestCase;
 
 /**
  * Connection-failure behaviour for Symfony NativeHttpClient.
  * The "with VCR" test is skipped — same headers-as-array limitation as #329.
  */
-final class ErrorTest extends TestCase
+final class ErrorTest extends AbstractIntegrationTestCase
 {
     private const UNBOUND_URL = 'http://localhost:9959/get';
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
 
     public function testConnectExceptionWithoutVcr(): void
     {

--- a/tests/Integration/Symfony/Native/HeadersAndStatusTest.php
+++ b/tests/Integration/Symfony/Native/HeadersAndStatusTest.php
@@ -4,127 +4,47 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Native;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\NativeHttpClient;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Custom headers and non-200 status codes for Symfony NativeHttpClient.
  * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
  * Cassette names prefixed 'symfony-native-headers-'.
  */
-final class HeadersAndStatusTest extends TestCase
+final class HeadersAndStatusTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testCustomRequestHeadersRecordAndReplay(): void
     {
         $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-headers-custom.yml');
-        $s1 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/get', [
-            'headers' => ['X-Custom-Header' => 'test-value'],
-        ])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-headers-custom.yml');
-        $s2 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/get', [
-            'headers' => ['X-Custom-Header' => 'test-value'],
-        ])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-native-headers-custom.yml',
+            fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/get', [
+                'headers' => ['X-Custom-Header' => 'test-value'],
+            ])->getStatusCode(),
+        );
     }
 
     public function testStatus404RecordAndReplay(): void
     {
         $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-headers-404.yml');
-        $s1 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(404, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-headers-404.yml');
-        $s2 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(404, $s2);
+        $this->recordAndReplay(
+            'symfony-native-headers-404.yml',
+            fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode(),
+            404,
+        );
     }
 
     public function testStatus500RecordAndReplay(): void
     {
         $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-headers-500.yml');
-        $s1 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(500, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-headers-500.yml');
-        $s2 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(500, $s2);
+        $this->recordAndReplay(
+            'symfony-native-headers-500.yml',
+            fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode(),
+            500,
+        );
     }
 }

--- a/tests/Integration/Symfony/Native/HeadersAndStatusTest.php
+++ b/tests/Integration/Symfony/Native/HeadersAndStatusTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Native;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Custom headers and non-200 status codes for Symfony NativeHttpClient.
+ * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
+ * Cassette names prefixed 'symfony-native-headers-'.
+ */
+final class HeadersAndStatusTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testCustomRequestHeadersRecordAndReplay(): void
+    {
+        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-headers-custom.yml');
+        $s1 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/get', [
+            'headers' => ['X-Custom-Header' => 'test-value'],
+        ])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-headers-custom.yml');
+        $s2 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/get', [
+            'headers' => ['X-Custom-Header' => 'test-value'],
+        ])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testStatus404RecordAndReplay(): void
+    {
+        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-headers-404.yml');
+        $s1 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(404, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-headers-404.yml');
+        $s2 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(404, $s2);
+    }
+
+    public function testStatus500RecordAndReplay(): void
+    {
+        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-headers-500.yml');
+        $s1 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(500, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-headers-500.yml');
+        $s2 = (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(500, $s2);
+    }
+}

--- a/tests/Integration/Symfony/Native/HttpMethodsTest.php
+++ b/tests/Integration/Symfony/Native/HttpMethodsTest.php
@@ -4,153 +4,64 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Native;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\NativeHttpClient;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * PUT / DELETE / PATCH record/replay/passthrough for Symfony NativeHttpClient.
  * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
  * Cassette names prefixed 'symfony-native-methods-'.
  */
-final class HttpMethodsTest extends TestCase
+final class HttpMethodsTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testPutRequestRecordAndReplay(): void
     {
         $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-methods-put.yml');
-        $s1 = (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-methods-put.yml');
-        $s2 = (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-native-methods-put.yml',
+            fn (): int => (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
+        );
     }
 
     public function testPassthroughPutRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
+        );
     }
 
     public function testDeleteRequestRecordAndReplay(): void
     {
         $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-methods-delete.yml');
-        $s1 = (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-methods-delete.yml');
-        $s2 = (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-native-methods-delete.yml',
+            fn (): int => (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
+        );
     }
 
     public function testPassthroughDeleteRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
+        );
     }
 
     public function testPatchRequestRecordAndReplay(): void
     {
         $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
 
-        $countBefore = $this->server()->getRequestCount();
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-methods-patch.yml');
-        $s1 = (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $countAfterRecord = $this->server()->getRequestCount();
-        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
-        $this->assertSame(200, $s1);
-
-        \VCR\VCR::turnOn();
-        \VCR\VCR::insertCassette('symfony-native-methods-patch.yml');
-        $s2 = (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
-        \VCR\VCR::turnOff();
-
-        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
-        $this->assertSame(200, $s2);
+        $this->recordAndReplay(
+            'symfony-native-methods-patch.yml',
+            fn (): int => (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
+        );
     }
 
     public function testPassthroughPatchRequest(): void
     {
-        $countBefore = $this->server()->getRequestCount();
-
-        $statusCode = (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
-
-        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
-        $this->assertSame(200, $statusCode);
+        $this->assertPassthrough(
+            fn (): int => (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
+        );
     }
 }

--- a/tests/Integration/Symfony/Native/HttpMethodsTest.php
+++ b/tests/Integration/Symfony/Native/HttpMethodsTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Native;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * PUT / DELETE / PATCH record/replay/passthrough for Symfony NativeHttpClient.
+ * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
+ * Cassette names prefixed 'symfony-native-methods-'.
+ */
+final class HttpMethodsTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testPutRequestRecordAndReplay(): void
+    {
+        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-methods-put.yml');
+        $s1 = (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-methods-put.yml');
+        $s2 = (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughPutRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode();
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame(200, $statusCode);
+    }
+
+    public function testDeleteRequestRecordAndReplay(): void
+    {
+        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-methods-delete.yml');
+        $s1 = (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-methods-delete.yml');
+        $s2 = (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughDeleteRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode();
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame(200, $statusCode);
+    }
+
+    public function testPatchRequestRecordAndReplay(): void
+    {
+        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-methods-patch.yml');
+        $s1 = (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 1, $countAfterRecord, 'Record must hit the server');
+        $this->assertSame(200, $s1);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-methods-patch.yml');
+        $s2 = (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $s2);
+    }
+
+    public function testPassthroughPatchRequest(): void
+    {
+        $countBefore = $this->server()->getRequestCount();
+
+        $statusCode = (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode();
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'Passthrough must hit the server');
+        $this->assertSame(200, $statusCode);
+    }
+}

--- a/tests/Integration/Symfony/Native/SequentialRequestsTest.php
+++ b/tests/Integration/Symfony/Native/SequentialRequestsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Symfony\Native;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use VCR\Tests\Util\TestHttpServer;
+
+/**
+ * Sequential multi-request record/replay for Symfony NativeHttpClient.
+ * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
+ * Cassette name prefixed 'symfony-native-seq-'.
+ */
+final class SequentialRequestsTest extends TestCase
+{
+    private static ?TestHttpServer $server = null;
+    private static string $baseUrl = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = TestHttpServer::start();
+        self::$baseUrl = self::$server->getBaseUrl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (null !== self::$server) {
+            self::$server->stop();
+            self::$server = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
+    }
+
+    protected function tearDown(): void
+    {
+        \VCR\VCR::turnOff();
+    }
+
+    private function server(): TestHttpServer
+    {
+        $server = self::$server;
+        $this->assertNotNull($server);
+
+        return $server;
+    }
+
+    public function testSequentialRequestsRecordAndReplay(): void
+    {
+        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
+
+        $countBefore = $this->server()->getRequestCount();
+        $client = new NativeHttpClient();
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-seq.yml');
+        $s1 = $client->request('GET', self::$baseUrl.'/get')->getStatusCode();
+        $s2 = $client->request('GET', self::$baseUrl.'/get?page=2')->getStatusCode();
+        $s3 = $client->request('GET', self::$baseUrl.'/get?page=3')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $countAfterRecord = $this->server()->getRequestCount();
+        $this->assertSame($countBefore + 3, $countAfterRecord, 'All three requests must hit the server');
+        $this->assertSame(200, $s1);
+        $this->assertSame(200, $s2);
+        $this->assertSame(200, $s3);
+
+        \VCR\VCR::turnOn();
+        \VCR\VCR::insertCassette('symfony-native-seq.yml');
+        $t1 = $client->request('GET', self::$baseUrl.'/get')->getStatusCode();
+        $t2 = $client->request('GET', self::$baseUrl.'/get?page=2')->getStatusCode();
+        $t3 = $client->request('GET', self::$baseUrl.'/get?page=3')->getStatusCode();
+        \VCR\VCR::turnOff();
+
+        $this->assertSame($countAfterRecord, $this->server()->getRequestCount(), 'Replay must not hit the server');
+        $this->assertSame(200, $t1);
+        $this->assertSame(200, $t2);
+        $this->assertSame(200, $t3);
+    }
+}

--- a/tests/Integration/Symfony/Native/SequentialRequestsTest.php
+++ b/tests/Integration/Symfony/Native/SequentialRequestsTest.php
@@ -4,54 +4,16 @@ declare(strict_types=1);
 
 namespace VCR\Tests\Integration\Symfony\Native;
 
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\NativeHttpClient;
-use VCR\Tests\Util\TestHttpServer;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Sequential multi-request record/replay for Symfony NativeHttpClient.
  * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
  * Cassette name prefixed 'symfony-native-seq-'.
  */
-final class SequentialRequestsTest extends TestCase
+final class SequentialRequestsTest extends AbstractHttpServerIntegrationTestCase
 {
-    private static ?TestHttpServer $server = null;
-    private static string $baseUrl = '';
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$server = TestHttpServer::start();
-        self::$baseUrl = self::$server->getBaseUrl();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (null !== self::$server) {
-            self::$server->stop();
-            self::$server = null;
-        }
-    }
-
-    protected function setUp(): void
-    {
-        vfsStream::setup('testDir');
-        \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
-    }
-
-    protected function tearDown(): void
-    {
-        \VCR\VCR::turnOff();
-    }
-
-    private function server(): TestHttpServer
-    {
-        $server = self::$server;
-        $this->assertNotNull($server);
-
-        return $server;
-    }
-
     public function testSequentialRequestsRecordAndReplay(): void
     {
         $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');

--- a/tests/Util/Server/Entrypoint.php
+++ b/tests/Util/Server/Entrypoint.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+// Suppress PHP notices/warnings from leaking into HTTP response bodies.
+// The built-in server has no separate stderr for PHP output; deprecation
+// notices from lowest-deps packages (e.g. guzzlehttp/promises on PHP 8.4)
+// would otherwise corrupt JSON responses and break test assertions.
+ini_set('display_errors', '0');
+error_reporting(\E_ALL & ~\E_DEPRECATED & ~\E_USER_DEPRECATED);
+
 require __DIR__.'/../../../vendor/autoload.php';
 
 VCR\Tests\Util\Server\Router::handle();

--- a/tests/Util/Server/Router.php
+++ b/tests/Util/Server/Router.php
@@ -8,6 +8,8 @@ final class Router
 {
     public static function handle(): void
     {
+        self::incrementCounter();
+
         $uri = (string) ($_SERVER['REQUEST_URI'] ?? '/');
         $path = strtok($uri, '?') ?: '/';
         $method = (string) ($_SERVER['REQUEST_METHOD'] ?? 'GET');
@@ -18,9 +20,45 @@ final class Router
             return;
         }
 
+        if (\in_array($method, ['POST', 'PUT', 'DELETE', 'PATCH'], true) && '/'.strtolower($method) === $path) {
+            self::sendBodyResponse($method, $uri);
+
+            return;
+        }
+
+        if ('GET' === $method && 1 === preg_match('#^/status/(\d+)$#', $path, $m)) {
+            http_response_code((int) $m[1]);
+            header('Content-Type: application/json');
+            echo json_encode(['status' => (int) $m[1]], \JSON_THROW_ON_ERROR);
+
+            return;
+        }
+
         http_response_code(404);
         header('Content-Type: application/json');
         echo json_encode(['error' => 'Not Found'], \JSON_THROW_ON_ERROR);
+    }
+
+    private static function incrementCounter(): void
+    {
+        $port = (int) ($_SERVER['SERVER_PORT'] ?? 0);
+        if (0 === $port) {
+            return;
+        }
+
+        $counterFile = sys_get_temp_dir()."/php-vcr-test-counter-{$port}";
+        $fp = fopen($counterFile, 'c+');
+        if (false === $fp) {
+            return;
+        }
+
+        flock($fp, \LOCK_EX);
+        $count = (int) stream_get_contents($fp);
+        fseek($fp, 0);
+        ftruncate($fp, 0);
+        fwrite($fp, (string) ($count + 1));
+        flock($fp, \LOCK_UN);
+        fclose($fp);
     }
 
     private static function sendGetResponse(string $uri): void
@@ -36,6 +74,44 @@ final class Router
 
         header('Content-Type: application/json');
         /** @var array<string, mixed> $args */
-        echo json_encode(['url' => $url, 'args' => $args], \JSON_THROW_ON_ERROR);
+        echo json_encode(['url' => $url, 'args' => $args, 'headers' => self::getRequestHeaders()], \JSON_THROW_ON_ERROR);
+    }
+
+    private static function sendBodyResponse(string $method, string $uri): void
+    {
+        $queryString = (string) ($_SERVER['QUERY_STRING'] ?? '');
+        $args = [];
+        if ('' !== $queryString) {
+            parse_str($queryString, $args);
+        }
+
+        $host = (string) ($_SERVER['HTTP_HOST'] ?? '127.0.0.1');
+        $url = 'http://'.$host.$uri;
+        $body = (string) file_get_contents('php://input');
+
+        header('Content-Type: application/json');
+        /** @var array<string, mixed> $args */
+        echo json_encode([
+            'url' => $url,
+            'method' => $method,
+            'args' => $args,
+            'body' => $body,
+            'headers' => self::getRequestHeaders(),
+        ], \JSON_THROW_ON_ERROR);
+    }
+
+    /** @return array<string, string> */
+    private static function getRequestHeaders(): array
+    {
+        $headers = [];
+        foreach ($_SERVER as $key => $value) {
+            if (!str_starts_with($key, 'HTTP_')) {
+                continue;
+            }
+            $name = str_replace('_', '-', substr($key, 5));
+            $headers[$name] = (string) $value;
+        }
+
+        return $headers;
     }
 }

--- a/tests/Util/TestHttpServer.php
+++ b/tests/Util/TestHttpServer.php
@@ -57,11 +57,41 @@ final class TestHttpServer
     {
         proc_terminate($this->process);
         proc_close($this->process);
+
+        $counterFile = $this->getCounterFilePath();
+        if (file_exists($counterFile)) {
+            unlink($counterFile);
+        }
     }
 
     public function getBaseUrl(): string
     {
         return "http://127.0.0.1:{$this->port}";
+    }
+
+    public function getRequestCount(): int
+    {
+        $counterFile = $this->getCounterFilePath();
+        if (!file_exists($counterFile)) {
+            return 0;
+        }
+
+        $content = file_get_contents($counterFile);
+
+        return false === $content ? 0 : (int) $content;
+    }
+
+    public function resetRequestCount(): void
+    {
+        $counterFile = $this->getCounterFilePath();
+        if (file_exists($counterFile)) {
+            file_put_contents($counterFile, '0');
+        }
+    }
+
+    private function getCounterFilePath(): string
+    {
+        return sys_get_temp_dir()."/php-vcr-test-counter-{$this->port}";
     }
 
     private static function findFreePort(): int


### PR DESCRIPTION
### Context

Closes #439. PHP-VCR lacked systematic functional integration tests for popular HTTP client libraries — issues like #329 (Symfony HttpClient) were only discovered by end users, not our own test suite.

This PR builds on the self-contained local HTTP server from #438 and adds functional tests covering the full VCR lifecycle (record → replay → passthrough) across all major HTTP backends.

### What has been done

**Test server extensions (`tests/Util/`):**
- Request counter (`getRequestCount()`/`resetRequestCount()`) so replay tests can assert the server was **not** hit
- New endpoints: `POST /post`, `PUT /put`, `DELETE /delete`, `PATCH /patch`, `GET /status/{code}`
- Suppress `E_DEPRECATED` in `Entrypoint.php` — prevents PHP 8.4 notices from lowest-dep packages corrupting JSON response bodies

**New test suites (16 new test classes, 36 active tests + 22 skipped):**
- `tests/Integration/Guzzle/` — `BasicLifecycleTest`, `HttpMethodsTest`, `HeadersAndStatusTest`, `SequentialRequestsTest` (covers #432 regression)
- `tests/Integration/Native/` — `CurlTest`, `StreamWrapperTest`
- `tests/Integration/Symfony/Curl/` — 6 classes for `CurlHttpClient`
- `tests/Integration/Symfony/Native/` — 6 classes for `NativeHttpClient`

**Known VCR limitations (tests present, skipped):**
- `CurlHttpClient`: `curl_getinfo()` called before `curl_multi_exec()` completes in CurlHook. See #329.
- `NativeHttpClient`: headers passed as array in stream context; `StreamHelper::parseRawHeader()` requires a string. See #329.

**`composer.json`:** `symfony/http-client ^5.4|^6.0|^7.0` added to `require-dev` (covers PHP 8.0–8.5).

**`composer test`:** Split into two phpunit invocations to isolate Unit and Integration suites — Unit tests leave stale `CurlHook::$responses` entries that contaminate Integration tests (root cause: issue #432).

### How to test

Verified on workspace80 (PHP 8.0) and workspace84 (PHP 8.4), lowest and highest deps:

```bash
docker compose run --rm workspace80 composer update --prefer-lowest
docker compose run --rm workspace80 composer test
docker compose run --rm workspace80 composer update
docker compose run --rm workspace80 composer test
docker compose run --rm workspace80 composer phpstan
docker compose run --rm workspace80 composer cs
docker compose run --rm workspace80 composer ec

docker compose run --rm workspace84 composer update --prefer-lowest
docker compose run --rm workspace84 composer test
docker compose run --rm workspace84 composer update
docker compose run --rm workspace84 composer test
```

All pass: 58 tests, 22 known-limitation skips, 0 failures.

### Notes

- Unreachable code after `markTestSkipped()` in Symfony tests is intentional (documents expected behaviour once #329 is fixed) and captured in `phpstan-baseline.neon`. Remove baseline entries when removing the skip.
- The `composer test` split is a workaround for #432. Once `curlClose()` is implemented, the split can be reverted.