### PR TITLE
fix(tests): remove leftover file_put_contents fixture in testSetStreamOptions

### DIFF
--- a/tests/Unit/Util/StreamProcessorTest.php
+++ b/tests/Unit/Util/StreamProcessorTest.php
@@ -109,6 +109,7 @@ final class StreamProcessorTest extends TestCase
         self::assertSame(0, stream_set_read_buffer($handle, 0));
 
         fclose($handle);
+        unlink('tests/fixtures/file_put_contents');
 
         $processor->restore();
     }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | Fix #460
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

`StreamProcessorTest::testSetStreamOptions` opened `tests/fixtures/file_put_contents`
with `fopen(..., 'w')` but never removed it — unlike `testFlockWithFilePutContents`,
which calls `unlink()` on the same path. The file was left untracked after every test
run and was accidentally committed in #457.

Added `unlink('tests/fixtures/file_put_contents')` after `fclose()`, mirroring the
existing cleanup in `testFlockWithFilePutContents`.

**Verified on:** workspace80, highest deps — `composer test` (400/400 green), `composer cs` (0 files to fix).