### PR TITLE
fix: follow redirects for native stream functions (fixes #138)

### DIFF
--- a/src/VCR/LibraryHooks/StreamWrapperHook.php
+++ b/src/VCR/LibraryHooks/StreamWrapperHook.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace VCR\LibraryHooks;
 
 use VCR\CodeTransform\AbstractCodeTransform;
+use VCR\Request;
 use VCR\Response;
 use VCR\Util\Assertion;
 use VCR\Util\CurlException;
@@ -14,6 +15,8 @@ use VCR\Util\StreamProcessor;
 
 class StreamWrapperHook implements LibraryHook
 {
+    private const REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308];
+
     protected static ?\Closure $requestCallback;
 
     // Static: PHP instantiates a new StreamWrapperHook (no args) for every fopen() call
@@ -103,17 +106,20 @@ class StreamWrapperHook implements LibraryHook
     public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
     {
         $request = StreamHelper::createRequestFromStreamContext($this->context, $path);
+        $request->setCurlOption(\CURLOPT_FOLLOWLOCATION, false);
 
         $requestCallback = self::$requestCallback;
         Assertion::isCallable($requestCallback);
         try {
-            $this->response = $requestCallback($request);
-            $this->responseHeaders = self::buildResponseHeaderLines($this->response);
-
-            return true;
+            $response = $requestCallback($request);
         } catch (CurlException $e) {
             return false;
         }
+
+        $this->response = $this->followRedirects($request, $response, $requestCallback);
+        $this->responseHeaders = self::buildResponseHeaderLines($this->response);
+
+        return true;
     }
 
     /**
@@ -267,6 +273,62 @@ class StreamWrapperHook implements LibraryHook
         }
 
         return $meta;
+    }
+
+    private function followRedirects(Request $request, Response $response, \Closure $requestCallback): Response
+    {
+        if (!StreamHelper::shouldFollowLocation($this->context)) {
+            return $response;
+        }
+
+        $maxRedirects = StreamHelper::maxRedirects($this->context);
+        $redirects = 0;
+
+        while ($redirects < $maxRedirects
+            && \in_array($response->getStatusCode(), self::REDIRECT_STATUS_CODES, true)
+            && null !== ($location = self::locationHeader($response))
+        ) {
+            $url = StreamHelper::resolveUrl((string) $request->getUrl(), $location);
+            $next = self::buildRedirectRequest($request, $response->getStatusCode(), $url);
+
+            try {
+                $response = $requestCallback($next);
+            } catch (\Exception $e) {
+                // The redirect target is not available (e.g. a legacy cassette that
+                // only recorded the redirect). Fall back to the redirect response.
+                break;
+            }
+
+            $request = $next;
+            ++$redirects;
+        }
+
+        return $response;
+    }
+
+    private static function locationHeader(Response $response): ?string
+    {
+        foreach ($response->getHeaders() as $name => $value) {
+            if (0 === strcasecmp($name, 'Location')) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    private static function buildRedirectRequest(Request $request, int $statusCode, string $url): Request
+    {
+        if (\in_array($statusCode, [307, 308], true)) {
+            $redirect = new Request($request->getMethod(), $url);
+            if (null !== $request->getBody()) {
+                $redirect->setBody($request->getBody());
+            }
+
+            return $redirect;
+        }
+
+        return new Request('GET', $url);
     }
 
     /** @return string[] */

--- a/src/VCR/LibraryHooks/StreamWrapperHook.php
+++ b/src/VCR/LibraryHooks/StreamWrapperHook.php
@@ -293,7 +293,7 @@ class StreamWrapperHook implements LibraryHook
 
             try {
                 $response = $requestCallback($next);
-            } catch (\Exception $e) {
+            } catch (\LogicException $e) {
                 // The redirect target is not available (e.g. a legacy cassette that
                 // only recorded the redirect). Fall back to the redirect response.
                 break;

--- a/src/VCR/Util/StreamHelper.php
+++ b/src/VCR/Util/StreamHelper.php
@@ -65,6 +65,65 @@ class StreamHelper
     }
 
     /**
+     * Resolves a possibly-relative Location value against a base URL.
+     */
+    public static function resolveUrl(string $base, string $location): string
+    {
+        if (1 === preg_match('#^[a-z][a-z0-9+.-]*://#i', $location)) {
+            return $location;
+        }
+
+        $parts = parse_url($base);
+        $scheme = $parts['scheme'] ?? 'http';
+
+        if (str_starts_with($location, '//')) {
+            return $scheme.':'.$location;
+        }
+
+        $host = $parts['host'] ?? '';
+        $port = isset($parts['port']) ? ':'.$parts['port'] : '';
+        $authority = $scheme.'://'.$host.$port;
+
+        if (str_starts_with($location, '/')) {
+            return $authority.$location;
+        }
+
+        $basePath = $parts['path'] ?? '/';
+        $lastSlash = strrpos($basePath, '/');
+        $dir = false === $lastSlash ? '/' : substr($basePath, 0, $lastSlash + 1);
+
+        return $authority.$dir.$location;
+    }
+
+    /**
+     * Whether redirects should be followed for the given stream context.
+     *
+     * Mirrors PHP's native http wrapper default (follow_location = 1).
+     *
+     * @param resource|null $context
+     */
+    public static function shouldFollowLocation($context): bool
+    {
+        $http = self::getHttpOptionsFromContext($context);
+
+        return (bool) ($http['follow_location'] ?? 1);
+    }
+
+    /**
+     * Maximum number of redirects to follow for the given stream context.
+     *
+     * Mirrors PHP's native http wrapper default (max_redirects = 20).
+     *
+     * @param resource|null $context
+     */
+    public static function maxRedirects($context): int
+    {
+        $http = self::getHttpOptionsFromContext($context);
+
+        return (int) ($http['max_redirects'] ?? 20);
+    }
+
+    /**
      * Returns HTTP options from current stream context.
      *
      * @see http://php.net/manual/en/context.http.php

--- a/tests/Unit/LibraryHooks/StreamWrapperHookTest.php
+++ b/tests/Unit/LibraryHooks/StreamWrapperHookTest.php
@@ -112,4 +112,131 @@ final class StreamWrapperHookTest extends TestCase
         fclose($resource);
         $hook->disable();
     }
+
+    public function testFollowsRedirectByDefault(): void
+    {
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
+        $calls = 0;
+        $hook->enable(static function ($request) use (&$calls) {
+            ++$calls;
+            if (1 === $calls) {
+                return new Response('301', ['Location' => 'http://example.com/final'], 'moved');
+            }
+
+            return new Response('200', [], 'final body');
+        });
+        $hook->stream_open('http://example.com/start', 'r', 0, $openedPath);
+
+        $this->assertSame(2, $calls);
+        $this->assertSame('final body', $hook->stream_read(100));
+        $hook->disable();
+    }
+
+    public function testDoesNotFollowWhenContextDisablesFollowLocation(): void
+    {
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
+        $calls = 0;
+        $hook->enable(static function ($request) use (&$calls) {
+            ++$calls;
+
+            return new Response('301', ['Location' => 'http://example.com/final'], 'moved');
+        });
+        $hook->context = stream_context_create(['http' => ['follow_location' => 0]]);
+        $hook->stream_open('http://example.com/start', 'r', 0, $openedPath);
+
+        $this->assertSame(1, $calls);
+        $this->assertSame('moved', $hook->stream_read(100));
+        $hook->disable();
+    }
+
+    public function testFollowsWhenContextExplicitlyEnablesFollowLocation(): void
+    {
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
+        $calls = 0;
+        $hook->enable(static function ($request) use (&$calls) {
+            ++$calls;
+            if (1 === $calls) {
+                return new Response('301', ['Location' => 'http://example.com/final'], 'moved');
+            }
+
+            return new Response('200', [], 'final body');
+        });
+        $hook->context = stream_context_create(['http' => ['follow_location' => 1]]);
+        $hook->stream_open('http://example.com/start', 'r', 0, $openedPath);
+
+        $this->assertSame(2, $calls);
+        $this->assertSame('final body', $hook->stream_read(100));
+        $hook->disable();
+    }
+
+    public function testDoesNotFollowNonRedirectResponseWithLocationHeader(): void
+    {
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
+        $calls = 0;
+        $hook->enable(static function ($request) use (&$calls) {
+            ++$calls;
+
+            // 200 with a stray Location header must not trigger a follow.
+            return new Response('200', ['Location' => 'http://example.com/final'], 'body');
+        });
+        $hook->stream_open('http://example.com/start', 'r', 0, $openedPath);
+
+        $this->assertSame(1, $calls);
+        $this->assertSame('body', $hook->stream_read(100));
+        $hook->disable();
+    }
+
+    public function testFallsBackToRedirectResponseWhenHopUnavailable(): void
+    {
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
+        $calls = 0;
+        $hook->enable(static function ($request) use (&$calls) {
+            ++$calls;
+            if (1 === $calls) {
+                return new Response('301', ['Location' => 'http://example.com/final'], 'moved');
+            }
+
+            throw new \LogicException('no recorded response for the redirect target');
+        });
+        $hook->stream_open('http://example.com/start', 'r', 0, $openedPath);
+
+        $this->assertSame(2, $calls);
+        $this->assertSame('moved', $hook->stream_read(100));
+        $hook->disable();
+    }
+
+    public function testFollowsRelativeRedirect(): void
+    {
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
+        $seen = [];
+        $hook->enable(static function ($request) use (&$seen) {
+            $seen[] = $request->getUrl();
+            if (1 === \count($seen)) {
+                return new Response('302', ['Location' => '/target'], 'moved');
+            }
+
+            return new Response('200', [], 'ok');
+        });
+        $hook->stream_open('http://example.com/a/b', 'r', 0, $openedPath);
+
+        $this->assertSame(['http://example.com/a/b', 'http://example.com/target'], $seen);
+        $this->assertSame('ok', $hook->stream_read(100));
+        $hook->disable();
+    }
+
+    public function testStopsAfterMaxRedirects(): void
+    {
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
+        $calls = 0;
+        $hook->enable(static function ($request) use (&$calls) {
+            ++$calls;
+
+            return new Response('301', ['Location' => 'http://example.com/loop'], 'loop');
+        });
+        $hook->stream_open('http://example.com/loop', 'r', 0, $openedPath);
+
+        // 1 initial request + 20 follows (default max_redirects)
+        $this->assertSame(21, $calls);
+        $hook->disable();
+    }
 }

--- a/tests/Unit/Util/StreamHelperTest.php
+++ b/tests/Unit/Util/StreamHelperTest.php
@@ -104,4 +104,49 @@ final class StreamHelperTest extends TestCase
         $request = StreamHelper::createRequestFromStreamContext($context, 'http://example.com');
         $testCallback($request);
     }
+
+    /**
+     * @dataProvider resolveUrlProvider
+     */
+    public function testResolveUrl(string $base, string $location, string $expected): void
+    {
+        $this->assertSame($expected, StreamHelper::resolveUrl($base, $location));
+    }
+
+    /**
+     * @return array<string,array{string,string,string}>
+     */
+    public static function resolveUrlProvider(): array
+    {
+        return [
+            'absolute' => ['http://example.com/a', 'https://other.com/b', 'https://other.com/b'],
+            'scheme relative' => ['https://example.com/a', '//cdn.example.com/b', 'https://cdn.example.com/b'],
+            'absolute path' => ['http://example.com/a/b', '/c/d', 'http://example.com/c/d'],
+            'relative path' => ['http://example.com/a/b', 'c', 'http://example.com/a/c'],
+            'relative root' => ['http://example.com', 'c', 'http://example.com/c'],
+            'with port' => ['http://example.com:8080/a/b', '/c', 'http://example.com:8080/c'],
+        ];
+    }
+
+    public function testShouldFollowLocationDefaultsToTrue(): void
+    {
+        $this->assertTrue(StreamHelper::shouldFollowLocation(null));
+    }
+
+    public function testShouldFollowLocationHonorsContextDisable(): void
+    {
+        $context = stream_context_create(['http' => ['follow_location' => 0]]);
+        $this->assertFalse(StreamHelper::shouldFollowLocation($context));
+    }
+
+    public function testMaxRedirectsDefaultsTo20(): void
+    {
+        $this->assertSame(20, StreamHelper::maxRedirects(null));
+    }
+
+    public function testMaxRedirectsHonorsContext(): void
+    {
+        $context = stream_context_create(['http' => ['max_redirects' => 5]]);
+        $this->assertSame(5, StreamHelper::maxRedirects($context));
+    }
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | Fixes #138
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

When code under test uses native stream functions (`file_get_contents()`, `fopen()`), a server-side redirect (301, 302, 303, 307, 308) previously got recorded and replayed as-is — the caller received the redirect body instead of the final response, unlike native PHP which follows redirects transparently.

`StreamWrapperHook::stream_open()` now follows redirects the same way PHP's own http stream wrapper does, honouring the `follow_location` and `max_redirects` stream context options (defaulting to following, with a limit of 20, exactly like PHP's defaults). Each hop is recorded/replayed as its own cassette interaction, and a hop that can't be satisfied during playback (e.g. an existing cassette that only ever recorded the redirect) falls back to returning the redirect response, so existing cassettes keep working unchanged.

cURL requests are unaffected — cURL already follows redirects on its own, and this change explicitly disables cURL's own following for the underlying request so a redirect is never resolved twice.

Example:

```php
VCR::insertCassette('example');
$body = file_get_contents('https://example.com/redirects-to-target');
// $body is now the final response body, and the cassette holds both hops
```

**Test plan:**
- `composer test`, `composer phpstan`, `composer cs`, `composer ec` on workspace80 (lowest and highest deps) and workspace85 (lowest and highest deps) — all green.
- Manual verification against a live redirecting endpoint: recording produced two cassette interactions (301 hop + final 200 hop), and a subsequent offline replay (`MODE_NONE`) returned a body identical to the recorded one.
