### PR TITLE
docs(github): modernise PR template to Symfony-style Q/A table

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,24 @@
-### Context
+| Q                | A
+| ---------------- | ---
+| Type             | Bug / Feature / Enhancement / Deprecation / BC Break / Security / Documentation / CI / Dependencies
+| Fixes            | Fix #... <!-- one line per referenced issue; omit if no related issue exists -->
+| BC break?        | yes / no <!-- yes is only mergeable into a major release -->
+| Deprecation?     | yes / no <!-- if yes, document the replacement and removal target -->
+| New dependency?  | yes / no <!-- if yes, justify and link to the discussion -->
+| License          | MIT
 
+<!--
+🛠️ Replace this comment with a short explanation of the change:
+- What it does and why it is needed
+- Example (PHP snippet, cassette excerpt) when behaviour is user-visible
+- Before/after for behavioural changes
 
-### What has been done
-
--
--
-
-### How to test
-
--
--
-
-### Todo
-
-- [ ]
-- [ ]
-
-### Notes
-
--
--
-
-
+Contributor guidelines:
+- ✅ All checks green: PHPUnit + PHPStan + PHP-CS-Fixer + editorconfig
+- 🐳 Verify locally on the Docker matrix — list the workspaces you actually ran
+  (e.g. workspace80 lowest/highest, workspace84 lowest/highest)
+- 📝 Conventional Commits (feat/fix/chore/refactor/docs/...), one logical change per commit, every commit green
+- 🔒 No breaking changes outside of a major release
+- 🏷️ Carry over the milestone and labels from the linked issue(s). Type labels:
+  Bug, Feature, Enhancement, Deprecation, BC Break, Security, Documentation, CI, Dependencies
+-->


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Documentation / CI
| Fixes            | <!-- no related issue -->
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

Replace the generic section-based template (Context / What has been done / How to test / Todo / Notes) with a structured Q/A header table and an HTML contributor-guidelines comment, modelled after the `symfony/symfony` PR template.

**What changes:**

- Q/A header table: Type (maps 1:1 to the label catalogue), Fixes, BC break?, Deprecation?, New dependency?, License — makes metadata explicit on every PR without the reviewer having to ask
- HTML comment block (invisible in rendered body): short description prompt + contributor guidelines (checks-green, Docker matrix, Conventional Commits, BC-break policy, milestone/label carry-over with full type-label list inline)
- Removed: generic section scaffolding (Context, What has been done, How to test, Todo, Notes) and unverified Todo checkboxes

**Test plan:**

- Opened this draft PR in the GitHub UI — Q/A table renders correctly, HTML comment is invisible in the preview
- No library code changed; no PHPUnit/PHPStan/CS-Fixer run required