### PR TITLE
feat: add MODE_ALL ("all") record mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,29 @@ To enable only specific hooks (e.g. when you know your code only uses curl):
 
 Available hook names: `stream_wrapper`, `curl`, `soap`.
 
+## Record modes
+
+The record mode controls how VCR behaves when a cassette is inserted.
+
+| Mode | Constant | Behaviour |
+|---|---|---|
+| `new_episodes` | `VCR::MODE_NEW_EPISODES` | **Default.** Plays back recorded interactions; performs real HTTP for any request that has no recording and records the response. |
+| `once` | `VCR::MODE_ONCE` | Plays back recorded interactions. Allows new requests only when the cassette is new (first run). Throws on a miss after that. |
+| `none` | `VCR::MODE_NONE` | Read-only. Plays back recorded interactions only. Throws on any request that has no recording. |
+| `all` | `VCR::MODE_ALL` | **Re-record mode.** Never plays back. Always performs the real HTTP request and records the response fresh. The cassette is purged on insert so every run starts clean. |
+
+```php
+// Re-record an existing cassette from scratch
+\VCR\VCR::configure()->setMode(\VCR\VCR::MODE_ALL);
+\VCR\VCR::turnOn();
+\VCR\VCR::insertCassette('my_cassette'); // existing recordings are purged
+file_get_contents('http://example.com');  // hits network, recorded fresh
+\VCR\VCR::eject();
+\VCR\VCR::turnOff();
+```
+
+> **Note:** A run under `MODE_ALL` that performs no HTTP request leaves an empty cassette — this is inherent to the fresh re-record semantics.
+
 ## Installation
 
 Simply run the following command:

--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -138,6 +138,7 @@ class Configuration
         VCR::MODE_NEW_EPISODES,
         VCR::MODE_ONCE,
         VCR::MODE_NONE,
+        VCR::MODE_ALL,
     ];
 
     /**

--- a/src/VCR/Storage/AbstractStorage.php
+++ b/src/VCR/Storage/AbstractStorage.php
@@ -12,7 +12,7 @@ use VCR\Util\Assertion;
  * A Storage can be iterated using standard loops.
  * New recordings can be stored.
  */
-abstract class AbstractStorage implements Storage
+abstract class AbstractStorage implements PurgeableStorage
 {
     /**
      * @var resource
@@ -20,6 +20,8 @@ abstract class AbstractStorage implements Storage
     protected $handle;
 
     protected string $filePath;
+
+    protected string $defaultContent;
 
     /**
      * @var array<string,mixed>|null current parsed record
@@ -40,6 +42,8 @@ abstract class AbstractStorage implements Storage
      */
     public function __construct(string $cassettePath, string $cassetteName, string $defaultContent = '[]')
     {
+        $this->defaultContent = $defaultContent;
+
         Assertion::directory($cassettePath, "Cassette path '{$cassettePath}' is not existing or not a directory");
 
         $this->filePath = rtrim($cassettePath, \DIRECTORY_SEPARATOR).\DIRECTORY_SEPARATOR.$cassetteName;
@@ -81,6 +85,21 @@ abstract class AbstractStorage implements Storage
     public function isNew(): bool
     {
         return $this->isNew;
+    }
+
+    public function purge(): void
+    {
+        ftruncate($this->handle, 0);
+        rewind($this->handle);
+        if ('' !== $this->defaultContent) {
+            fwrite($this->handle, $this->defaultContent);
+            rewind($this->handle);
+        }
+        $this->position = 0;
+        $this->current = null;
+        $this->isEOF = false;
+        $this->isValidPosition = true;
+        $this->isNew = true;
     }
 
     public function __destruct()

--- a/src/VCR/Storage/Blackhole.php
+++ b/src/VCR/Storage/Blackhole.php
@@ -7,9 +7,13 @@ namespace VCR\Storage;
 /**
  * Backhole storage, the storage that looses everything.
  */
-class Blackhole implements Storage
+class Blackhole implements PurgeableStorage
 {
     public function storeRecording(array $recording): void
+    {
+    }
+
+    public function purge(): void
     {
     }
 

--- a/src/VCR/Storage/PurgeableStorage.php
+++ b/src/VCR/Storage/PurgeableStorage.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+/**
+ * Storage that can be purged, i.e. reset to its empty/default state.
+ *
+ * Under record mode "all" the cassette is purged on insert so every run
+ * starts from a clean recording.
+ */
+interface PurgeableStorage extends Storage
+{
+    /**
+     * Purge all stored recordings and reset the storage to its empty state.
+     */
+    public function purge(): void;
+}

--- a/src/VCR/VCR.php
+++ b/src/VCR/VCR.php
@@ -35,6 +35,12 @@ class VCR
     public const MODE_NONE = 'none';
 
     /**
+     * Never play back recorded interactions; always perform the real request and record fresh.
+     * Purges the cassette on insert so every run captures a clean recording.
+     */
+    public const MODE_ALL = 'all';
+
+    /**
      * @param mixed[] $parameters
      */
     public static function __callStatic(string $method, array $parameters): mixed

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -125,9 +125,7 @@ class Videorecorder
 
         if (VCR::MODE_ALL === $this->config->getMode()) {
             if (!$storage instanceof PurgeableStorage) {
-                throw new \LogicException(
-                    \sprintf('Storage "%s" does not support MODE_ALL: implement PurgeableStorage to enable purge on cassette insert.', \get_class($storage))
-                );
+                throw new \LogicException(\sprintf('Storage "%s" does not support MODE_ALL: implement PurgeableStorage to enable purge on cassette insert.', $storage::class));
             }
             $storage->purge();
         }

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -12,6 +12,8 @@ use VCR\Event\BeforeHttpRequestEvent;
 use VCR\Event\BeforePlaybackEvent;
 use VCR\Event\BeforeRecordEvent;
 use VCR\Event\Event;
+use VCR\Storage\PurgeableStorage;
+use VCR\Storage\Storage;
 use VCR\Util\Assertion;
 use VCR\Util\HttpClient;
 
@@ -119,7 +121,16 @@ class Videorecorder
             $this->eject();
         }
 
-        $storage = $this->factory->get('Storage', [$cassetteName]);
+        $storage = $this->createStorage($cassetteName);
+
+        if (VCR::MODE_ALL === $this->config->getMode()) {
+            if (!$storage instanceof PurgeableStorage) {
+                throw new \LogicException(
+                    \sprintf('Storage "%s" does not support MODE_ALL: implement PurgeableStorage to enable purge on cassette insert.', \get_class($storage))
+                );
+            }
+            $storage->purge();
+        }
 
         $this->cassette = new Cassette($cassetteName, $this->config, $storage);
         $this->enableLibraryHooks();
@@ -151,20 +162,23 @@ class Videorecorder
             throw new \BadMethodCallException('Invalid http request. No cassette inserted. Please make sure to insert a cassette in your unit test using '."VCR::insertCassette('name');");
         }
 
-        $this->dispatch(new BeforePlaybackEvent($request, $this->cassette), VCREvents::VCR_BEFORE_PLAYBACK);
-
         // Add an index to the request to allow recording identical requests and play them back in the same sequence.
         $index = $this->iterateIndex($request);
-        $response = $this->cassette->playback($request, $index);
 
-        // Playback succeeded and the recorded response can be returned.
-        if (!empty($response)) {
-            $this->dispatch(
-                new AfterPlaybackEvent($request, $response, $this->cassette),
-                VCREvents::VCR_AFTER_PLAYBACK
-            );
+        if (VCR::MODE_ALL !== $this->config->getMode()) {
+            $this->dispatch(new BeforePlaybackEvent($request, $this->cassette), VCREvents::VCR_BEFORE_PLAYBACK);
 
-            return $response;
+            $response = $this->cassette->playback($request, $index);
+
+            // Playback succeeded and the recorded response can be returned.
+            if (!empty($response)) {
+                $this->dispatch(
+                    new AfterPlaybackEvent($request, $response, $this->cassette),
+                    VCREvents::VCR_AFTER_PLAYBACK
+                );
+
+                return $response;
+            }
         }
 
         if (VCR::MODE_NONE === $this->config->getMode()
@@ -188,6 +202,14 @@ class Videorecorder
         }
 
         return $response;
+    }
+
+    /**
+     * @return Storage<array>
+     */
+    protected function createStorage(string $cassetteName): Storage
+    {
+        return $this->factory->get('Storage', [$cassetteName]);
     }
 
     /**

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -6,6 +6,7 @@ namespace VCR\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use VCR\Configuration;
+use VCR\VCR;
 use VCR\VCRException;
 
 final class ConfigurationTest extends TestCase
@@ -159,5 +160,11 @@ final class ConfigurationTest extends TestCase
         $this->expectException(VCRException::class);
         $this->expectExceptionMessage("Mode 'invalid' does not exist.");
         $this->config->setMode('invalid');
+    }
+
+    public function testSetModeAllIsAccepted(): void
+    {
+        $this->config->setMode(VCR::MODE_ALL);
+        $this->assertSame(VCR::MODE_ALL, $this->config->getMode());
     }
 }

--- a/tests/Unit/Storage/BlackholeTest.php
+++ b/tests/Unit/Storage/BlackholeTest.php
@@ -6,6 +6,7 @@ namespace VCR\Tests\Unit\Storage;
 
 use PHPUnit\Framework\TestCase;
 use VCR\Storage\Blackhole;
+use VCR\Storage\PurgeableStorage;
 
 final class BlackholeTest extends TestCase
 {
@@ -69,5 +70,18 @@ final class BlackholeTest extends TestCase
     public function testIsNewIsAlwaysTrue(): void
     {
         $this->assertTrue($this->storage->isNew());
+    }
+
+    public function testImplementsPurgeableStorage(): void
+    {
+        $this->assertInstanceOf(PurgeableStorage::class, $this->storage);
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testPurgeIsNoOp(): void
+    {
+        $this->storage->purge();
     }
 }

--- a/tests/Unit/Storage/JsonTest.php
+++ b/tests/Unit/Storage/JsonTest.php
@@ -7,6 +7,7 @@ namespace VCR\Tests\Unit\Storage;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use VCR\Storage\Json;
+use VCR\Storage\PurgeableStorage;
 
 final class JsonTest extends TestCase
 {
@@ -123,6 +124,47 @@ final class JsonTest extends TestCase
         $jsonObject->storeRecording($stored);
 
         $this->assertJson((string) file_get_contents($filePath));
+    }
+
+    public function testImplementsPurgeableStorage(): void
+    {
+        $this->assertInstanceOf(PurgeableStorage::class, $this->jsonObject);
+    }
+
+    public function testPurgeEmptiesStorage(): void
+    {
+        $this->jsonObject->storeRecording(['request' => 'r', 'response' => 's']);
+
+        $before = [];
+        foreach ($this->jsonObject as $recording) {
+            $before[] = $recording;
+        }
+        $this->assertCount(1, $before, 'Storage should contain the recording before purge.');
+
+        $this->jsonObject->purge();
+
+        $actual = [];
+        foreach ($this->jsonObject as $recording) {
+            $actual[] = $recording;
+        }
+        $this->assertEmpty($actual);
+        $this->assertTrue($this->jsonObject->isNew());
+    }
+
+    public function testPurgeAllowsSubsequentRecording(): void
+    {
+        $this->jsonObject->storeRecording(['request' => 'old', 'response' => 'old']);
+        $this->jsonObject->purge();
+
+        $expected = ['request' => 'new', 'response' => 'new'];
+        $this->jsonObject->storeRecording($expected);
+
+        $actual = [];
+        foreach ($this->jsonObject as $recording) {
+            $actual[] = $recording;
+        }
+        $this->assertCount(1, $actual);
+        $this->assertEquals($expected, $actual[0]);
     }
 
     /** @param array<mixed> $expected */

--- a/tests/Unit/Storage/YamlTest.php
+++ b/tests/Unit/Storage/YamlTest.php
@@ -6,6 +6,7 @@ namespace VCR\Tests\Unit\Storage;
 
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
+use VCR\Storage\PurgeableStorage;
 use VCR\Storage\Yaml;
 
 final class YamlTest extends TestCase
@@ -123,6 +124,47 @@ final class YamlTest extends TestCase
         $this->assertCount(2, $actual, 'More that two recordings stores.');
         $this->assertEquals($expected, $actual[0], 'Storing and reading first recording failed.');
         $this->assertEquals($expected, $actual[1], 'Storing and reading second recording failed.');
+    }
+
+    public function testImplementsPurgeableStorage(): void
+    {
+        $this->assertInstanceOf(PurgeableStorage::class, $this->yamlObject);
+    }
+
+    public function testPurgeEmptiesStorage(): void
+    {
+        $this->yamlObject->storeRecording(['request' => 'r', 'response' => 's']);
+
+        $before = [];
+        foreach ($this->yamlObject as $recording) {
+            $before[] = $recording;
+        }
+        $this->assertCount(1, $before, 'Storage should contain the recording before purge.');
+
+        $this->yamlObject->purge();
+
+        $actual = [];
+        foreach ($this->yamlObject as $recording) {
+            $actual[] = $recording;
+        }
+        $this->assertEmpty($actual);
+        $this->assertTrue($this->yamlObject->isNew());
+    }
+
+    public function testPurgeAllowsSubsequentRecording(): void
+    {
+        $this->yamlObject->storeRecording(['request' => 'old', 'response' => 'old']);
+        $this->yamlObject->purge();
+
+        $expected = ['request' => 'new', 'response' => 'new'];
+        $this->yamlObject->storeRecording($expected);
+
+        $actual = [];
+        foreach ($this->yamlObject as $recording) {
+            $actual[] = $recording;
+        }
+        $this->assertCount(1, $actual);
+        $this->assertEquals($expected, $actual[0]);
     }
 
     /** @param array<mixed> $expected */

--- a/tests/Unit/VCRTest.php
+++ b/tests/Unit/VCRTest.php
@@ -21,6 +21,11 @@ final class VCRTest extends TestCase
         VCR::configure()->setCassettePath('tests/fixtures');
     }
 
+    public function testModeAllConstantIsDefined(): void
+    {
+        $this->assertSame('all', VCR::MODE_ALL);
+    }
+
     public function testUseStaticCallsNotInitialized(): void
     {
         VCR::configure()->enableLibraryHooks(['stream_wrapper']);

--- a/tests/Unit/VideorecorderTest.php
+++ b/tests/Unit/VideorecorderTest.php
@@ -10,6 +10,7 @@ use VCR\Cassette;
 use VCR\Configuration;
 use VCR\Request;
 use VCR\Response;
+use VCR\Storage\Storage;
 use VCR\Util\HttpClient;
 use VCR\VCR;
 use VCR\VCRFactory;
@@ -140,6 +141,101 @@ final class VideorecorderTest extends TestCase
         $videorecorder->setCassette($this->getCassetteMock($request, $response, 'once', false));
 
         $videorecorder->handleRequest($request);
+    }
+
+    public function testInsertCassettePurgesStorageWhenModeIsAll(): void
+    {
+        vfsStream::setup('testDir');
+        $cassetteName = 'purge_test';
+        vfsStream::create([$cassetteName => "- request:\n    url: http://example.com\n  response:\n    status: 200\n"]);
+
+        $factory = VCRFactory::getInstance();
+        $configuration = $factory->get('VCR\Configuration');
+        $configuration->setCassettePath(vfsStream::url('testDir'));
+        $configuration->enableLibraryHooks([]);
+        $configuration->setMode(VCR::MODE_ALL);
+
+        $videorecorder = new Videorecorder($configuration, new HttpClient(), $factory);
+        $videorecorder->turnOn();
+        $videorecorder->insertCassette($cassetteName);
+
+        $content = (string) file_get_contents(vfsStream::url('testDir').'/'.$cassetteName);
+        $this->assertSame('', $content);
+
+        $videorecorder->turnOff();
+    }
+
+    public function testInsertCassetteThrowsExceptionWhenStorageIsNotPurgeableInModeAll(): void
+    {
+        $nonPurgeableStorage = new class implements Storage {
+            public function storeRecording(array $recording): void {}
+
+            public function isNew(): bool { return true; }
+
+            public function current(): ?array { return null; }
+
+            public function key(): int { return 0; }
+
+            public function next(): void {}
+
+            public function rewind(): void {}
+
+            public function valid(): bool { return false; }
+        };
+
+        $configuration = new Configuration();
+        $configuration->enableLibraryHooks([]);
+        $configuration->setMode(VCR::MODE_ALL);
+
+        $videorecorder = new class($configuration, new HttpClient(), VCRFactory::getInstance(), $nonPurgeableStorage) extends Videorecorder {
+            private Storage $nonPurgeableStorage;
+
+            public function __construct(Configuration $config, HttpClient $client, VCRFactory $factory, Storage $storage)
+            {
+                parent::__construct($config, $client, $factory);
+                $this->nonPurgeableStorage = $storage;
+            }
+
+            protected function createStorage(string $cassetteName): Storage
+            {
+                return $this->nonPurgeableStorage;
+            }
+        };
+
+        $videorecorder->turnOn();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/does not support MODE_ALL/');
+        $videorecorder->insertCassette('cassette');
+    }
+
+    public function testHandleRequestSkipsPlaybackAndAlwaysRecordsWhenModeIsAll(): void
+    {
+        $request = new Request('GET', 'http://example.com', ['User-Agent' => 'Unit-Test']);
+        $response = new Response('200', [], 'example response');
+        $client = $this->getClientMock($request, $response);
+        $configuration = new Configuration();
+        $configuration->enableLibraryHooks([]);
+        $configuration->setMode(VCR::MODE_ALL);
+
+        $cassette = $this->getMockBuilder(Cassette::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['record', 'playback', 'isNew', 'getName'])
+            ->getMock();
+        $cassette->expects($this->never())->method('playback');
+        $cassette->expects($this->once())->method('record')->with($request, $response);
+        $cassette->method('getName')->willReturn('foobar');
+
+        $videorecorder = new class($configuration, $client, VCRFactory::getInstance()) extends Videorecorder {
+            public function setCassette(Cassette $cassette): void
+            {
+                $this->cassette = $cassette;
+            }
+        };
+
+        $videorecorder->setCassette($cassette);
+
+        $this->assertEquals($response, $videorecorder->handleRequest($request));
     }
 
     protected function getClientMock(Request $request, Response $response): HttpClient

--- a/tests/Unit/VideorecorderTest.php
+++ b/tests/Unit/VideorecorderTest.php
@@ -163,6 +163,7 @@ final class VideorecorderTest extends TestCase
         $this->assertSame('', $content);
 
         $videorecorder->turnOff();
+        $configuration->setMode(VCR::MODE_NEW_EPISODES);
     }
 
     public function testInsertCassetteThrowsExceptionWhenStorageIsNotPurgeableInModeAll(): void

--- a/tests/Unit/VideorecorderTest.php
+++ b/tests/Unit/VideorecorderTest.php
@@ -168,19 +168,38 @@ final class VideorecorderTest extends TestCase
     public function testInsertCassetteThrowsExceptionWhenStorageIsNotPurgeableInModeAll(): void
     {
         $nonPurgeableStorage = new class implements Storage {
-            public function storeRecording(array $recording): void {}
+            public function storeRecording(array $recording): void
+            {
+            }
 
-            public function isNew(): bool { return true; }
+            public function isNew(): bool
+            {
+                return true;
+            }
 
-            public function current(): ?array { return null; }
+            /** @return array<string, mixed>|null */
+            public function current(): ?array
+            {
+                return null;
+            }
 
-            public function key(): int { return 0; }
+            public function key(): int
+            {
+                return 0;
+            }
 
-            public function next(): void {}
+            public function next(): void
+            {
+            }
 
-            public function rewind(): void {}
+            public function rewind(): void
+            {
+            }
 
-            public function valid(): bool { return false; }
+            public function valid(): bool
+            {
+                return false;
+            }
         };
 
         $configuration = new Configuration();


### PR DESCRIPTION
## Summary

Closes #462

- Adds `VCR::MODE_ALL` (`"all"`) record mode: purges the cassette on insert,
  skips playback on every request, and always performs a real HTTP call so
  recordings are refreshed from scratch each run.
- Introduces `PurgeableStorage` interface (`purge(): void`) and implements it
  on `AbstractStorage` (Yaml, Json) and `Blackhole` (no-op).
- Guards `insertCassette()` with a `LogicException` when a custom storage does
  not implement `PurgeableStorage` and `MODE_ALL` is active.
- Documents all four record modes in `README.md`.

## Test plan

Verified locally across PHP 8.0 and 8.4:

**workspace80 — static analysis + style**
- `composer phpstan`: 0 errors
- `composer cs-fix` + `composer cs`: 0 files to fix

**workspace80 — tests (lowest + highest deps)**
- `composer update --prefer-lowest && composer test`: 411/411 ✓
- `composer update && composer test`: 411/411 ✓

**workspace84 — tests (lowest + highest deps)**
- `composer update --prefer-lowest && composer test`: 411/411 ✓
- `composer update && composer test`: 411/411 ✓