### PR TITLE
fix: parse empty-value curl headers set with semicolon notation

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -261,7 +261,7 @@ class CurlHelper
                 foreach ($value as $header) {
                     $headerParts = explode(': ', $header, 2);
                     if (!isset($headerParts[1])) {
-                        $headerParts[0] = rtrim($headerParts[0], ':');
+                        $headerParts[0] = rtrim($headerParts[0], ':;');
                         $headerParts[1] = '';
                     }
                     $request->setHeader($headerParts[0], $headerParts[1]);

--- a/tests/Unit/Util/CurlHelperTest.php
+++ b/tests/Unit/Util/CurlHelperTest.php
@@ -110,6 +110,26 @@ final class CurlHelperTest extends TestCase
         $this->assertEquals(['Host' => 'example.com'], $request->getHeaders());
     }
 
+    public function testSetCurlOptionOnRequestSetHeaderWithoutValueSemicolonNotation(): void
+    {
+        $request = new Request('GET', 'http://example.com');
+        $headers = ['Host: example.com', 'SOAPAction;'];
+
+        CurlHelper::setCurlOptionOnRequest($request, \CURLOPT_HTTPHEADER, $headers);
+
+        $this->assertEquals(['Host' => 'example.com', 'SOAPAction' => ''], $request->getHeaders());
+    }
+
+    public function testSetCurlOptionOnRequestSetHeaderWithoutValueColonNotation(): void
+    {
+        $request = new Request('GET', 'http://example.com');
+        $headers = ['Host: example.com', 'Accept:'];
+
+        CurlHelper::setCurlOptionOnRequest($request, \CURLOPT_HTTPHEADER, $headers);
+
+        $this->assertEquals(['Host' => 'example.com', 'Accept' => ''], $request->getHeaders());
+    }
+
     public function testSetCurlOptionOnRequestSetMultipleHeadersTwice(): void
     {
         $request = new Request('GET', 'http://example.com');


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | Fix #308
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

`CURLOPT_HTTPHEADER` accepts two notations for a header with no value: `Name:`
(colon) and `Name;` (semicolon). `CurlHelper::setCurlOptionOnRequest` only
stripped the colon form, so a semicolon-terminated header such as `SOAPAction;`
was stored under the key `SOAPAction;` instead of `SOAPAction`. This broke
cassette replay for SOAP calls made over cURL, since the recorded header name
never matched what the SOAP client sent.

Before:
```yaml
headers:
    SOAPAction;: ''
```

After:
```yaml
headers:
    SOAPAction: ''
```

Verified on workspace80 (phpstan, cs, ec, tests lowest/highest) and workspace85
(tests lowest/highest).