### PR TITLE
fix(httputil): guard parseResponse against response without body separator

### DIFF
--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -103,7 +103,7 @@ class HttpUtil
             $separatorOffset = strpos($response, "\r\n\r\n", $responseOffset);
         }
 
-        [$rawHeader, $rawBody] = explode("\r\n\r\n", substr($response, $responseOffset), 2);
+        [$rawHeader, $rawBody] = array_pad(explode("\r\n\r\n", substr($response, $responseOffset), 2), 2, '');
 
         // Parse headers and status.
         $headers = self::parseRawHeader($rawHeader);

--- a/tests/Unit/Util/HttpUtilTest.php
+++ b/tests/Unit/Util/HttpUtilTest.php
@@ -107,6 +107,26 @@ final class HttpUtilTest extends TestCase
         $this->assertEquals("first\r\n\r\nsecond", $body);
     }
 
+    public function testParseResponseEmpty(): void
+    {
+        $raw = '';
+        [$status, $headers, $body] = HttpUtil::parseResponse($raw);
+
+        $this->assertEquals('', $status);
+        $this->assertEquals([], $headers);
+        $this->assertEquals('', $body);
+    }
+
+    public function testParseResponseWithoutBodySeparator(): void
+    {
+        $raw = 'HTTP/1.1 404 Not Found';
+        [$status, $headers, $body] = HttpUtil::parseResponse($raw);
+
+        $this->assertEquals('HTTP/1.1 404 Not Found', $status);
+        $this->assertEquals([], $headers);
+        $this->assertEquals('', $body);
+    }
+
     public function testParseResponsePreservesBodyStartingWithHttpStatusLine(): void
     {
         $raw = "HTTP/1.1 200 OK\r\nContent-Type: message/http\r\nContent-Length: 35\r\n\r\nHTTP/1.1 404 Not Found\r\n\r\nreal body";


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | Fixes #272
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

An empty response, or one consisting only of a status line (e.g. a 204 No Content or certain 404 responses), has no `\r\n\r\n` header/body separator. `explode()` in `HttpUtil::parseResponse()` then returns a single-element array, and destructuring into `[$rawHeader, $rawBody]` raises an undefined array key warning on PHP 8.

`explode()`'s result is now padded to two elements with `array_pad()`, so a missing body is treated as an empty string instead of raising a warning.

Supersedes #302, which proposed the same fix against an earlier version of this method and predates the current PHP 8 support range.
