### PR TITLE
fix: shorten context7.json rule to fit schema limit

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -14,6 +14,6 @@
     "Storage formats are yaml and json, configured via VCR::configure()->setStorage()",
     "By default requests are matched by method and url only — enable additional matchers (host, headers, body, post_fields, query_string) via VCR::configure()->enableRequestMatchers([...])",
     "Redacting a request body in a VCR_BEFORE_RECORD listener breaks replay unless the body/post_fields matchers are also narrowed to ignore the redacted parts",
-    "When using the curl or soap library hooks, call VCR::turnOn(); VCR::turnOff(); once at bootstrap, right after the Composer autoloader and before any application code is included — this registers the file:// stream wrapper that rewrites curl_*/SoapClient calls in code loaded later; skipping it means the hooks never intercept those calls"
+    "With curl/soap hooks, call VCR::turnOn(); VCR::turnOff(); once at bootstrap, right after the autoloader — this registers the stream wrapper that later rewrites curl_*/SoapClient calls; skipping it disables interception"
   ]
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bug
| Fixes            | Fixes #488
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| Docs updated?    | n/a
| License          | MIT

Follow-up to #491: one of the `rules` entries added to `context7.json` in that PR exceeded the
schema's 255-character limit per rule (it was 337 characters), so `context7.json` was invalid
against `https://context7.com/schema/context7.json` on master.

Shortens the bootstrap `VCR::turnOn(); VCR::turnOff();` rule to the same meaning within the limit.
Verified the whole file against the downloaded schema with `jsonschema` — no violations remain.