### PR TITLE
fix: probe file existence against the native filesysteme in strem_open

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -66,7 +66,7 @@ class StreamProcessor
         if (!$this->isIntercepting) {
             ini_set('opcache.enable', '0');
             stream_wrapper_unregister(self::PROTOCOL);
-            $this->isIntercepting = stream_wrapper_register(self::PROTOCOL, __CLASS__);
+            $this->isIntercepting = stream_wrapper_register(self::PROTOCOL, static::class);
         }
     }
 
@@ -137,12 +137,19 @@ class StreamProcessor
 
     public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
     {
+        // Delegate to the native file wrapper for the rest of this call. This must happen
+        // *before* the existence check below: otherwise file_exists() is routed back through
+        // this wrapper's own url_stat(), and any fragility there (re-entrancy, a strict error
+        // handler, paths containing "..") can make an existing file look missing and abort an
+        // include() with "Failed opening ... for inclusion" (see GitHub issue #424).
+        $this->restore();
+
         // file_exists catches paths like /dev/urandom that are missed by is_file.
         if ('r' === substr($mode, 0, 1) && !file_exists($path)) {
+            $this->intercept();
+
             return false;
         }
-
-        $this->restore();
 
         if (isset($this->context)) {
             $this->resource = fopen($path, $mode, (bool) ($options & \STREAM_USE_PATH), $this->context);

--- a/tests/Unit/Util/StreamProcessorTest.php
+++ b/tests/Unit/Util/StreamProcessorTest.php
@@ -8,8 +8,44 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use VCR\Util\StreamProcessor;
 
+/**
+ * Simulates an environment in which routing the existence check back through the
+ * VCR wrapper's own url_stat() makes an existing file look missing (issue #424).
+ */
+final class BrokenUrlStatStreamProcessor extends StreamProcessor
+{
+    public function url_stat(string $path, int $flags)
+    {
+        return false;
+    }
+}
+
 final class StreamProcessorTest extends TestCase
 {
+    /**
+     * When this wrapper is intercepting, including an existing file must still
+     * succeed even if this wrapper's own url_stat() would report it as missing,
+     * because the existence check has to run against the native filesystem.
+     *
+     * @see https://github.com/php-vcr/php-vcr/issues/424
+     */
+    public function testStreamOpenChecksExistenceAgainstNativeFilesystem(): void
+    {
+        $processor = new BrokenUrlStatStreamProcessor();
+        $processor->intercept();
+
+        try {
+            // A path containing ".." just like Composer's classmap autoloader produces.
+            $path = __DIR__.'/../../fixtures/../fixtures/streamprocessor_include_target.php';
+            $result = include $path;
+        } finally {
+            $processor->restore();
+        }
+
+        $this->assertNotFalse($result, 'Including an existing file must not fail while VCR is intercepting.');
+        $this->assertTrue(class_exists(\VCR\Tests\Fixtures\StreamProcessorIncludeTarget::class, false));
+    }
+
     /**
      * test flock with file_put_contents.
      */

--- a/tests/Unit/Util/StreamProcessorTest.php
+++ b/tests/Unit/Util/StreamProcessorTest.php
@@ -20,6 +20,18 @@ final class BrokenUrlStatStreamProcessor extends StreamProcessor
     }
 }
 
+/**
+ * Exposes the protected interception state so tests can assert the wrapper is
+ * never left restored after an early return in stream_open().
+ */
+final class InterceptStateStreamProcessor extends StreamProcessor
+{
+    public function isIntercepting(): bool
+    {
+        return $this->isIntercepting;
+    }
+}
+
 final class StreamProcessorTest extends TestCase
 {
     /**
@@ -44,6 +56,26 @@ final class StreamProcessorTest extends TestCase
 
         $this->assertNotFalse($result, 'Including an existing file must not fail while VCR is intercepting.');
         $this->assertTrue(class_exists(\VCR\Tests\Fixtures\StreamProcessorIncludeTarget::class, false));
+    }
+
+    /**
+     * A missing file in read mode returns false, but the wrapper must re-intercept
+     * before returning so it is never left in an inconsistent (restored) state.
+     *
+     * @see https://github.com/php-vcr/php-vcr/issues/424
+     */
+    public function testStreamOpenStaysInterceptingAfterMissingRead(): void
+    {
+        $processor = new InterceptStateStreamProcessor();
+        $processor->intercept();
+
+        try {
+            $result = $processor->stream_open('tests/fixtures/unknown', 'r', StreamProcessor::STREAM_OPEN_FOR_INCLUDE, $fullPath);
+            $this->assertFalse($result);
+            $this->assertTrue($processor->isIntercepting(), 'The wrapper must stay intercepting after a missing read.');
+        } finally {
+            $processor->restore();
+        }
     }
 
     /**

--- a/tests/fixtures/streamprocessor_include_target.php
+++ b/tests/fixtures/streamprocessor_include_target.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Fixtures;
+
+class StreamProcessorIncludeTarget
+{
+    public static function marker(): string
+    {
+        return 'included';
+    }
+}


### PR DESCRIPTION
 | Q                | A
  | ---------------- | ---
  | Type             | Bug
  | Fixes            | Fix #424
  | BC break?        | no
  | Deprecation?     | no
  | New dependency?  | no
  | License          | MIT

  ## What it does and why

  `StreamProcessor::stream_open()` reorders the restoration of the native wrapper and
  the file-existence check to fix `include()` failures of the form
  `Failed opening ... for inclusion` (issue #424).

  Previously, `file_exists($path)` was evaluated **while** the VCR wrapper was still
  active, so the existence check was routed back through the wrapper's own `url_stat()`.
  Any fragility there (re-entrancy, a strict error handler, paths containing `..` like
  those produced by Composer's classmap autoloader) could make an existing file look
  missing and abort the `include()`.

  Now `$this->restore()` is called **before** the existence check, so `file_exists()`
  queries the native filesystem. If the file really is missing in read mode, we
  re-intercept (`$this->intercept()`) before returning, so the wrapper is never left in
  an inconsistent state.

  Along the way, `stream_wrapper_register()` now uses `static::class` instead of
  `__CLASS__`, so that subclasses of `StreamProcessor` are registered correctly
  (required by the regression test).

  ### Before / after

  - **Before:** an `include` of an existing file through a path containing `..` could
    fail while VCR was intercepting.
  - **After:** the `include` succeeds, because the existence check runs against the
    native filesystem.

  ### Test

  `StreamProcessorTest::testStreamOpenChecksExistenceAgainstNativeFilesystem` adds a
  `BrokenUrlStatStreamProcessor` whose `url_stat()` always returns `false`: it
  reproduces the #424 scenario and guarantees that including an existing file succeeds
  even when `url_stat()` would report it as missing.
