### PR TITLE
chore: add Daniel Hürtgen as maintainer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,11 @@
         {
             "name": "Adrian Philipp",
             "email": "mail@adrian-philipp.com"
+        },
+        {
+            "name": "Daniel Hürtgen",
+            "email": "daniel@higidi.com",
+            "role": "Maintainer"
         }
     ],
     "require": {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Documentation
| Fixes            | —
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

Adds Daniel Hürtgen (`daniel@higidi.com`) as a maintainer in `composer.json`.