### PR TITLE
fix(stream-wrapper): intercept stream_get_meta_data() for Symfony NativeHttpClient compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ Disclaimer: Doing this in PHP is not as easy as in programming languages which s
 ## Features
 
 * Automatically records and replays your HTTP(s) interactions with minimal setup/configuration code.
-* Supports common http functions and extensions
-  * everything using [streamWrapper](http://php.net/manual/en/class.streamwrapper.php): fopen(), fread(), file_get_contents(), ... without any modification (except `$http_response_header` see [#96](https://github.com/php-vcr/php-vcr/issues/96))
-  * [SoapClient](http://www.php.net/manual/en/soapclient.soapclient.php) by adding `\VCR\VCR::turnOn();` in your `tests/bootstrap.php`
-  * curl(), by adding `\VCR\VCR::turnOn();` in your `tests/bootstrap.php`
+* Supports common http functions and extensions — see [Supported HTTP libraries](#supported-http-libraries) below
 * The same request can receive different responses in different tests -- just use different cassettes.
 * Disables all HTTP requests that you don't explicitly allow by [setting the record mode](http://php-vcr.github.io/documentation/configuration/)
 * [Request matching](http://php-vcr.github.io/documentation/configuration/) is configurable based on HTTP method, URI, host, path, body and headers, or you can easily
@@ -84,6 +81,25 @@ class VCRTest extends TestCase
     }
 }
 ```
+
+## Supported HTTP libraries
+
+All three hooks are **enabled by default** when you call `VCR::turnOn()`. No extra configuration is required.
+
+| Hook name | Intercepted libraries | How it works |
+|---|---|---|
+| `stream_wrapper` | `fopen()`, `fread()`, `file_get_contents()`, `Symfony\Component\HttpClient\NativeHttpClient` | Replaces the `http`/`https` stream wrapper — no source rewriting |
+| `curl` | `curl_*` functions, `Symfony\Component\HttpClient\CurlHttpClient`, Guzzle (curl backend) | Rewrites `curl_*` calls in loaded PHP source via a stream filter |
+| `soap` | `SoapClient` | Rewrites `new SoapClient(…)` in loaded PHP source via a stream filter |
+
+To enable only specific hooks (e.g. when you know your code only uses curl):
+
+```php
+\VCR\VCR::configure()->enableLibraryHooks(['curl']);
+\VCR\VCR::turnOn();
+```
+
+Available hook names: `stream_wrapper`, `curl`, `soap`.
 
 ## Installation
 

--- a/src/VCR/CodeTransform/StreamWrapperCodeTransform.php
+++ b/src/VCR/CodeTransform/StreamWrapperCodeTransform.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\CodeTransform;
+
+use VCR\Util\Assertion;
+
+class StreamWrapperCodeTransform extends AbstractCodeTransform
+{
+    public const NAME = 'vcr_stream_wrapper';
+
+    /**
+     * @var array<string, string>
+     */
+    private static $patterns = [
+        '/(?<!::|->|\w_)\\\?stream_get_meta_data\s*\(/i' => '\VCR\LibraryHooks\StreamWrapperHook::streamGetMetaData(',
+    ];
+
+    protected function transformCode(string $code): string
+    {
+        $transformedCode = preg_replace(array_keys(self::$patterns), array_values(self::$patterns), $code);
+        Assertion::string($transformedCode);
+
+        return $transformedCode;
+    }
+}

--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
      *
      * @var string[] a blacklist is a list of paths
      */
-    private $blackList = ['src/VCR/LibraryHooks/', 'src/VCR/Util/SoapClient', 'tests/VCR/Filter'];
+    private $blackList = ['src/VCR/LibraryHooks/', 'src/VCR/Util/SoapClient', 'src/VCR/Util/StreamProcessor', 'tests/VCR/Filter'];
 
     private string $mode = VCR::MODE_NEW_EPISODES;
 

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -362,9 +362,10 @@ class CurlHook implements LibraryHook
      */
     public static function curlSetopt(\CurlHandle $curlHandle, int $option, $value): bool
     {
-        CurlHelper::setCurlOptionOnRequest(self::$requests[(int) $curlHandle], $option, $value);
-
-        static::$curlOptions[(int) $curlHandle][$option] = $value;
+        if (isset(self::$requests[(int) $curlHandle])) {
+            CurlHelper::setCurlOptionOnRequest(self::$requests[(int) $curlHandle], $option, $value);
+            static::$curlOptions[(int) $curlHandle][$option] = $value;
+        }
 
         return curl_setopt($curlHandle, $option, $value);
     }

--- a/src/VCR/LibraryHooks/StreamWrapperHook.php
+++ b/src/VCR/LibraryHooks/StreamWrapperHook.php
@@ -7,6 +7,7 @@ namespace VCR\LibraryHooks;
 use VCR\Response;
 use VCR\Util\Assertion;
 use VCR\Util\CurlException;
+use VCR\Util\HttpUtil;
 use VCR\Util\StreamHelper;
 
 class StreamWrapperHook implements LibraryHook
@@ -18,6 +19,9 @@ class StreamWrapperHook implements LibraryHook
     protected string $status = self::DISABLED;
 
     protected Response $response;
+
+    /** @var string[] */
+    protected array $responseHeaders = [];
 
     /**
      * @var resource current stream context
@@ -70,6 +74,7 @@ class StreamWrapperHook implements LibraryHook
         Assertion::isCallable($requestCallback);
         try {
             $this->response = $requestCallback($request);
+            $this->responseHeaders = self::buildResponseHeaderLines($this->response);
 
             return true;
         } catch (CurlException $e) {
@@ -198,5 +203,39 @@ class StreamWrapperHook implements LibraryHook
     public function stream_metadata(string $path, int $option, $var): bool
     {
         return false;
+    }
+
+    /**
+     * Interception target for stream_get_meta_data() under VCR.
+     *
+     * When the stream was opened through this wrapper, PHP puts the wrapper
+     * object into wrapper_data. Replace it with the pre-built HTTP response
+     * header lines that Symfony's NativeResponse::addResponseHeaders() expects.
+     *
+     * @param resource $resource
+     *
+     * @return array<string, mixed>
+     */
+    public static function streamGetMetaData($resource): array
+    {
+        $meta = stream_get_meta_data($resource);
+
+        if (isset($meta['wrapper_data']) && $meta['wrapper_data'] instanceof self) {
+            $meta['wrapper_data'] = $meta['wrapper_data']->responseHeaders;
+        }
+
+        return $meta;
+    }
+
+    /** @return string[] */
+    private static function buildResponseHeaderLines(Response $response): array
+    {
+        $lines = [rtrim(HttpUtil::formatAsStatusString($response), "\r\n")];
+
+        foreach ($response->getHeaders() as $name => $value) {
+            $lines[] = $name.': '.$value;
+        }
+
+        return $lines;
     }
 }

--- a/src/VCR/LibraryHooks/StreamWrapperHook.php
+++ b/src/VCR/LibraryHooks/StreamWrapperHook.php
@@ -4,15 +4,23 @@ declare(strict_types=1);
 
 namespace VCR\LibraryHooks;
 
+use VCR\CodeTransform\AbstractCodeTransform;
 use VCR\Response;
 use VCR\Util\Assertion;
 use VCR\Util\CurlException;
 use VCR\Util\HttpUtil;
 use VCR\Util\StreamHelper;
+use VCR\Util\StreamProcessor;
 
 class StreamWrapperHook implements LibraryHook
 {
     protected static ?\Closure $requestCallback;
+
+    // Static: PHP instantiates a new StreamWrapperHook (no args) for every fopen() call
+    // through the registered stream wrapper, so these cannot be instance properties.
+    protected static ?AbstractCodeTransform $codeTransformer = null;
+
+    protected static ?StreamProcessor $processor = null;
 
     protected int $position = 0;
 
@@ -28,8 +36,30 @@ class StreamWrapperHook implements LibraryHook
      */
     public $context;
 
+    public function __construct(
+        ?AbstractCodeTransform $codeTransformer = null,
+        ?StreamProcessor $processor = null
+    ) {
+        if (null !== $codeTransformer) {
+            self::$codeTransformer = $codeTransformer;
+        }
+        if (null !== $processor) {
+            self::$processor = $processor;
+        }
+    }
+
     public function enable(\Closure $requestCallback): void
     {
+        if (self::ENABLED == $this->status) {
+            return;
+        }
+
+        if (null !== self::$codeTransformer && null !== self::$processor) {
+            self::$codeTransformer->register();
+            self::$processor->appendCodeTransformer(self::$codeTransformer);
+            self::$processor->intercept();
+        }
+
         self::$requestCallback = $requestCallback;
         stream_wrapper_unregister('http');
         stream_wrapper_register('http', __CLASS__, \STREAM_IS_URL);

--- a/src/VCR/LibraryHooks/StreamWrapperHook.php
+++ b/src/VCR/LibraryHooks/StreamWrapperHook.php
@@ -236,6 +236,14 @@ class StreamWrapperHook implements LibraryHook
     }
 
     /**
+     * @see https://www.php.net/manual/en/streamwrapper.stream-set-option.php
+     */
+    public function stream_set_option(int $option, int $arg1, ?int $arg2): bool
+    {
+        return false;
+    }
+
+    /**
      * Interception target for stream_get_meta_data() under VCR.
      *
      * When the stream was opened through this wrapper, PHP puts the wrapper

--- a/src/VCR/LibraryHooks/StreamWrapperHook.php
+++ b/src/VCR/LibraryHooks/StreamWrapperHook.php
@@ -72,6 +72,10 @@ class StreamWrapperHook implements LibraryHook
 
     public function disable(): void
     {
+        if (self::ENABLED !== $this->status) {
+            return;
+        }
+
         self::$requestCallback = null;
         stream_wrapper_restore('http');
         stream_wrapper_restore('https');

--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -44,11 +44,20 @@ class HttpUtil
      */
     public static function parseStatus(string $status): array
     {
-        Assertion::startsWith(
-            $status,
-            'HTTP/',
-            "Invalid HTTP status '$status', expected format like: 'HTTP/1.1 200 OK'."
-        );
+        // Pre-check with str_starts_with so that Assertion::startsWith is only
+        // called on the error path. On PHP 8.4, beberlei/assert <3.3.4 calls
+        // mb_strpos() with null offset inside startsWith(), triggering E_DEPRECATED.
+        // Symfony NativeResponse registers its own error handler during stream reads
+        // that converts any E_DEPRECATED into a TransportException — so the deprecation
+        // must never be triggered on the happy path. Keeping Assertion::startsWith on
+        // the error path preserves the Assert\InvalidArgumentException type for callers.
+        if (!str_starts_with($status, 'HTTP/')) {
+            Assertion::startsWith(
+                $status,
+                'HTTP/',
+                "Invalid HTTP status '$status', expected format like: 'HTTP/1.1 200 OK'."
+            );
+        }
 
         $part = explode(' ', $status, 3);
 

--- a/src/VCR/VCRFactory.php
+++ b/src/VCR/VCRFactory.php
@@ -7,6 +7,7 @@ namespace VCR;
 use Assert\Assertion;
 use VCR\LibraryHooks\CurlHook;
 use VCR\LibraryHooks\SoapHook;
+use VCR\LibraryHooks\StreamWrapperHook;
 use VCR\Storage\Storage;
 use VCR\Util\StreamProcessor;
 
@@ -69,6 +70,14 @@ class VCRFactory
     {
         return new CurlHook(
             $this->getOrCreate('VCR\CodeTransform\CurlCodeTransform'),
+            $this->getOrCreate('VCR\Util\StreamProcessor')
+        );
+    }
+
+    protected function createVCRLibraryHooksStreamWrapperHook(): StreamWrapperHook
+    {
+        return new StreamWrapperHook(
+            $this->getOrCreate('VCR\CodeTransform\StreamWrapperCodeTransform'),
             $this->getOrCreate('VCR\Util\StreamProcessor')
         );
     }

--- a/tests/Integration/Guzzle/BasicLifecycleTest.php
+++ b/tests/Integration/Guzzle/BasicLifecycleTest.php
@@ -18,14 +18,14 @@ final class BasicLifecycleTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'guzzle-basic-get.yml',
-            fn (): int => (new Client())->get(self::$baseUrl.'/get')->getStatusCode(),
+            static fn (): int => (new Client())->get(self::$baseUrl.'/get')->getStatusCode(),
         );
     }
 
     public function testPassthroughGetRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new Client())->get(self::$baseUrl.'/get')->getStatusCode(),
+            static fn (): int => (new Client())->get(self::$baseUrl.'/get')->getStatusCode(),
         );
     }
 
@@ -33,14 +33,14 @@ final class BasicLifecycleTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'guzzle-basic-post.yml',
-            fn (): int => (new Client())->post(self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+            static fn (): int => (new Client())->post(self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
         );
     }
 
     public function testPassthroughPostRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new Client())->post(self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+            static fn (): int => (new Client())->post(self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
         );
     }
 }

--- a/tests/Integration/Guzzle/HeadersAndStatusTest.php
+++ b/tests/Integration/Guzzle/HeadersAndStatusTest.php
@@ -18,7 +18,7 @@ final class HeadersAndStatusTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'guzzle-headers-custom.yml',
-            fn (): int => (new Client())->get(self::$baseUrl.'/get', ['headers' => ['X-Custom-Header' => 'test-value']])->getStatusCode(),
+            static fn (): int => (new Client())->get(self::$baseUrl.'/get', ['headers' => ['X-Custom-Header' => 'test-value']])->getStatusCode(),
         );
     }
 
@@ -26,7 +26,7 @@ final class HeadersAndStatusTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'guzzle-headers-404.yml',
-            fn (): int => (new Client(['http_errors' => false]))->get(self::$baseUrl.'/status/404')->getStatusCode(),
+            static fn (): int => (new Client(['http_errors' => false]))->get(self::$baseUrl.'/status/404')->getStatusCode(),
             404,
         );
     }
@@ -35,7 +35,7 @@ final class HeadersAndStatusTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'guzzle-headers-500.yml',
-            fn (): int => (new Client(['http_errors' => false]))->get(self::$baseUrl.'/status/500')->getStatusCode(),
+            static fn (): int => (new Client(['http_errors' => false]))->get(self::$baseUrl.'/status/500')->getStatusCode(),
             500,
         );
     }

--- a/tests/Integration/Guzzle/HttpMethodsTest.php
+++ b/tests/Integration/Guzzle/HttpMethodsTest.php
@@ -18,7 +18,7 @@ final class HttpMethodsTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'guzzle-methods-put.yml',
-            fn (): int => (new Client())->put(self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
+            static fn (): int => (new Client())->put(self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
         );
     }
 
@@ -26,7 +26,7 @@ final class HttpMethodsTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'guzzle-methods-delete.yml',
-            fn (): int => (new Client())->delete(self::$baseUrl.'/delete')->getStatusCode(),
+            static fn (): int => (new Client())->delete(self::$baseUrl.'/delete')->getStatusCode(),
         );
     }
 
@@ -34,7 +34,7 @@ final class HttpMethodsTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'guzzle-methods-patch.yml',
-            fn (): int => (new Client())->patch(self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
+            static fn (): int => (new Client())->patch(self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
         );
     }
 }

--- a/tests/Integration/Symfony/Curl/BasicLifecycleTest.php
+++ b/tests/Integration/Symfony/Curl/BasicLifecycleTest.php
@@ -18,14 +18,14 @@ final class BasicLifecycleTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'symfony-curl-basic-get.yml',
-            fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
         );
     }
 
     public function testPassthroughGetRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
         );
     }
 
@@ -33,14 +33,14 @@ final class BasicLifecycleTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'symfony-curl-basic-post.yml',
-            fn (): int => (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
         );
     }
 
     public function testPassthroughPostRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
         );
     }
 }

--- a/tests/Integration/Symfony/Curl/HeadersAndStatusTest.php
+++ b/tests/Integration/Symfony/Curl/HeadersAndStatusTest.php
@@ -17,7 +17,7 @@ final class HeadersAndStatusTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'symfony-curl-headers-custom.yml',
-            fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/get', [
+            static fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/get', [
                 'headers' => ['X-Custom-Header' => 'test-value'],
             ])->getStatusCode(),
         );
@@ -27,7 +27,7 @@ final class HeadersAndStatusTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'symfony-curl-headers-404.yml',
-            fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode(),
             404,
         );
     }
@@ -36,7 +36,7 @@ final class HeadersAndStatusTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'symfony-curl-headers-500.yml',
-            fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode(),
             500,
         );
     }

--- a/tests/Integration/Symfony/Curl/HttpMethodsTest.php
+++ b/tests/Integration/Symfony/Curl/HttpMethodsTest.php
@@ -17,14 +17,14 @@ final class HttpMethodsTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'symfony-curl-methods-put.yml',
-            fn (): int => (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
         );
     }
 
     public function testPassthroughPutRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
         );
     }
 
@@ -32,14 +32,14 @@ final class HttpMethodsTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'symfony-curl-methods-delete.yml',
-            fn (): int => (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
         );
     }
 
     public function testPassthroughDeleteRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
         );
     }
 
@@ -47,14 +47,14 @@ final class HttpMethodsTest extends AbstractHttpServerIntegrationTestCase
     {
         $this->recordAndReplay(
             'symfony-curl-methods-patch.yml',
-            fn (): int => (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
         );
     }
 
     public function testPassthroughPatchRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
+            static fn (): int => (new CurlHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
         );
     }
 }

--- a/tests/Integration/Symfony/Native/AsyncTest.php
+++ b/tests/Integration/Symfony/Native/AsyncTest.php
@@ -9,15 +9,12 @@ use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Concurrent lazy requests for Symfony NativeHttpClient.
- * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
  * Cassette name prefixed 'symfony-native-async-'.
  */
 final class AsyncTest extends AbstractHttpServerIntegrationTestCase
 {
     public function testConcurrentRequestsRecordAndReplay(): void
     {
-        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
-
         $countBefore = $this->server()->getRequestCount();
         $client = new NativeHttpClient();
 

--- a/tests/Integration/Symfony/Native/BasicLifecycleTest.php
+++ b/tests/Integration/Symfony/Native/BasicLifecycleTest.php
@@ -10,11 +10,6 @@ use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 /**
  * Basic GET + POST record/replay/passthrough for Symfony NativeHttpClient via StreamWrapperHook.
  *
- * Record/replay tests are skipped: NativeHttpClient passes HTTP headers as an array in
- * the PHP stream context, but VCR's StreamHelper::createRequestFromStreamContext() calls
- * HttpUtil::parseRawHeader() which requires a string. Remove the markTestSkipped() calls
- * once that is fixed.
- *
  * Passthrough tests (no VCR) verify that NativeHttpClient can reach the test server.
  * Cassette names prefixed 'symfony-native-basic-' to avoid VCRFactory cache collisions.
  */
@@ -22,35 +17,31 @@ final class BasicLifecycleTest extends AbstractHttpServerIntegrationTestCase
 {
     public function testGetRequestRecordAndReplay(): void
     {
-        $this->markTestSkipped('NativeHttpClient: headers as array in stream context; parseRawHeader() requires string. See #329.');
-
         $this->recordAndReplay(
             'symfony-native-basic-get.yml',
-            fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
         );
     }
 
     public function testPassthroughGetRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/get')->getStatusCode(),
         );
     }
 
     public function testPostRequestRecordAndReplay(): void
     {
-        $this->markTestSkipped('NativeHttpClient: headers as array in stream context; parseRawHeader() requires string. See #329.');
-
         $this->recordAndReplay(
             'symfony-native-basic-post.yml',
-            fn (): int => (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
         );
     }
 
     public function testPassthroughPostRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('POST', self::$baseUrl.'/post', ['body' => 'hello=world'])->getStatusCode(),
         );
     }
 }

--- a/tests/Integration/Symfony/Native/ErrorTest.php
+++ b/tests/Integration/Symfony/Native/ErrorTest.php
@@ -10,7 +10,6 @@ use VCR\Tests\Integration\AbstractIntegrationTestCase;
 
 /**
  * Connection-failure behaviour for Symfony NativeHttpClient.
- * The "with VCR" test is skipped — same headers-as-array limitation as #329.
  */
 final class ErrorTest extends AbstractIntegrationTestCase
 {
@@ -31,8 +30,6 @@ final class ErrorTest extends AbstractIntegrationTestCase
 
     public function testConnectExceptionPassesThroughWithVcr(): void
     {
-        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
-
         \VCR\VCR::turnOn();
         \VCR\VCR::insertCassette('symfony-native-error.yml');
 

--- a/tests/Integration/Symfony/Native/HeadersAndStatusTest.php
+++ b/tests/Integration/Symfony/Native/HeadersAndStatusTest.php
@@ -9,18 +9,15 @@ use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Custom headers and non-200 status codes for Symfony NativeHttpClient.
- * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
  * Cassette names prefixed 'symfony-native-headers-'.
  */
 final class HeadersAndStatusTest extends AbstractHttpServerIntegrationTestCase
 {
     public function testCustomRequestHeadersRecordAndReplay(): void
     {
-        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
-
         $this->recordAndReplay(
             'symfony-native-headers-custom.yml',
-            fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/get', [
+            static fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/get', [
                 'headers' => ['X-Custom-Header' => 'test-value'],
             ])->getStatusCode(),
         );
@@ -28,22 +25,18 @@ final class HeadersAndStatusTest extends AbstractHttpServerIntegrationTestCase
 
     public function testStatus404RecordAndReplay(): void
     {
-        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
-
         $this->recordAndReplay(
             'symfony-native-headers-404.yml',
-            fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/404')->getStatusCode(),
             404,
         );
     }
 
     public function testStatus500RecordAndReplay(): void
     {
-        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
-
         $this->recordAndReplay(
             'symfony-native-headers-500.yml',
-            fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('GET', self::$baseUrl.'/status/500')->getStatusCode(),
             500,
         );
     }

--- a/tests/Integration/Symfony/Native/HttpMethodsTest.php
+++ b/tests/Integration/Symfony/Native/HttpMethodsTest.php
@@ -9,59 +9,52 @@ use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * PUT / DELETE / PATCH record/replay/passthrough for Symfony NativeHttpClient.
- * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
  * Cassette names prefixed 'symfony-native-methods-'.
  */
 final class HttpMethodsTest extends AbstractHttpServerIntegrationTestCase
 {
     public function testPutRequestRecordAndReplay(): void
     {
-        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
-
         $this->recordAndReplay(
             'symfony-native-methods-put.yml',
-            fn (): int => (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
         );
     }
 
     public function testPassthroughPutRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('PUT', self::$baseUrl.'/put', ['body' => 'data=1'])->getStatusCode(),
         );
     }
 
     public function testDeleteRequestRecordAndReplay(): void
     {
-        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
-
         $this->recordAndReplay(
             'symfony-native-methods-delete.yml',
-            fn (): int => (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
         );
     }
 
     public function testPassthroughDeleteRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('DELETE', self::$baseUrl.'/delete')->getStatusCode(),
         );
     }
 
     public function testPatchRequestRecordAndReplay(): void
     {
-        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
-
         $this->recordAndReplay(
             'symfony-native-methods-patch.yml',
-            fn (): int => (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
         );
     }
 
     public function testPassthroughPatchRequest(): void
     {
         $this->assertPassthrough(
-            fn (): int => (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
+            static fn (): int => (new NativeHttpClient())->request('PATCH', self::$baseUrl.'/patch', ['body' => 'field=value'])->getStatusCode(),
         );
     }
 }

--- a/tests/Integration/Symfony/Native/SequentialRequestsTest.php
+++ b/tests/Integration/Symfony/Native/SequentialRequestsTest.php
@@ -9,15 +9,12 @@ use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
 
 /**
  * Sequential multi-request record/replay for Symfony NativeHttpClient.
- * Record/replay skipped — NativeHttpClient sends headers as array. See #329.
  * Cassette name prefixed 'symfony-native-seq-'.
  */
 final class SequentialRequestsTest extends AbstractHttpServerIntegrationTestCase
 {
     public function testSequentialRequestsRecordAndReplay(): void
     {
-        $this->markTestSkipped('NativeHttpClient: headers as array in stream context. See #329.');
-
         $countBefore = $this->server()->getRequestCount();
         $client = new NativeHttpClient();
 

--- a/tests/Unit/CodeTransform/StreamWrapperCodeTransformTest.php
+++ b/tests/Unit/CodeTransform/StreamWrapperCodeTransformTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\CodeTransform;
+
+use PHPUnit\Framework\TestCase;
+use VCR\CodeTransform\StreamWrapperCodeTransform;
+
+final class StreamWrapperCodeTransformTest extends TestCase
+{
+    /**
+     * @dataProvider codeSnippetProvider
+     */
+    public function testTransformCode(string $expected, string $code): void
+    {
+        $codeTransform = new class extends StreamWrapperCodeTransform {
+            // A proxy to access the protected transformCode method.
+            public function publicTransformCode(string $code): string
+            {
+                return $this->transformCode($code);
+            }
+        };
+
+        $this->assertEquals($expected, $codeTransform->publicTransformCode($code));
+    }
+
+    /** @return array<string[]> */
+    public static function codeSnippetProvider(): array
+    {
+        return [
+            // Positive: bare function call (case-insensitive)
+            ['\VCR\LibraryHooks\StreamWrapperHook::streamGetMetaData(', 'stream_get_meta_data('],
+            ['\VCR\LibraryHooks\StreamWrapperHook::streamGetMetaData(', 'STREAM_GET_META_DATA('],
+            ['\VCR\LibraryHooks\StreamWrapperHook::streamGetMetaData(', 'Stream_Get_Meta_Data('],
+
+            // Positive: with leading backslash
+            ['\VCR\LibraryHooks\StreamWrapperHook::streamGetMetaData(', '\\stream_get_meta_data('],
+            ['\VCR\LibraryHooks\StreamWrapperHook::streamGetMetaData(', '\\STREAM_GET_META_DATA('],
+
+            // Guard: static call — must NOT be rewritten
+            ['SomeClass::stream_get_meta_data(', 'SomeClass::stream_get_meta_data('],
+
+            // Guard: method call — must NOT be rewritten
+            ['$object->stream_get_meta_data(', '$object->stream_get_meta_data('],
+
+            // Guard: identifier with underscore suffix — must NOT be rewritten
+            ['function some_stream_get_meta_data(', 'function some_stream_get_meta_data('],
+        ];
+    }
+}

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -678,6 +678,20 @@ final class CurlHookTest extends TestCase
         CurlHook::curlGetinfo($nativeHandle);
     }
 
+    public function testCurlSetoptPassesThroughForUnregisteredHandle(): void
+    {
+        // Simulates a curl handle created outside VCR (e.g. by Symfony CurlResponse
+        // error-path code loaded via CurlCodeTransform but called from NativeHttpClient).
+        $nativeHandle = curl_init('http://example.com');
+        \assert(false !== $nativeHandle);
+
+        $this->curlHook->enable($this->getTestCallback());
+
+        // Must not throw even though the handle is not in self::$requests.
+        $result = CurlHook::curlSetopt($nativeHandle, \CURLOPT_TIMEOUT, 5);
+        $this->assertTrue($result);
+    }
+
     protected function getTestCallback(string $statusCode = '200'): \Closure
     {
         $testClass = $this;

--- a/tests/Unit/LibraryHooks/StreamWrapperHookTest.php
+++ b/tests/Unit/LibraryHooks/StreamWrapperHookTest.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace VCR\Tests\Unit\LibraryHooks;
 
 use PHPUnit\Framework\TestCase;
+use VCR\CodeTransform\StreamWrapperCodeTransform;
+use VCR\Configuration;
 use VCR\LibraryHooks\StreamWrapperHook;
 use VCR\Response;
+use VCR\Util\StreamProcessor;
 
 final class StreamWrapperHookTest extends TestCase
 {
     public function testEnable(): void
     {
-        $streamWrapper = new StreamWrapperHook();
+        $streamWrapper = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
 
         $testClass = $this;
         $streamWrapper->enable(static function ($request) use ($testClass): void {
@@ -24,14 +27,14 @@ final class StreamWrapperHookTest extends TestCase
 
     public function testDisable(): void
     {
-        $streamWrapper = new StreamWrapperHook();
+        $streamWrapper = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
         $streamWrapper->disable();
         $this->assertFalse($streamWrapper->isEnabled());
     }
 
     public function testSeek(): void
     {
-        $hook = new StreamWrapperHook();
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
         $hook->enable(static fn ($request) => new Response('200', [], 'A Test'));
         $hook->stream_open('http://example.com', 'r', 0, $openedPath);
 
@@ -55,9 +58,9 @@ final class StreamWrapperHookTest extends TestCase
 
     public function testStreamGetMetaDataReplacesWrapperDataWithResponseHeaderLines(): void
     {
-        $hook = new StreamWrapperHook();
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
         $hook->enable(static fn ($request) => new Response(
-            ['code' => 200, 'message' => 'OK', 'http_version' => '1.1'],
+            ['code' => '200', 'message' => 'OK', 'http_version' => '1.1'],
             ['Content-Type' => 'text/plain', 'X-Custom' => 'value'],
             'body'
         ));
@@ -91,9 +94,9 @@ final class StreamWrapperHookTest extends TestCase
 
     public function testStreamGetMetaDataUsesDefaultHttpVersionWhenNoneSet(): void
     {
-        $hook = new StreamWrapperHook();
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
         $hook->enable(static fn ($request) => new Response(
-            ['code' => 204, 'message' => 'No Content'],
+            ['code' => '204', 'message' => 'No Content'],
             [],
             ''
         ));

--- a/tests/Unit/LibraryHooks/StreamWrapperHookTest.php
+++ b/tests/Unit/LibraryHooks/StreamWrapperHookTest.php
@@ -19,6 +19,7 @@ final class StreamWrapperHookTest extends TestCase
             $testClass->assertInstanceOf('\VCR\Request', $request);
         });
         $this->assertTrue($streamWrapper->isEnabled());
+        $streamWrapper->disable();
     }
 
     public function testDisable(): void
@@ -48,5 +49,64 @@ final class StreamWrapperHookTest extends TestCase
 
         // invalid whence
         $this->assertFalse($hook->stream_seek(0, -1));
+
+        $hook->disable();
+    }
+
+    public function testStreamGetMetaDataReplacesWrapperDataWithResponseHeaderLines(): void
+    {
+        $hook = new StreamWrapperHook();
+        $hook->enable(static fn ($request) => new Response(
+            ['code' => 200, 'message' => 'OK', 'http_version' => '1.1'],
+            ['Content-Type' => 'text/plain', 'X-Custom' => 'value'],
+            'body'
+        ));
+
+        $resource = fopen('http://example.com', 'r');
+        $this->assertIsResource($resource);
+
+        $meta = StreamWrapperHook::streamGetMetaData($resource);
+
+        $this->assertIsArray($meta['wrapper_data']);
+        $this->assertSame('HTTP/1.1 200 OK', $meta['wrapper_data'][0]);
+        $this->assertContains('Content-Type: text/plain', $meta['wrapper_data']);
+        $this->assertContains('X-Custom: value', $meta['wrapper_data']);
+
+        fclose($resource);
+        $hook->disable();
+    }
+
+    public function testStreamGetMetaDataPassesThroughForNonVcrStream(): void
+    {
+        $resource = fopen('php://memory', 'r');
+        $this->assertIsResource($resource);
+
+        $expected = stream_get_meta_data($resource);
+        $actual = StreamWrapperHook::streamGetMetaData($resource);
+
+        $this->assertEquals($expected, $actual);
+
+        fclose($resource);
+    }
+
+    public function testStreamGetMetaDataUsesDefaultHttpVersionWhenNoneSet(): void
+    {
+        $hook = new StreamWrapperHook();
+        $hook->enable(static fn ($request) => new Response(
+            ['code' => 204, 'message' => 'No Content'],
+            [],
+            ''
+        ));
+
+        $resource = fopen('http://example.com', 'r');
+        $this->assertIsResource($resource);
+
+        $meta = StreamWrapperHook::streamGetMetaData($resource);
+
+        $this->assertIsArray($meta['wrapper_data']);
+        $this->assertSame('HTTP/1.1 204 No Content', $meta['wrapper_data'][0]);
+
+        fclose($resource);
+        $hook->disable();
     }
 }


### PR DESCRIPTION
### Context

Closes #444.

Symfony `NativeHttpClient` uses PHP's native stream wrappers for HTTP. When VCR intercepts requests via `StreamWrapperHook`, `stream_get_meta_data($resource)['wrapper_data']` returns the `StreamWrapperHook` instance instead of the array of HTTP response header strings that `NativeResponse::addResponseHeaders()` expects, causing a `TypeError`.

PHP provides no userland mechanism to override what `stream_get_meta_data()` returns for a user-space stream wrapper, so the fix intercepts the call site in loaded PHP source — the same approach used by `CurlCodeTransform` for `curl_*` functions.

### What has been done

- Added `StreamWrapperCodeTransform` (`php_user_filter`) that rewrites `stream_get_meta_data(` calls in loaded PHP source to `\VCR\LibraryHooks\StreamWrapperHook::streamGetMetaData(`
- Added `StreamWrapperHook::streamGetMetaData()` static interception target: calls real `stream_get_meta_data()`, then replaces `wrapper_data` with pre-built HTTP response header lines when the resource was opened through VCR's wrapper
- Wired `StreamWrapperCodeTransform` + `StreamProcessor` into `StreamWrapperHook` via constructor injection; `VCRFactory` constructs the hook with both dependencies
- Added `stream_set_option()` stub — required stream wrapper protocol method, absence triggers a PHP notice
- Added `src/VCR/Util/StreamProcessor` to `Configuration::$blackList` to prevent VCR from transforming its own file stream wrapper code
- Guarded `StreamWrapperHook::disable()` against calling `stream_wrapper_restore()` without a prior `enable()`
- Guarded `CurlHook::curlSetopt()` against unregistered curl handles — `CurlResponse` is called from `NativeHttpClient`'s error path with handles that were never registered via `curlInit()`
- Fixed `HttpUtil::parseStatus()` to use `str_starts_with()` pre-check, avoiding a PHP 8.4 `E_DEPRECATED` in `beberlei/assert <3.3.4` that Symfony `NativeResponse`'s error handler converts to a `TransportException`
- Enabled all six `tests/Integration/Symfony/Native/` integration tests (previously skipped)

### How to test

```bash
# workspace80: static analysis + style
docker compose run --rm workspace80 composer update
docker compose run --rm workspace80 composer phpstan
docker compose run --rm workspace80 composer cs-fix
docker compose run --rm workspace80 composer cs
docker compose run --rm workspace80 composer ec

# workspace80: lowest + highest deps
docker compose run --rm workspace80 composer update --prefer-lowest
docker compose run --rm workspace80 composer test
docker compose run --rm workspace80 composer update
docker compose run --rm workspace80 composer test

# workspace84: lowest + highest deps
docker compose run --rm workspace84 composer update --prefer-lowest
docker compose run --rm workspace84 composer test
docker compose run --rm workspace84 composer update
docker compose run --rm workspace84 composer test
```

Acceptance criterion: all six tests in `tests/Integration/Symfony/Native/` pass green in both workspaces.

### Todo

- [ ]

### Notes

-