### PR TITLE
fix: add opt-in stream wrapper restoration to VCR::turnOff()

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -78,6 +78,7 @@ class StreamProcessor
         // stream_wrapper_restore can throw when stream_wrapper was never changed, so we unregister first
         stream_wrapper_unregister(self::PROTOCOL);
         stream_wrapper_restore(self::PROTOCOL);
+        $this->isIntercepting = false;
     }
 
     /**

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -90,10 +90,15 @@ class Videorecorder
     /**
      * @api
      */
-    public function turnOff(): void
+    public function turnOff(bool $restoreStreamWrappers = false): void
     {
         if ($this->isOn) {
             $this->disableLibraryHooks();
+
+            if ($restoreStreamWrappers) {
+                $this->factory->get('VCR\Util\StreamProcessor')->restore();
+            }
+
             $this->eject();
             $this->isOn = false;
         }

--- a/tests/Unit/Util/StreamProcessorTest.php
+++ b/tests/Unit/Util/StreamProcessorTest.php
@@ -79,6 +79,23 @@ final class StreamProcessorTest extends TestCase
     }
 
     /**
+     * @see https://github.com/php-vcr/php-vcr/issues/350
+     */
+    public function testRestoreResetsInterceptingState(): void
+    {
+        $processor = new InterceptStateStreamProcessor();
+        $processor->intercept();
+        $this->assertTrue($processor->isIntercepting(), 'Sanity: intercept() must set the flag.');
+
+        $processor->restore();
+
+        $this->assertFalse(
+            $processor->isIntercepting(),
+            'restore() must reset isIntercepting so a later intercept() re-registers the wrapper.'
+        );
+    }
+
+    /**
      * test flock with file_put_contents.
      */
     public function testFlockWithFilePutContents(): void

--- a/tests/Unit/VideorecorderTest.php
+++ b/tests/Unit/VideorecorderTest.php
@@ -26,6 +26,61 @@ final class VideorecorderTest extends TestCase
         );
     }
 
+    /**
+     * @see https://github.com/php-vcr/php-vcr/issues/350
+     */
+    public function testTurnOffRestoresStreamWrapperWhenRequested(): void
+    {
+        $configuration = new Configuration();
+        $configuration->enableLibraryHooks([]);
+        $factory = VCRFactory::getInstance();
+        $processor = $factory->get('VCR\Util\StreamProcessor');
+        $processor->intercept();
+
+        $reflection = new \ReflectionObject($processor);
+        $property = $reflection->getProperty('isIntercepting');
+        $property->setAccessible(true);
+        $this->assertTrue($property->getValue($processor), 'Sanity: intercept() must set the flag.');
+
+        $videorecorder = new Videorecorder($configuration, new HttpClient(), $factory);
+        $videorecorder->turnOn();
+        $videorecorder->turnOff(true);
+
+        $this->assertFalse(
+            $property->getValue($processor),
+            'turnOff(true) must restore the shared StreamProcessor file:// wrapper (issue #350).'
+        );
+
+        $processor->restore();
+    }
+
+    /**
+     * @see https://github.com/php-vcr/php-vcr/issues/350
+     */
+    public function testTurnOffDoesNotRestoreStreamWrapperByDefault(): void
+    {
+        $configuration = new Configuration();
+        $configuration->enableLibraryHooks([]);
+        $factory = VCRFactory::getInstance();
+        $processor = $factory->get('VCR\Util\StreamProcessor');
+        $processor->intercept();
+
+        $reflection = new \ReflectionObject($processor);
+        $property = $reflection->getProperty('isIntercepting');
+        $property->setAccessible(true);
+
+        $videorecorder = new Videorecorder($configuration, new HttpClient(), $factory);
+        $videorecorder->turnOn();
+        $videorecorder->turnOff();
+
+        $this->assertTrue(
+            $property->getValue($processor),
+            'turnOff() without arguments must not change existing behavior — the fix for issue #350 is opt-in.'
+        );
+
+        $processor->restore();
+    }
+
     public function testInsertCassetteEjectExisting(): void
     {
         vfsStream::setup('testDir');


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | Fixes #350
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

`VCR::turnOff()` left the `file://` stream wrapper (and disabled opcache) registered after VCR was supposedly off. The literal fix suggested in #350 — calling `$this->processor->restore()` from `CurlHook::disable()`/`SoapHook::disable()` — breaks the project's own Unit test suite (details in the issue comment: it undoes the wrapper registration `tests/bootstrap.php` relies on to get `CurlHookTest`/`SoapHookTest` code-transformed at all).

Resolution: an opt-in parameter on the existing lifecycle method everyone already calls.

```php
VCR::turnOff();       // unchanged default behavior
VCR::turnOff(true);   // additionally restores the file:// stream wrapper
```

- `StreamProcessor::restore()` now also resets its internal `isIntercepting` flag, so a subsequent `VCR::turnOn()` correctly re-registers the wrapper (`intercept()` was previously a no-op after a `restore()` call).
- `Videorecorder::turnOff(bool $restoreStreamWrappers = false)` — default preserves today's exact behavior; `true` additionally restores the shared `StreamProcessor` used internally by `CurlHook`, `SoapHook`, and `StreamWrapperHook`.
- No changes to `CurlHook`, `SoapHook`, `StreamWrapperHook`, or the `LibraryHook` interface.

Verified locally:
- workspace80: `composer phpstan` (no new baseline entries), `composer cs-fix`/`composer cs` (0 files to fix), `composer ec` clean on all changed files, `composer test` with `--prefer-lowest` and highest deps (417/417 passing both).
- workspace85: `composer test` with `--prefer-lowest` and highest deps (417/417 passing both).
- Manual sanity check: `VCR::turnOff()` and `VCR::turnOff(true)` both run without error; the full Unit suite (including `tests/bootstrap.php`'s own `VCR::turnOn(); VCR::turnOff();` priming call) stays green, confirming no regression in the code-transformation path.