### PR TITLE
fix(response): handle duplicate response headers without breaking replay

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: src/VCR/Util/HttpUtil.php
 
 		-
-			message: "#^Method VCR\\\\Util\\\\HttpUtil\\:\\:parseHeaders\\(\\) should return array\\<string, string\\> but returns array\\<array\\<int, string\\>\\|string\\>\\.$#"
-			count: 1
-			path: src/VCR/Util/HttpUtil.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/VCR/Util/HttpUtil.php

--- a/src/VCR/LibraryHooks/StreamWrapperHook.php
+++ b/src/VCR/LibraryHooks/StreamWrapperHook.php
@@ -310,7 +310,8 @@ class StreamWrapperHook implements LibraryHook
     {
         foreach ($response->getHeaders() as $name => $value) {
             if (0 === strcasecmp($name, 'Location')) {
-                return $value;
+                // A repeated Location header is malformed; the first occurrence wins.
+                return \is_array($value) ? $value[0] : $value;
             }
         }
 
@@ -337,7 +338,9 @@ class StreamWrapperHook implements LibraryHook
         $lines = [rtrim(HttpUtil::formatAsStatusString($response), "\r\n")];
 
         foreach ($response->getHeaders() as $name => $value) {
-            $lines[] = $name.': '.$value;
+            foreach (\is_array($value) ? $value : [$value] as $singleValue) {
+                $lines[] = $name.': '.$singleValue;
+            }
         }
 
         return $lines;

--- a/src/VCR/Response.php
+++ b/src/VCR/Response.php
@@ -16,7 +16,7 @@ class Response
     protected string $statusMessage = '';
 
     /**
-     * @var array<string,string>
+     * @var array<string, string|list<string>>
      */
     protected array $headers = [];
     protected ?string $body;
@@ -28,9 +28,9 @@ class Response
     protected mixed $httpVersion = null;
 
     /**
-     * @param string|array<string, string> $status
-     * @param array<string,string>         $headers
-     * @param array<string,mixed>          $curlInfo
+     * @param string|array<string, string>       $status
+     * @param array<string, string|list<string>> $headers
+     * @param array<string,mixed>                $curlInfo
      */
     final public function __construct($status, array $headers = [], ?string $body = null, array $curlInfo = [])
     {
@@ -83,11 +83,11 @@ class Response
     {
         $body = $response['body'] ?? null;
 
-        $gzip = isset($response['headers']['Content-Type'])
-            && str_contains($response['headers']['Content-Type'], 'application/x-gzip');
+        $contentType = self::firstHeaderValue($response['headers']['Content-Type'] ?? null);
+        $gzip = null !== $contentType && str_contains($contentType, 'application/x-gzip');
 
-        $binary = isset($response['headers']['Content-Transfer-Encoding'])
-            && 'binary' == $response['headers']['Content-Transfer-Encoding'];
+        $contentTransferEncoding = self::firstHeaderValue($response['headers']['Content-Transfer-Encoding'] ?? null);
+        $binary = 'binary' == $contentTransferEncoding;
 
         // Base64 decode when binary
         if ($gzip || $binary) {
@@ -108,6 +108,14 @@ class Response
     }
 
     /**
+     * @param string|list<string>|null $value
+     */
+    private static function firstHeaderValue($value): ?string
+    {
+        return \is_array($value) ? (reset($value) ?: null) : $value;
+    }
+
+    /**
      * @return array<string,mixed>|mixed|null
      */
     public function getCurlInfo(?string $option = null): mixed
@@ -123,7 +131,7 @@ class Response
     }
 
     /**
-     * @return array<string,string>
+     * @return array<string, string|list<string>>
      */
     public function getHeaders(): array
     {
@@ -142,11 +150,7 @@ class Response
 
     public function getHeader(string $key): ?string
     {
-        if (!isset($this->headers[$key])) {
-            return null;
-        }
-
-        return $this->headers[$key];
+        return self::firstHeaderValue($this->headers[$key] ?? null);
     }
 
     public function getHttpVersion(): mixed

--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -13,7 +13,8 @@ class HttpUtil
      *
      * @param string[] $headers List of headers. Example: ['Content-Type: text/html', '...']
      *
-     * @return array<string,string> Key/value pairs of headers, e.g. ['Content-Type' => 'text/html']
+     * @return array<string, string|list<string>> Key/value pairs of headers, e.g. ['Content-Type' => 'text/html'];
+     *                                            a header repeated in the raw list becomes a list of its values.
      */
     public static function parseHeaders(array $headers): array
     {
@@ -125,7 +126,7 @@ class HttpUtil
     /**
      * Returns a list of headers from a key/value paired array.
      *
-     * @param array<string,string|array<string,string>|null> $headers Headers as key/value pairs
+     * @param array<string, string|list<string>|null> $headers Headers as key/value pairs
      *
      * @return string[] List of headers ['Content-Type: text/html\r\n', '...'].
      */

--- a/src/VCR/Util/StreamHelper.php
+++ b/src/VCR/Util/StreamHelper.php
@@ -35,7 +35,9 @@ class StreamHelper
                 : HttpUtil::parseRawHeader($http['header']);
             $headers = HttpUtil::parseHeaders($rawHeaders);
             foreach ($headers as $key => $value) {
-                $request->setHeader($key, $value);
+                // A repeated header line collapses to a list; Request only models a single
+                // value per header, so the first occurrence wins.
+                $request->setHeader($key, \is_array($value) ? $value[0] : $value);
             }
         }
 

--- a/tests/Unit/LibraryHooks/StreamWrapperHookTest.php
+++ b/tests/Unit/LibraryHooks/StreamWrapperHookTest.php
@@ -79,6 +79,29 @@ final class StreamWrapperHookTest extends TestCase
         $hook->disable();
     }
 
+    public function testStreamGetMetaDataEmitsOneLinePerDuplicateHeaderValue(): void
+    {
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
+        $hook->enable(static fn ($request) => new Response(
+            ['code' => '200', 'message' => 'OK', 'http_version' => '1.1'],
+            ['Set-Cookie' => ['a=1; Path=/', 'b=2; Path=/']],
+            'body'
+        ));
+
+        $resource = fopen('http://example.com', 'r');
+        $this->assertIsResource($resource);
+
+        $meta = StreamWrapperHook::streamGetMetaData($resource);
+
+        $this->assertIsArray($meta['wrapper_data']);
+        $this->assertContains('Set-Cookie: a=1; Path=/', $meta['wrapper_data']);
+        $this->assertContains('Set-Cookie: b=2; Path=/', $meta['wrapper_data']);
+        $this->assertNotContains('Set-Cookie: Array', $meta['wrapper_data']);
+
+        fclose($resource);
+        $hook->disable();
+    }
+
     public function testStreamGetMetaDataPassesThroughForNonVcrStream(): void
     {
         $resource = fopen('php://memory', 'r');
@@ -121,6 +144,25 @@ final class StreamWrapperHookTest extends TestCase
             ++$calls;
             if (1 === $calls) {
                 return new Response('301', ['Location' => 'http://example.com/final'], 'moved');
+            }
+
+            return new Response('200', [], 'final body');
+        });
+        $hook->stream_open('http://example.com/start', 'r', 0, $openedPath);
+
+        $this->assertSame(2, $calls);
+        $this->assertSame('final body', $hook->stream_read(100));
+        $hook->disable();
+    }
+
+    public function testFollowsRedirectWithDuplicateLocationHeader(): void
+    {
+        $hook = new StreamWrapperHook(new StreamWrapperCodeTransform(), new StreamProcessor(new Configuration()));
+        $calls = 0;
+        $hook->enable(static function ($request) use (&$calls) {
+            ++$calls;
+            if (1 === $calls) {
+                return new Response('301', ['Location' => ['http://example.com/final', 'http://example.com/decoy']], 'moved');
             }
 
             return new Response('200', [], 'final body');

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -150,6 +150,78 @@ final class ResponseTest extends TestCase
         $this->assertEquals($expectedCurlOptions, $response->getCurlInfo());
     }
 
+    public function testGetHeaderReturnsFirstValueForDuplicateHeader(): void
+    {
+        $response = Response::fromArray([
+            'headers' => [
+                'Set-Cookie' => ['a=1; Path=/', 'b=2; Path=/'],
+            ],
+        ]);
+
+        $this->assertSame('a=1; Path=/', $response->getHeader('Set-Cookie'));
+    }
+
+    public function testGetHeadersPreservesAllValuesForDuplicateHeader(): void
+    {
+        $values = ['a=1; Path=/', 'b=2; Path=/'];
+
+        $response = Response::fromArray([
+            'headers' => ['Set-Cookie' => $values],
+        ]);
+
+        $this->assertSame($values, $response->getHeaders()['Set-Cookie']);
+    }
+
+    public function testGetContentTypeReturnsFirstValueForDuplicateContentType(): void
+    {
+        $response = Response::fromArray([
+            'headers' => [
+                'Content-Type' => ['application/json; charset=utf-8', 'application/json; charset=utf-8'],
+            ],
+        ]);
+
+        $this->assertSame('application/json; charset=utf-8', $response->getContentType());
+    }
+
+    public function testFromArrayDetectsGzipWithDuplicateContentType(): void
+    {
+        $body = 'this is an example body';
+        $responseArray = [
+            'headers' => ['Content-Type' => ['application/x-gzip', 'application/x-gzip']],
+            'body' => base64_encode($body),
+        ];
+
+        $response = Response::fromArray($responseArray);
+
+        $this->assertEquals($body, $response->getBody());
+    }
+
+    public function testFromArrayDetectsBinaryWithDuplicateContentTransferEncoding(): void
+    {
+        $body = 'this is an example body';
+        $responseArray = [
+            'headers' => ['Content-Transfer-Encoding' => ['binary', 'binary']],
+            'body' => base64_encode($body),
+        ];
+
+        $response = Response::fromArray($responseArray);
+
+        $this->assertEquals($body, $response->getBody());
+    }
+
+    public function testToArrayHandlesDuplicateContentTransferEncoding(): void
+    {
+        $body = 'this is an example body';
+        $response = new Response('200', [
+            'Content-Type' => 'application/octet-stream',
+            'Content-Transfer-Encoding' => ['binary', 'binary'],
+        ], $body);
+
+        $responseArray = $response->toArray();
+
+        $this->assertEquals(base64_encode($body), $responseArray['body']);
+    }
+
     public function testToArray(): void
     {
         $expectedArray = [

--- a/tests/Unit/Util/CurlHelperTest.php
+++ b/tests/Unit/Util/CurlHelperTest.php
@@ -546,6 +546,14 @@ final class CurlHelperTest extends TestCase
                 \CURLINFO_CERTINFO,
                 [['Subject' => 'CN=example.com']],
             ],
+            'size_download uses first value for a duplicated Content-Length header' => [
+                Response::fromArray([
+                    'status' => 200,
+                    'headers' => ['Content-Length' => ['123', '123']],
+                ]),
+                \CURLINFO_SIZE_DOWNLOAD,
+                '123',
+            ],
         ];
     }
 

--- a/tests/Unit/Util/StreamHelperTest.php
+++ b/tests/Unit/Util/StreamHelperTest.php
@@ -52,6 +52,13 @@ final class StreamHelperTest extends TestCase
                 },
             ],
 
+            'duplicate header line uses first value' => [
+                ['header' => "Set-Cookie: a=1\r\nSet-Cookie: b=2"],
+                static function (Request $request): void {
+                    Assert::assertEquals('a=1', $request->getHeader('Set-Cookie'));
+                },
+            ],
+
             'user_agent' => [
                 ['user_agent' => 'example'],
                 static function (Request $request): void {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | Fix #477
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

A server sending the same header name more than once (e.g. two `Set-Cookie` lines — legal per RFC 6265 — or a malformed duplicate `Content-Type`) already gets collapsed into an array value by `HttpUtil::parseHeaders()`. That shape round-trips through the cassette fine, but several consumers assumed a plain string and misbehaved:

- `Response::getHeader()`/`getContentType()` were declared `?string` yet returned the array, so `str_contains()` in the gzip/binary detection threw a `TypeError`.
- On the stream-wrapper replay path, `StreamWrapperHook::buildResponseHeaderLines()` concatenated the array straight into a string, emitting the literal line `Set-Cookie: Array` instead of the real header — corrupting the response exposed via `stream_get_meta_data()`.
- `StreamWrapperHook::locationHeader()` had the same assumption for redirect resolution.

Recording always worked; replaying or reading a response with duplicated headers either threw or produced a broken header block, on both the curl and the stream_wrapper hook.

Fix keeps the array-preserving model — the only RFC-safe option for `Set-Cookie` (values must never be comma-joined) — and normalizes every string-assuming consumer to the first value instead. `getHeader()` keeps its existing `?string` signature; the full list of values for a duplicated header stays available via `getHeaders()`. No public API changed.

```php
// Cassette recorded from a server sending two Set-Cookie headers:
// headers:
//   Set-Cookie:
//     - 'a=1; Path=/'
//     - 'b=2; Path=/'

$response->getHeader('Set-Cookie');   // 'a=1; Path=/' (first value, ?string contract honored)
$response->getHeaders()['Set-Cookie']; // ['a=1; Path=/', 'b=2; Path=/'] (full list, unchanged)
```

Widening `parseHeaders()`'s return type surfaced one more latent spot with the same assumption on the request side (`StreamHelper::createRequestFromStreamContext()` feeding `Request::setHeader()`), fixed the same way.
