### PR TITLE
feat: add option to disable identical-request index matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ file_get_contents('http://example.com');  // hits network, recorded fresh
 
 > **Note:** A run under `MODE_ALL` that performs no HTTP request leaves an empty cassette — this is inherent to the fresh re-record semantics.
 
+## Recording identical requests
+
+By default php-vcr records identical requests separately and replays them in
+the same order they were made (each gets an incrementing `index` in the
+cassette). If your test issues an identical request a variable number of times
+across runs, disable this so every identical request replays the first
+recorded response:
+
+```php
+\VCR\VCR::configure()->setRecordIdenticalRequests(false);
+```
+
 ## Installation
 
 Simply run the following command:

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -35,7 +35,9 @@ class Cassette
             // always match this record if the request matches
             $recording['index'] ??= $index;
 
-            if ($storedRequest->matches($request, $this->getRequestMatchers()) && $index == $recording['index']) {
+            $indexMatches = !$this->config->getRecordIdenticalRequests() || $index == $recording['index'];
+
+            if ($storedRequest->matches($request, $this->getRequestMatchers()) && $indexMatches) {
                 return Response::fromArray($recording['response']);
             }
         }

--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -124,6 +124,8 @@ class Configuration
 
     private string $mode = VCR::MODE_NEW_EPISODES;
 
+    private bool $recordIdenticalRequests = true;
+
     /**
      * List of available modes.
      *
@@ -321,6 +323,18 @@ class Configuration
     {
         Assertion::choice($mode, $this->availableModes, "Mode '{$mode}' does not exist.");
         $this->mode = $mode;
+
+        return $this;
+    }
+
+    public function getRecordIdenticalRequests(): bool
+    {
+        return $this->recordIdenticalRequests;
+    }
+
+    public function setRecordIdenticalRequests(bool $recordIdenticalRequests): self
+    {
+        $this->recordIdenticalRequests = $recordIdenticalRequests;
 
         return $this;
     }

--- a/tests/Unit/CassetteTest.php
+++ b/tests/Unit/CassetteTest.php
@@ -131,15 +131,48 @@ final class CassetteTest extends TestCase
     /**
      * @param array<int,array<string,int|string|array<string,mixed>|null>> $recordings
      */
-    protected function createCassetteWithRecordings(array $recordings): Cassette
+    protected function createCassetteWithRecordings(array $recordings, ?Configuration $configuration = null): Cassette
     {
         $storage = new Yaml(vfsStream::url('test/'), 'json_test');
 
         foreach ($recordings as $recording) {
             $storage->storeRecording($recording);
         }
-        $configuration = new Configuration();
+        $configuration ??= new Configuration();
 
         return new Cassette('cassette_name', $configuration, $storage);
+    }
+
+    /**
+     * Ensure that with recordIdenticalRequests disabled, identical requests all
+     * replay the first matching recording regardless of the requested index.
+     */
+    public function testPlaybackOfIdenticalRequestsIgnoresIndexWhenDisabled(): void
+    {
+        $request1 = new Request('GET', 'https://example.com');
+        $response1 = new Response('200', [], 'response1');
+
+        $request2 = new Request('GET', 'https://example.com');
+        $response2 = new Response('200', [], 'response2');
+
+        $recordings = [
+            [
+                'request' => $request1->toArray(),
+                'response' => $response1->toArray(),
+                'index' => 0,
+            ],
+            [
+                'request' => $request2->toArray(),
+                'response' => $response2->toArray(),
+                'index' => 1,
+            ],
+        ];
+
+        $configuration = new Configuration();
+        $configuration->setRecordIdenticalRequests(false);
+        $cassette = $this->createCassetteWithRecordings($recordings, $configuration);
+
+        $this->assertEquals($response1->toArray(), $cassette->playback($request1, 0)?->toArray());
+        $this->assertEquals($response1->toArray(), $cassette->playback($request2, 1)?->toArray());
     }
 }

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -167,4 +167,15 @@ final class ConfigurationTest extends TestCase
         $this->config->setMode(VCR::MODE_ALL);
         $this->assertSame(VCR::MODE_ALL, $this->config->getMode());
     }
+
+    public function testRecordIdenticalRequestsDefaultsToTrue(): void
+    {
+        $this->assertTrue($this->config->getRecordIdenticalRequests());
+    }
+
+    public function testSetRecordIdenticalRequests(): void
+    {
+        $this->config->setRecordIdenticalRequests(false);
+        $this->assertFalse($this->config->getRecordIdenticalRequests());
+    }
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Enhancement
| Fixes            | Fixes #391
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

Adds a `recordIdenticalRequests` configuration option. By default (`true`) php-vcr keeps its existing behavior: identical requests are recorded and replayed in the order they were made, using an incrementing `index`. Setting it to `false` disables the index check, so every identical request replays the first recorded response regardless of how many times it was actually issued during recording or replay.

This addresses cases where a request is issued a variable number of times across recording sessions (e.g. fetching a cached auth token), which previously caused index mismatches on replay.

```php
VCR::configure()->setRecordIdenticalRequests(false);
```

Default is `true`, so this is fully backwards-compatible.
