### PR TITLE
fix(curl): return CURLM_OK from CurlHook::curlMultiAddHandle for Guzzle 7.14

### DIFF
--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -201,13 +201,15 @@ class CurlHook implements LibraryHook
      *
      * @see http://www.php.net/manual/en/function.curl-multi-add-handle.php
      */
-    public static function curlMultiAddHandle(\CurlMultiHandle $multiHandle, \CurlHandle $curlHandle): void
+    public static function curlMultiAddHandle(\CurlMultiHandle $multiHandle, \CurlHandle $curlHandle): int
     {
         if (!isset(self::$multiHandles[(int) $multiHandle])) {
             self::$multiHandles[(int) $multiHandle] = [];
         }
 
         self::$multiHandles[(int) $multiHandle][(int) $curlHandle] = $curlHandle;
+
+        return \CURLM_OK;
     }
 
     /**

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -375,6 +375,29 @@ final class CurlHookTest extends TestCase
         $this->assertFalse($afterLastInfo, 'Multi info called the last time should return false.');
     }
 
+    public function testCurlMultiAddHandleReturnsCurlmOk(): void
+    {
+        $this->curlHook->enable($this->getTestCallback());
+
+        $curlHandle = curl_init('http://example.com');
+        Assertion::notSame($curlHandle, false);
+        $curlMultiHandle = curl_multi_init();
+        Assertion::notSame($curlMultiHandle, false);
+
+        $result = curl_multi_add_handle($curlMultiHandle, $curlHandle);
+
+        curl_multi_remove_handle($curlMultiHandle, $curlHandle);
+        curl_multi_close($curlMultiHandle);
+        $this->curlHook->disable();
+
+        $this->assertSame(
+            \CURLM_OK,
+            $result,
+            'curl_multi_add_handle() must return CURLM_OK so callers checking the return value '
+            .'(e.g. Guzzle >= 7.14) do not treat a successful add as a failure.'
+        );
+    }
+
     /**
      * @doesNotPerformAssertions
      */


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | Backport of #470, fixes #469
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

Backport of #470 to the `1.9` branch. Guzzle 7.14 changed `CurlMultiHandler::addCurlHandle()` to check the return value of `curl_multi_add_handle()` against `CURLM_OK` and throw a `RequestException` otherwise. VCR's `CurlCodeTransform` rewrites that call to `CurlHook::curlMultiAddHandle()`, which was declared `void` and therefore always returned `null`. Under Guzzle >= 7.14 this made the check fail on every `curl_multi` request, breaking `AsyncTest::testAsyncLock` and any real-world use of Guzzle's async client.

Fix: `CurlHook::curlMultiAddHandle()` now returns `CURLM_OK` (int) instead of `void`, matching the real `curl_multi_add_handle()` contract. Cherry-picked from `master`; the `1.9` branch predates a later `WeakReference` refactor of `CurlHook`, so the fix commit merged automatically around unrelated context — no conflicts, and the resulting diff is identical to the one applied on `master`/`1.10`.