### PR TITLE
fix(curl): return bool from curlSetoptArray

### DIFF
--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -390,11 +390,15 @@ class CurlHook implements LibraryHook
      *
      * @param array<int, mixed> $options an array specifying which options to set and their values
      */
-    public static function curlSetoptArray(\CurlHandle $curlHandle, array $options): void
+    public static function curlSetoptArray(\CurlHandle $curlHandle, array $options): bool
     {
         foreach ($options as $option => $value) {
-            static::curlSetopt($curlHandle, $option, $value);
+            if (!static::curlSetopt($curlHandle, $option, $value)) {
+                return false;
+            }
         }
+
+        return true;
     }
 
     /**

--- a/tests/Unit/LibraryHooks/CurlHookTest.php
+++ b/tests/Unit/LibraryHooks/CurlHookTest.php
@@ -210,6 +210,25 @@ final class CurlHookTest extends TestCase
         $this->curlHook->disable();
     }
 
+    public function testShouldReturnTrueFromSetoptArray(): void
+    {
+        $this->curlHook->enable($this->getTestCallback());
+
+        $curlHandle = curl_init('http://example.com');
+        Assertion::notSame($curlHandle, false);
+        $result = curl_setopt_array(
+            $curlHandle,
+            [
+                \CURLOPT_RETURNTRANSFER => true,
+            ]
+        );
+        curl_close($curlHandle);
+
+        $this->assertTrue($result, 'curl_setopt_array() should return true on success.');
+
+        $this->curlHook->disable();
+    }
+
     public function testShouldReturnCurlInfoStatusCode(): void
     {
         $this->curlHook->enable($this->getTestCallback());


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | Fixes #481
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

`CurlHook::curlSetoptArray()` had a `void` return type, while the native `curl_setopt_array()` returns
`bool`. Code using `curl_setopt_array(` gets rewritten to call this method (see
`CurlCodeTransform`), so any library that checks the return value received `null` instead of a proper
`bool` while VCR was active — reported against the Twilio PHP SDK.

This now returns `true` if every option was set successfully, and `false` as soon as one option fails
to be set, matching the native function's short-circuit behavior.

Builds on the fix originally proposed in #267 by @lpradovera, extended to cover the failure case.
That PR will be closed in favor of this one.