### PR TITLE
fix(curl): set method to HEAD for CURLOPT_NOBODY

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -235,6 +235,11 @@ class CurlHelper
             case \CURLOPT_CUSTOMREQUEST:
                 $request->setCurlOption(\CURLOPT_CUSTOMREQUEST, $value);
                 break;
+            case \CURLOPT_NOBODY:
+                if (true == $value && 'GET' === $request->getMethod()) {
+                    $request->setMethod('HEAD');
+                }
+                break;
             case \CURLOPT_POST:
                 if (true == $value) {
                     $request->setMethod('POST');

--- a/tests/Unit/Util/CurlHelperTest.php
+++ b/tests/Unit/Util/CurlHelperTest.php
@@ -579,6 +579,25 @@ final class CurlHelperTest extends TestCase
         $this->assertEquals('DELETE', $request->getMethod());
     }
 
+    public function testSetCurlOptionNoBodySetsMethodToHead(): void
+    {
+        $request = new Request('GET', 'http://example.com');
+
+        CurlHelper::setCurlOptionOnRequest($request, \CURLOPT_NOBODY, true);
+
+        $this->assertEquals('HEAD', $request->getMethod());
+    }
+
+    public function testSetCurlOptionNoBodyDoesNotOverridePostMethod(): void
+    {
+        $request = new Request('GET', 'http://example.com');
+
+        CurlHelper::setCurlOptionOnRequest($request, \CURLOPT_POST, true);
+        CurlHelper::setCurlOptionOnRequest($request, \CURLOPT_NOBODY, true);
+
+        $this->assertEquals('POST', $request->getMethod());
+    }
+
     /**
      * Function used for testing CURLOPT_HEADERFUNCTION.
      *


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | Fix #483
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| License          | MIT

Setting `curl_setopt($ch, CURLOPT_NOBODY, true)` implicitly sets the request method to `HEAD`
per the PHP manual. VCR's curl hook had no case for `CURLOPT_NOBODY`, so it fell through to the
generic default handling and the recorded method stayed `GET`. This affected Guzzle 3's `head()`
client and any code setting `CURLOPT_NOBODY` directly.

`CurlHelper::setCurlOptionOnRequest()` now sets the method to `HEAD` when `CURLOPT_NOBODY` is
`true` and the method is still `GET`, mirroring the existing `CURLOPT_POST` handling. The
`GET`-only guard avoids overriding a method already set via `CURLOPT_POST` or
`CURLOPT_CUSTOMREQUEST`.

Verified on the Docker matrix: workspace80 (phpstan, cs, ec, tests lowest/highest) and
workspace85 (tests lowest/highest) — all green.

Originally reported with a fix proposed in #226 by @snelg; adapted here for the current codebase
(pathing and method signatures have since changed, and the original branch conflicts with
master).