### PR TITLE
fix: parse responses after proxy acknowledgements

### DIFF
--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -77,9 +77,33 @@ class HttpUtil
      */
     public static function parseResponse(string $response): array
     {
-        $response = str_replace("HTTP/1.1 100 Continue\r\n\r\n", '', $response);
+        $responseOffset = 0;
+        $separatorOffset = strpos($response, "\r\n\r\n");
+        while (false !== $separatorOffset) {
+            $rawHeader = substr($response, $responseOffset, $separatorOffset - $responseOffset);
+            $headerLines = explode("\r\n", $rawHeader);
+            $statusLine = array_shift($headerLines);
+            if (1 !== preg_match('/^HTTP\/\S+ (\d{3})(?: [^\r\n]*)?$/D', $statusLine, $matches)) {
+                break;
+            }
 
-        [$rawHeader, $rawBody] = explode("\r\n\r\n", $response, 2);
+            $statusCode = (int) $matches[1];
+            $isInformational = 100 <= $statusCode && 200 > $statusCode;
+            $isProxyAcknowledgement = 200 <= $statusCode && 300 > $statusCode && [] === $headerLines;
+            if (!$isInformational && !$isProxyAcknowledgement) {
+                break;
+            }
+
+            $nextResponseOffset = $separatorOffset + 4;
+            if ($nextResponseOffset !== strpos($response, 'HTTP/', $nextResponseOffset)) {
+                break;
+            }
+
+            $responseOffset = $nextResponseOffset;
+            $separatorOffset = strpos($response, "\r\n\r\n", $responseOffset);
+        }
+
+        [$rawHeader, $rawBody] = explode("\r\n\r\n", substr($response, $responseOffset), 2);
 
         // Parse headers and status.
         $headers = self::parseRawHeader($rawHeader);

--- a/tests/Unit/Util/HttpUtilTest.php
+++ b/tests/Unit/Util/HttpUtilTest.php
@@ -97,6 +97,26 @@ final class HttpUtilTest extends TestCase
         $this->assertEquals($expectedHeaders, $headers);
     }
 
+    public function testParseResponseAfterProxyAcknowledgements(): void
+    {
+        $raw = "HTTP/1.0 200 Connection established\r\n\r\nHTTP/2 200\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/plain\r\nContent-Length: 15\r\n\r\nfirst\r\n\r\nsecond";
+        [$status, $headers, $body] = HttpUtil::parseResponse($raw);
+
+        $this->assertEquals('HTTP/1.1 201 Created', $status);
+        $this->assertEquals(['Content-Type: text/plain', 'Content-Length: 15'], $headers);
+        $this->assertEquals("first\r\n\r\nsecond", $body);
+    }
+
+    public function testParseResponsePreservesBodyStartingWithHttpStatusLine(): void
+    {
+        $raw = "HTTP/1.1 200 OK\r\nContent-Type: message/http\r\nContent-Length: 35\r\n\r\nHTTP/1.1 404 Not Found\r\n\r\nreal body";
+        [$status, $headers, $body] = HttpUtil::parseResponse($raw);
+
+        $this->assertEquals('HTTP/1.1 200 OK', $status);
+        $this->assertEquals(['Content-Type: message/http', 'Content-Length: 35'], $headers);
+        $this->assertEquals("HTTP/1.1 404 Not Found\r\n\r\nreal body", $body);
+    }
+
     public function testParseHeadersBasic(): void
     {
         $inputArray = [


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | Fix #456
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

Parse and skip complete leading HTTP status blocks before splitting the final response. This handles proxy tunnel acknowledgements and repeated `100 Continue` blocks while preserving the final body bytes. A valid status-line boundary prevents ordinary HTTP-looking body content from being consumed.

Local validation:

- Focused `HttpUtilTest`: 12 tests, 26 assertions
- Full unit suite: 357 tests, 549 assertions
- Full integration suite: 58 tests, 331 assertions
- PHPStan: no errors
- PHP-CS-Fixer: 100 files, no fixable files
- EditorConfig: 116 files, no violations
- `composer validate --strict`, PHP syntax checks, and `git diff --check`

The Docker matrix was not run locally because Docker is unavailable in this environment. The repository CI matrix remains the source of truth for PHP 8.0–8.5 and lowest/highest dependency coverage.
