### PR TITLE
fix(http): accept array-form http.header in StreamHelper

### DIFF
--- a/src/VCR/Util/StreamHelper.php
+++ b/src/VCR/Util/StreamHelper.php
@@ -30,7 +30,10 @@ class StreamHelper
         }
 
         if (!empty($http['header'])) {
-            $headers = HttpUtil::parseHeaders(HttpUtil::parseRawHeader($http['header']));
+            $rawHeaders = \is_array($http['header'])
+                ? $http['header']
+                : HttpUtil::parseRawHeader($http['header']);
+            $headers = HttpUtil::parseHeaders($rawHeaders);
             foreach ($headers as $key => $value) {
                 $request->setHeader($key, $value);
             }

--- a/tests/Unit/Util/StreamHelperTest.php
+++ b/tests/Unit/Util/StreamHelperTest.php
@@ -37,6 +37,21 @@ final class StreamHelperTest extends TestCase
                 },
             ],
 
+            'header as array' => [
+                ['header' => ['Content-Type: application/json']],
+                static function (Request $request): void {
+                    Assert::assertEquals('application/json', $request->getHeader('Content-Type'));
+                },
+            ],
+
+            'multiple headers as array' => [
+                ['header' => ['Content-Type: application/json', 'Content-Length: 123']],
+                static function (Request $request): void {
+                    Assert::assertEquals('application/json', $request->getHeader('Content-Type'));
+                    Assert::assertEquals('123', $request->getHeader('Content-Length'));
+                },
+            ],
+
             'user_agent' => [
                 ['user_agent' => 'example'],
                 static function (Request $request): void {


### PR DESCRIPTION
### Context

Symfony `NativeHttpClient` writes the `http.header` stream-context option exclusively as `array<int, string>` (PHP 7.2+ supported form). VCR's `StreamHelper::createRequestFromStreamContext()` passed the value unconditionally to `HttpUtil::parseRawHeader(string)`, so every intercepted NativeHttpClient request crashed with `TypeError` under `strict_types`. Empirical run on 2026-06-10 confirmed all 11 record/replay tests in `tests/Integration/Symfony/Native/` fail with the identical stack:

```
TypeError: VCR\Util\HttpUtil::parseRawHeader():
Argument #1 ($rawHeader) must be of type string, array given,
called in src/VCR/Util/StreamHelper.php on line 33
```

Closes #449. Contributes to #444 (the remaining `wrapper_data` / `stream_get_meta_data` interception gap stays open under that ticket — fix will follow).

### What has been done

- `StreamHelper::createRequestFromStreamContext()` branches on `is_array($http['header'])` and passes arrays straight to `HttpUtil::parseHeaders()`; the string path is unchanged.
- New data-provider cases in `StreamHelperTest`: `header as array`, `multiple headers as array`.

### How to test

- `docker compose run --rm workspace80 composer update && composer phpstan`
- `docker compose run --rm workspace80 composer cs`
- `docker compose run --rm workspace80 composer ec`
- `docker compose run --rm workspace80 composer update --prefer-lowest && composer test`
- `docker compose run --rm workspace80 composer update && composer test`
- `docker compose run --rm workspace84 composer update --prefer-lowest && composer test`
- `docker compose run --rm workspace84 composer update && composer test`
- Targeted: `docker compose run --rm workspace80 vendor/bin/phpunit tests/Unit/Util/StreamHelperTest.php`

### Todo

_(none — all verification steps completed locally)_

### Notes

- Integration tests under `tests/Integration/Symfony/Native/` remain `markTestSkipped()`. This fix on its own does not unblock them — the `wrapper_data` interception gap from #444 is the second half. A follow-up PR will lift those skips together with the #444 fix.
- No PHPStan baseline change expected; the new branch is additive and type-narrow.