### PR TITLE
feat(github): add structured issue templates (bug report, feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.yaml
@@ -1,0 +1,84 @@
+name: 🐛 Bug Report
+description: ⚠️ NEVER report security issues — open a private advisory at https://github.com/php-vcr/php-vcr/security/advisories/new instead
+type: Bug
+labels: Bug
+
+body:
+    - type: input
+      id: php-vcr-version
+      attributes:
+          label: php-vcr version
+          description: Output of `composer show php-vcr/php-vcr` or the tag from your `composer.lock`.
+          placeholder: x.y.z
+      validations:
+          required: true
+    - type: dropdown
+      id: php-version
+      attributes:
+          label: PHP version
+          description: Output of `php -v`.
+          options:
+              - "8.0"
+              - "8.1"
+              - "8.2 (>= 8.2.9)"
+              - "8.3"
+              - "8.4"
+              - "8.5"
+              - Other (please mention in Additional context)
+      validations:
+          required: true
+    - type: dropdown
+      id: library-hook
+      attributes:
+          label: Library hook in use
+          description: Which interception mechanism is active during the failing test? See VCR::configure()->enableLibraryHooks().
+          options:
+              - curl
+              - soap
+              - stream_wrapper
+              - Multiple
+              - Not sure
+      validations:
+          required: true
+    - type: dropdown
+      id: storage-backend
+      attributes:
+          label: Storage backend
+          description: "Storage format: yaml / json / blackhole, or a custom implementation."
+          options:
+              - yaml
+              - json
+              - blackhole
+              - Custom
+              - Not sure
+      validations:
+          required: true
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: A clear and concise description of the problem.
+      validations:
+          required: true
+    - type: textarea
+      id: how-to-reproduce
+      attributes:
+          label: How to reproduce
+          description: |
+            ⚠️ This is the most important part of the report ⚠️
+            Without a way to reliably reproduce the issue, there is little chance we will be able to help you and work on a fix.
+            Please share a minimal, runnable PHP snippet plus the relevant cassette (or a redacted version). Mention any non-default configuration: matchers, record mode, request hooks.
+      validations:
+          required: true
+    - type: textarea
+      id: possible-solution
+      attributes:
+          label: Possible Solution
+          description: |
+            Optional: only if you have suggestions on a fix/reason for the bug.
+            Don't hesitate to open a pull request with your solution — it gets faster feedback.
+    - type: textarea
+      id: additional-context
+      attributes:
+          label: Additional Context
+          description: "Optional: any other context: log messages, stack traces, screenshots, related issues."

--- a/.github/ISSUE_TEMPLATE/2_Feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.yaml
@@ -1,0 +1,19 @@
+name: 🚀 Feature Request
+description: Ideas, RFCs and proposals for new features or improvements
+type: Feature
+
+body:
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: A clear and concise description of the new feature or improvement.
+      validations:
+          required: true
+    - type: textarea
+      id: example
+      attributes:
+          label: Example
+          description: |
+              A simple example of the new feature in action (include PHP code, YAML cassette excerpt, etc.).
+              If it changes existing behaviour, include a simple before/after comparison.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
### Context

No structured issue templates existed; reporters opened free-form issues
without consistent version/PHP/hook information, which slowed down triage.
This PR ports Symfony's Issue Forms approach (`.github/ISSUE_TEMPLATE/*.yaml`)
and adapts it to php-vcr.

### What has been done

- Added `1_Bug_report.yaml` with required php-vcr version, PHP version
  dropdown, library-hook dropdown, storage-backend dropdown, description and
  how-to-reproduce. Auto-applies the `Bug` label and sets the `Bug` issue
  type via the form's `type:` frontmatter.
- Added `2_Feature_request.yaml` with required description and optional
  example. Sets the `Feature` issue type via `type:`; no auto-label
  (Symfony convention — maintainers decide between `Feature`/`Enhancement`
  after triage).
- Added `config.yml` disabling blank issues so reporters must choose a form.

### How to test

- YAML files parse without error (no tabs, valid structure).
- On GitHub, open "New issue": two templates appear (🐛 Bug Report,
  🚀 Feature Request), "Open a blank issue" is gone.
- Submitting the bug form auto-applies the `Bug` label and sets Issue Type
  `Bug`.

### Notes

- Targets `master`; backwards-compatible (templates are additive).
- No PHP code change → no docker-compose CI matrix run needed.
- `Bug` label exists on the repo (set up in the prior label-reconciliation).