### PR TITLE
test(httputil): cover 100 Continue with extra header

### DIFF
--- a/tests/Unit/Util/HttpUtilTest.php
+++ b/tests/Unit/Util/HttpUtilTest.php
@@ -97,6 +97,22 @@ final class HttpUtilTest extends TestCase
         $this->assertEquals($expectedHeaders, $headers);
     }
 
+    public function testParseContinueWithHeaderPlusResponse(): void
+    {
+        $raw = "HTTP/1.1 100 Continue\r\nX-Note: Gateway Ack\r\n\r\nHTTP/1.1 200 OK\r\nX-Backside-Transport: OK OK,OK OK\r\nContent-Type: text/xml\r\nContent-Length: 5\r\n\r\n<xml>";
+        [$status, $headers, $body] = HttpUtil::parseResponse($raw);
+
+        $expectedHeaders = [
+            'X-Backside-Transport: OK OK,OK OK',
+            'Content-Type: text/xml',
+            'Content-Length: 5',
+        ];
+
+        $this->assertEquals('HTTP/1.1 200 OK', $status);
+        $this->assertEquals('<xml>', $body);
+        $this->assertEquals($expectedHeaders, $headers);
+    }
+
     public function testParseResponseAfterProxyAcknowledgements(): void
     {
         $raw = "HTTP/1.0 200 Connection established\r\n\r\nHTTP/2 200\r\n\r\nHTTP/1.1 201 Created\r\nContent-Type: text/plain\r\nContent-Length: 15\r\n\r\nfirst\r\n\r\nsecond";


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | -
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

Adds regression coverage for the scenario reported in #335 — a `100 Continue`
response carrying an extra header (e.g. `X-Note: Gateway Ack`) before the real
response, which previously caused the wrong response to be recorded.

The generic informational-response handling introduced in `HttpUtil::parseResponse()`
(released in 1.11.1) already skips any headers between a `100 Continue` and the
following status line, so this scenario is covered without needing the
header-specific `str_replace` originally proposed in #335. This PR adds a test
that proves it.

Contributor checklist:
- All checks green: PHPUnit + PHPStan + PHP-CS-Fixer + editorconfig
- Verified locally on the Docker matrix: workspace80 (lowest/highest), workspace85 (lowest/highest)
- Conventional Commits, one logical change per commit