### PR TITLE
ci: exercise PHPUnit 11 in the CI matrix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "ext-soap": "*",
         "guzzlehttp/guzzle": "^7",
         "symfony/http-client": "^5.4|^6.0|^7.0",
-        "phpunit/phpunit": "^9.5.10|^10.5",
+        "phpunit/phpunit": "^9.5.10|^10.5|^11.0",
         "mikey179/vfsstream": "^1.6.10",
         "phpstan/phpstan": "^1",
         "phpstan/phpstan-beberlei-assert": "^1",

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -54,6 +54,11 @@ class CurlHook implements LibraryHook
      */
     protected static array $lastErrors = [];
 
+    /**
+     * @var array<int, \WeakReference<\CurlHandle>> live references keyed by spl_object_id to detect handle-ID reuse
+     */
+    protected static array $handleRefs = [];
+
     public function __construct(
         private AbstractCodeTransform $codeTransformer,
         private StreamProcessor $processor
@@ -133,6 +138,7 @@ class CurlHook implements LibraryHook
             $id = (int) $curlHandle;
             self::$requests[$id] = new Request('GET', $url);
             self::$curlOptions[$id] = [];
+            self::$handleRefs[$id] = \WeakReference::create($curlHandle);
             unset(self::$responses[$id], self::$lastErrors[$id]);
         }
 
@@ -150,6 +156,7 @@ class CurlHook implements LibraryHook
             self::$responses[$id],
             self::$curlOptions[$id],
             self::$lastErrors[$id],
+            self::$handleRefs[$id],
         );
         curl_close($curlHandle);
     }
@@ -160,9 +167,11 @@ class CurlHook implements LibraryHook
     public static function curlReset(\CurlHandle $curlHandle): void
     {
         curl_reset($curlHandle);
-        self::$requests[(int) $curlHandle] = new Request('GET', null);
-        self::$curlOptions[(int) $curlHandle] = [];
-        unset(self::$responses[(int) $curlHandle]);
+        $id = (int) $curlHandle;
+        self::$requests[$id] = new Request('GET', null);
+        self::$curlOptions[$id] = [];
+        self::$handleRefs[$id] = \WeakReference::create($curlHandle);
+        unset(self::$responses[$id]);
     }
 
     /**
@@ -319,38 +328,40 @@ class CurlHook implements LibraryHook
      */
     public static function curlGetinfo(\CurlHandle $curlHandle, int $option = 0): mixed
     {
+        $id = (int) $curlHandle;
+        $ref = self::$handleRefs[$id] ?? null;
+        if (null === $ref || $ref->get() !== $curlHandle) {
+            throw new \RuntimeException('Unexpected curl handle: not initialized via curl_init() or already closed');
+        }
+
         if (\CURLINFO_PRIVATE === $option) {
-            return self::$curlOptions[(int) $curlHandle][\CURLOPT_PRIVATE] ?? '';
-        } elseif (isset(self::$responses[(int) $curlHandle])) {
+            return self::$curlOptions[$id][\CURLOPT_PRIVATE] ?? '';
+        } elseif (isset(self::$responses[$id])) {
             return CurlHelper::getCurlOptionFromResponse(
-                self::$responses[(int) $curlHandle],
+                self::$responses[$id],
                 $option
             );
         }
 
-        if (isset(self::$lastErrors[(int) $curlHandle])) {
+        if (isset(self::$lastErrors[$id])) {
             $value = CurlHelper::getCurlInfoFromArray(
-                self::$lastErrors[(int) $curlHandle]->getInfo(),
+                self::$lastErrors[$id]->getInfo(),
                 $option
             );
             if (false === $value) {
                 return CurlHelper::getDefaultCurlInfo(
                     $option,
-                    (self::$requests[(int) $curlHandle] ?? null)?->getUrl()
+                    (self::$requests[$id] ?? null)?->getUrl()
                 );
             }
 
             return $value;
         }
 
-        if (isset(self::$requests[(int) $curlHandle])) {
-            return CurlHelper::getDefaultCurlInfo(
-                $option,
-                self::$requests[(int) $curlHandle]->getUrl()
-            );
-        }
-
-        throw new \RuntimeException('Unexpected curl handle: not initialized via curl_init() or already closed');
+        return CurlHelper::getDefaultCurlInfo(
+            $option,
+            self::$requests[$id]->getUrl()
+        );
     }
 
     /**


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug, CI
| Fixes            | Fix #461
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

Add `^11.0` to the `phpunit/phpunit` require-dev constraint so the CI matrix runs against PHPUnit 11.

php-vcr already supports PHPUnit 11 for consumers (PHPUnit is a dev-only dependency with no runtime coupling; the stream_open fix from #457 removed the last functional blocker). This PR closes the gap on the testing side.

Composer resolves the highest compatible version per PHP level automatically — no changes to `ci.yml` or test code are needed:

| Job | PHPUnit |
|---|---|
| highest @ PHP 8.2 / 8.3 / 8.4 / 8.5 | **11** |
| highest @ PHP 8.1 | 10 |
| highest @ PHP 8.0 | 9 |
| lowest @ all | 9.5.10 |

PHPUnit 11 emits deprecation notices for `@dataProvider`/`@covers`/`@group` doc-comment annotations and `getMockForAbstractClass()`. These are intentionally left as-is: migrating to `#[DataProvider]` etc. requires PHPUnit 10+, but the PHP 8.0 job resolves PHPUnit 9 which does not read attributes — so the annotations are mandatory while PHP 8.0 support exists. `failOnDeprecation` is not set, so the suite stays green.

**Bug fix included:** Running the full suite with PHPUnit 11 + PCOV on PHP 8.5 exposed a pre-existing bug in `CurlHook`. PHP reuses `spl_object_id` values after GC; under PCOV coverage instrumentation the reuse is aggressive enough that a native `CurlHandle` created outside VCR's `curlInit()` can receive the same integer ID as a stale registered handle. This caused `curlGetinfo()` to find stale data and silently return a default result instead of throwing `RuntimeException`, making `testCurlGetinfoThrowsForUnknownHandle` fail.

Fixed by tracking a `WeakReference` per registered handle in a new `$handleRefs` array. `curlGetinfo()` now verifies at entry that the WeakReference for the handle's integer ID resolves to the exact same object — a GC'd original (WeakRef returns `null`) or a recycled ID (WeakRef points to a different object) both trigger the exception immediately. `curlInit()` and `curlReset()` populate `$handleRefs`; `curlClose()` clears it alongside the other per-handle arrays.

**Verified locally:**

- `workspace82 composer update` → PHPUnit 11.5.55; `composer test` → 413/413 (27 expected deprecations)
- `workspace84 composer update` → PHPUnit 11.5.55; `composer test` → 413/413
- `workspace85 composer update` → PHPUnit 11.5.55; `composer test` → 413/413
- `workspace80 composer update` → PHPUnit 9.6.34; `composer test` → 413/413
- `workspace80 composer update --prefer-lowest` → PHPUnit 9.5.10; `composer test` → 413/413
- `workspace80 composer phpstan` → no new issues
- `workspace80 composer cs` → 0 files to fix
- `workspace80 composer validate --strict` → valid