### PR TITLE
feat: inject custom storage via StorageFactoryInterface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ php-vcr's documentation is a projection of the **current** codebase — never wr
 docs/
   index.md, getting-started.md, requirements.md, upgrading.md
   guides/    — explanation: how a mechanism works and why (how-vcr-works, cassettes, record-modes, request-matching)
-  howto/     — task recipes (use-with-phpunit, use-with-codeception, filter-sensitive-data, custom-request-matcher, select-library-hooks, record-soap)
+  howto/     — task recipes (use-with-phpunit, use-with-codeception, filter-sensitive-data, custom-request-matcher, custom-storage, select-library-hooks, record-soap)
   reference/ — exhaustive lookup, one page per surface (vcr-facade, configuration, request-matchers, library-hooks, storage-backends, events, request-response)
 ```
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Full documentation — searchable, versioned, dark mode — lives at
 
 * [Getting Started](docs/getting-started.md) · [How VCR works](docs/guides/how-vcr-works.md)
 * [Cassettes](docs/guides/cassettes.md) · [Record Modes](docs/guides/record-modes.md) · [Request Matching](docs/guides/request-matching.md)
-* How-to: [PHPUnit](docs/howto/use-with-phpunit.md) · [Codeception](docs/howto/use-with-codeception.md) · [Filter sensitive data](docs/howto/filter-sensitive-data.md) · [SOAP](docs/howto/record-soap.md)
+* How-to: [PHPUnit](docs/howto/use-with-phpunit.md) · [Codeception](docs/howto/use-with-codeception.md) · [Filter sensitive data](docs/howto/filter-sensitive-data.md) · [SOAP](docs/howto/record-soap.md) · [Storage factory / custom storage](docs/howto/custom-storage.md)
 * Reference: [Configuration](docs/reference/configuration.md) · [Events](docs/reference/events.md) · [Storage backends](docs/reference/storage-backends.md)
 
 ## Contributing

--- a/context7.json
+++ b/context7.json
@@ -11,7 +11,8 @@
     "Call VCR::turnOn() before any code using curl_* or SoapClient is loaded, and VCR::insertCassette() before making requests",
     "Always call VCR::eject() and VCR::turnOff() after the test to detach the cassette and disable interception",
     "Record modes are once (default), new_episodes, and none — set via VCR::configure()->setMode()",
-    "Storage formats are yaml and json, configured via VCR::configure()->setStorage()",
+    "Built-in storage formats are yaml (default), json, and blackhole, selected via VCR::configure()->setStorage() — deprecated since 1.12 in favor of setStorageFactory()",
+    "Inject a custom storage backend (e.g. database-backed) via VCR::configure()->setStorageFactory(new MyFactory()), implementing StorageFactoryInterface::create(): StorageInterface",
     "By default requests are matched by method and url only — enable additional matchers (host, headers, body, post_fields, query_string) via VCR::configure()->enableRequestMatchers([...])",
     "Redacting a request body in a VCR_BEFORE_RECORD listener breaks replay unless the body/post_fields matchers are also narrowed to ignore the redacted parts",
     "With curl/soap hooks, call VCR::turnOn(); VCR::turnOff(); once at bootstrap, right after the autoloader — this registers the stream wrapper that later rewrites curl_*/SoapClient calls; skipping it disables interception"

--- a/docs/guides/record-modes.md
+++ b/docs/guides/record-modes.md
@@ -72,7 +72,7 @@ file_get_contents('http://example.com'); // always a real request, always re-rec
 > **⚠️ Warning:** a run under `all` that performs no HTTP request leaves an **empty** cassette — that's
 > inherent to "purge first, then re-record," not a bug.
 
-- **Requires** a storage that implements `PurgeableStorage` — all three built-in backends
+- **Requires** a storage that implements `PurgeableStorageInterface` — all three built-in backends
   ([`yaml`](../reference/storage-backends.md#yaml), [`json`](../reference/storage-backends.md#json),
   [`blackhole`](../reference/storage-backends.md#blackhole)) do.
 

--- a/docs/howto/custom-request-matcher.md
+++ b/docs/howto/custom-request-matcher.md
@@ -38,4 +38,4 @@ Now a request only replays if the method, path, **and** the custom header all ag
 (other headers, body, query string) is ignored for matching purposes.
 
 ---
-← [Filter sensitive data](filter-sensitive-data.md) · Next: [Select library hooks](select-library-hooks.md) →
+← [Filter sensitive data](filter-sensitive-data.md) · Next: [Custom storage](custom-storage.md) →

--- a/docs/howto/custom-storage.md
+++ b/docs/howto/custom-storage.md
@@ -250,8 +250,8 @@ storage must be able to reset itself. That requires implementing `\VCR\Storage\P
 throws:
 
 ```text
-LogicException: Storage "InMemoryStorage" does not support MODE_ALL: implement PurgeableStorageInterface to
-enable purge on cassette insert.
+LogicException: Storage "App\Storage\InMemoryStorage" does not support MODE_ALL: implement
+PurgeableStorageInterface to enable purge on cassette insert.
 ```
 
 `PdoStorage` already implements `PurgeableStorageInterface` and its `purge()` deletes every row for the

--- a/docs/howto/custom-storage.md
+++ b/docs/howto/custom-storage.md
@@ -19,7 +19,7 @@ needs.
 ## In-memory storage
 
 The smallest possible backend — no dependencies, storage lives in a plain PHP array. It shows the full
-`\VCR\Storage\StorageInterface` contract: the four `\Iterator` methods (`current()`, `key()`, `next()`,
+`\VCR\Storage\StorageInterface` contract: the five `\Iterator` methods (`current()`, `key()`, `next()`,
 `rewind()`, `valid()`) plus `storeRecording()` and `isNew()`.
 
 ```php

--- a/docs/howto/custom-storage.md
+++ b/docs/howto/custom-storage.md
@@ -1,0 +1,275 @@
+# Custom Storage Backend
+
+> One-liner: implement `StorageFactoryInterface` to serialize cassettes anywhere — not just the bundled
+> YAML/JSON files — and inject whatever dependency the backend needs (a database connection, a client, ...).
+>
+> **🆕 Since 1.12**
+
+**On this page:** [In-memory storage](#in-memory-storage) · [Database-backed storage](#database-backed-storage) ·
+[Supporting MODE_ALL](#supporting-mode_all) · [Migrating from setStorage()](#migrating-from-setstorage)
+
+Use this when none of the built-in [storage backends](../reference/storage-backends.md) fit — for example,
+cassettes need to live in a database rather than a file, or a test double needs to inject a connection the
+storage itself doesn't know how to construct. Before 1.12, the only way to pick a storage was
+`setStorage()`, which only ever accepted one of three fixed name strings (`yaml`/`json`/`blackhole`) for
+exactly that reason: there's no way to hand a constructed dependency to a class-name string.
+`setStorageFactory()` takes an object instead, so the factory can carry whatever dependency the storage
+needs.
+
+## In-memory storage
+
+The smallest possible backend — no dependencies, storage lives in a plain PHP array. It shows the full
+`\VCR\Storage\StorageInterface` contract: the four `\Iterator` methods (`current()`, `key()`, `next()`,
+`rewind()`, `valid()`) plus `storeRecording()` and `isNew()`.
+
+```php
+namespace App\Storage;
+
+use VCR\Storage\StorageInterface;
+
+final class InMemoryStorage implements StorageInterface
+{
+    private int $position = 0;
+
+    /**
+     * @param array<int, array<string,mixed>> $recordings shared with the factory that created this storage
+     */
+    public function __construct(private array &$recordings)
+    {
+    }
+
+    public function storeRecording(array $recording): void
+    {
+        $this->recordings[] = $recording;
+    }
+
+    public function isNew(): bool
+    {
+        return [] === $this->recordings;
+    }
+
+    public function current(): ?array
+    {
+        return $this->recordings[$this->position] ?? null;
+    }
+
+    public function key(): int
+    {
+        return $this->position;
+    }
+
+    public function next(): void
+    {
+        ++$this->position;
+    }
+
+    public function rewind(): void
+    {
+        $this->position = 0;
+    }
+
+    public function valid(): bool
+    {
+        return isset($this->recordings[$this->position]);
+    }
+}
+```
+
+A `\VCR\Storage\StorageFactoryInterface` implementation only has to build one of these per cassette. Keeping the
+array on the factory, keyed by cassette name, means every `insertCassette()` call for the same name inside one
+process reuses the same records:
+
+```php
+namespace App\Storage;
+
+use VCR\Storage\StorageFactoryInterface;
+use VCR\Storage\StorageInterface;
+
+final class InMemoryStorageFactory implements StorageFactoryInterface
+{
+    /** @var array<string, array<int, array<string,mixed>>> */
+    private array $recordingsByCassette = [];
+
+    public function create(string $cassettePath, string $cassetteName): StorageInterface
+    {
+        $this->recordingsByCassette[$cassetteName] ??= [];
+
+        return new InMemoryStorage($this->recordingsByCassette[$cassetteName]);
+    }
+}
+```
+
+```php
+\VCR\VCR::configure()->setStorageFactory(new \App\Storage\InMemoryStorageFactory());
+```
+
+> **📌 Note:** the array lives only as long as the PHP process does. That's fine for a test that records and
+> replays within the same run, but it means recordings don't survive between separate invocations the way a
+> file or database would — pick a backend that persists to disk or a database if you need cassettes to outlive
+> the process that recorded them (see below).
+
+## Database-backed storage
+
+A storage backed by SQLite via `PDO` — the recordings persist across separate PHP processes, so a suite can
+record once and replay in a later run, same as with the YAML/JSON backends. The factory receives the `\PDO`
+connection as a constructor dependency and hands it, together with the cassette name, to each storage it
+creates:
+
+```php
+namespace App\Storage;
+
+use VCR\Storage\PurgeableStorageInterface;
+
+final class PdoStorage implements PurgeableStorageInterface
+{
+    private int $position = 0;
+
+    /** @var array<string,mixed>|null */
+    private ?array $current = null;
+
+    private bool $isNew;
+
+    public function __construct(private \PDO $pdo, private string $cassette)
+    {
+        $this->pdo->exec(
+            'CREATE TABLE IF NOT EXISTS recordings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                cassette TEXT NOT NULL,
+                recording TEXT NOT NULL
+            )'
+        );
+
+        $statement = $this->pdo->prepare('SELECT COUNT(*) FROM recordings WHERE cassette = :cassette');
+        $statement->execute(['cassette' => $this->cassette]);
+        $this->isNew = 0 === (int) $statement->fetchColumn();
+    }
+
+    public function storeRecording(array $recording): void
+    {
+        $statement = $this->pdo->prepare(
+            'INSERT INTO recordings (cassette, recording) VALUES (:cassette, :recording)'
+        );
+        $statement->execute([
+            'cassette' => $this->cassette,
+            'recording' => json_encode($recording),
+        ]);
+    }
+
+    public function isNew(): bool
+    {
+        return $this->isNew;
+    }
+
+    public function current(): ?array
+    {
+        return $this->current;
+    }
+
+    public function key(): int
+    {
+        return $this->position;
+    }
+
+    public function next(): void
+    {
+        ++$this->position;
+        $this->loadCurrent();
+    }
+
+    public function rewind(): void
+    {
+        $this->position = 0;
+        $this->loadCurrent();
+    }
+
+    public function valid(): bool
+    {
+        return null !== $this->current;
+    }
+
+    public function purge(): void
+    {
+        $statement = $this->pdo->prepare('DELETE FROM recordings WHERE cassette = :cassette');
+        $statement->execute(['cassette' => $this->cassette]);
+
+        $this->position = 0;
+        $this->current = null;
+        $this->isNew = true;
+    }
+
+    private function loadCurrent(): void
+    {
+        $statement = $this->pdo->prepare(
+            'SELECT recording FROM recordings WHERE cassette = :cassette ORDER BY id LIMIT 1 OFFSET :offset'
+        );
+        $statement->bindValue('cassette', $this->cassette);
+        $statement->bindValue('offset', $this->position, \PDO::PARAM_INT);
+        $statement->execute();
+        $recording = $statement->fetchColumn();
+        $this->current = false !== $recording ? json_decode($recording, true) : null;
+    }
+}
+```
+
+```php
+namespace App\Storage;
+
+use VCR\Storage\StorageFactoryInterface;
+use VCR\Storage\StorageInterface;
+
+final class PdoStorageFactory implements StorageFactoryInterface
+{
+    public function __construct(private \PDO $pdo)
+    {
+    }
+
+    public function create(string $cassettePath, string $cassetteName): StorageInterface
+    {
+        return new PdoStorage($this->pdo, $cassetteName);
+    }
+}
+```
+
+```php
+$pdo = new \PDO('sqlite:'.__DIR__.'/cassettes.sqlite');
+
+\VCR\VCR::configure()->setStorageFactory(new \App\Storage\PdoStorageFactory($pdo));
+```
+
+This is the case a class-name string can't cover: `PdoStorage` needs the `$pdo` connection at construction
+time, and the factory is what carries that dependency from application setup to the moment php-vcr actually
+creates the storage.
+
+## Supporting `MODE_ALL`
+
+[`MODE_ALL`](../guides/record-modes.md#all) purges the cassette on every `insertCassette()`, so the configured
+storage must be able to reset itself. That requires implementing `\VCR\Storage\PurgeableStorageInterface`
+(adds one method, `purge()`) instead of the plain `StorageInterface`.
+
+`InMemoryStorage` above only implements `StorageInterface` — inserting a cassette under `MODE_ALL` with it
+throws:
+
+```text
+LogicException: Storage "InMemoryStorage" does not support MODE_ALL: implement PurgeableStorageInterface to
+enable purge on cassette insert.
+```
+
+`PdoStorage` already implements `PurgeableStorageInterface` and its `purge()` deletes every row for the
+current cassette, so it works with `MODE_ALL` without any further changes.
+
+## Migrating from `setStorage()`
+
+`setStorage()`/`getStorage()` were the original, name-based way to select a storage — before 1.12 they only
+ever supported the three built-in names. They're deprecated in favour of `setStorageFactory()`/`getStorageFactory()`
+— see [Upgrading → Deprecations](../upgrading.md#deprecations) for the full mapping.
+
+```php
+// before
+\VCR\VCR::configure()->setStorage('json');
+
+// after
+\VCR\VCR::configure()->setStorageFactory(new \VCR\Storage\JsonStorageFactory());
+```
+
+---
+← [Custom matcher](custom-request-matcher.md) · Next: [Select library hooks](select-library-hooks.md) →

--- a/docs/howto/select-library-hooks.md
+++ b/docs/howto/select-library-hooks.md
@@ -32,4 +32,4 @@ the ones listed.
 > fixes it. `stream_wrapper` has no such restriction.
 
 ---
-← [Custom request matcher](custom-request-matcher.md) · Next: [Record SOAP requests](record-soap.md) →
+← [Custom storage](custom-storage.md) · Next: [Record SOAP requests](record-soap.md) →

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ You're in the docs. Full pitch, badges and a 30-second example live in the
 | 🎞️ **[Cassettes](guides/cassettes.md)** | What gets recorded, the file format, identical-request sequencing. |
 | 🎬 **[Record Modes](guides/record-modes.md)** | `new_episodes` / `once` / `none` / `all` — and when to use which. |
 | 🎯 **[Request Matching](guides/request-matching.md)** | How php-vcr decides a request "matches" a recording. |
-| 🧑‍🍳 **How-to** | [PHPUnit](howto/use-with-phpunit.md) · [Codeception](howto/use-with-codeception.md) · [Filter sensitive data](howto/filter-sensitive-data.md) · [Custom matcher](howto/custom-request-matcher.md) · [Select hooks](howto/select-library-hooks.md) · [SOAP](howto/record-soap.md) |
+| 🧑‍🍳 **How-to** | [PHPUnit](howto/use-with-phpunit.md) · [Codeception](howto/use-with-codeception.md) · [Filter sensitive data](howto/filter-sensitive-data.md) · [Custom matcher](howto/custom-request-matcher.md) · [Custom storage](howto/custom-storage.md) · [Select hooks](howto/select-library-hooks.md) · [SOAP](howto/record-soap.md) |
 | 📖 **Reference** | [VCR facade](reference/vcr-facade.md) · [Configuration](reference/configuration.md) · [Request matchers](reference/request-matchers.md) · [Library hooks](reference/library-hooks.md) · [Storage backends](reference/storage-backends.md) · [Events](reference/events.md) · [Request/Response](reference/request-response.md) |
 | 🆙 **[Upgrading](upgrading.md)** | Breaking changes by version. |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -10,7 +10,7 @@
 \VCR\VCR::turnOn();
 ```
 
-**On this page:** [cassette-path](#cassette-path) · [mode](#mode) · [storage](#storage) · [library-hooks](#library-hooks) · [request-matchers](#request-matchers) · [white/blacklist](#white---blacklist) · [record-identical-requests](#record-identical-requests)
+**On this page:** [cassette-path](#cassette-path) · [mode](#mode) · [storage-factory](#storage-factory) · [storage](#storage) · [library-hooks](#library-hooks) · [request-matchers](#request-matchers) · [white/blacklist](#white---blacklist) · [record-identical-requests](#record-identical-requests)
 
 Every entry below follows the same shape: **Values · Default · Description · Example · Notes**.
 
@@ -39,11 +39,36 @@ Every entry below follows the same shape: **Values · Default · Description · 
 \VCR\VCR::configure()->setMode(\VCR\VCR::MODE_ONCE);
 ```
 
+## `storage-factory`
+
+> **🆕 Since 1.12**
+
+- **Setter/Getter:** `setStorageFactory(StorageFactoryInterface $storageFactory): self` /
+  `getStorageFactory(): StorageFactoryInterface`
+- **Values:** any `StorageFactoryInterface` implementation — the three built-ins are
+  `\VCR\Storage\YamlStorageFactory`, `\VCR\Storage\JsonStorageFactory`, `\VCR\Storage\BlackholeStorageFactory`
+- **Default:** `YamlStorageFactory`, created lazily on the first `getStorageFactory()` call
+- Which [storage backend](storage-backends.md) serializes cassettes to disk. Implement your own factory to plug
+  in a custom backend (e.g. a database) — see [Custom storage backend](../howto/custom-storage.md).
+
+```php
+\VCR\VCR::configure()->setStorageFactory(new \VCR\Storage\JsonStorageFactory());
+```
+
+> **💡 Tip:** switch to `JsonStorageFactory` if you hit a segfault recording very large requests/responses —
+> that's a known PCRE backtrack-limit issue with the YAML parser (raise `pcre.backtrack_limit` in `php.ini`, or
+> use JSON).
+
 ## `storage`
 
 - **Setter/Getter:** `setStorage(string $name): self` / `getStorage(): string` (returns the resolved class name)
+
+> **🗑️ Deprecated since 1.12** — use [`storage-factory`](#storage-factory) instead.
+
 - **Values:** `yaml` · `json` · `blackhole`
 - **Default:** `yaml`
+- **Throws:** `getStorage()` throws `VCRException` if a custom (non-built-in) storage factory is configured — its
+  class name can't be resolved ahead of time; use [`getStorageFactory()`](#storage-factory) instead.
 - Which [storage backend](storage-backends.md) serializes cassettes to disk.
 
 ```php

--- a/docs/reference/storage-backends.md
+++ b/docs/reference/storage-backends.md
@@ -2,14 +2,16 @@
 
 > One-liner: cassettes are files on disk, serialized as YAML (default), JSON, or nowhere at all (Blackhole).
 
-**On this page:** [yaml](#yaml) · [json](#json) · [blackhole](#blackhole) · [Cassette file naming](#cassette-file-naming)
+**On this page:** [yaml](#yaml) · [json](#json) · [blackhole](#blackhole) ·
+[Custom storage backend](#custom-storage-backend) · [Cassette file naming](#cassette-file-naming)
 
-Select via [`setStorage()`](configuration.md#storage). All three implement `PurgeableStorage`, so all three
-work with [`MODE_ALL`](../guides/record-modes.md#all).
+Select via [`setStorageFactory()`](configuration.md#storage-factory). All three implement
+`PurgeableStorageInterface`, so all three work with [`MODE_ALL`](../guides/record-modes.md#all).
 
 ## `yaml`
 
 - **Default.**
+- **Factory:** `\VCR\Storage\YamlStorageFactory`
 - One YAML list entry per recording, appended as it's recorded — streamed one record at a time rather than
   parsed whole into memory.
 
@@ -32,6 +34,7 @@ work with [`MODE_ALL`](../guides/record-modes.md#all).
 
 ## `json`
 
+- **Factory:** `\VCR\Storage\JsonStorageFactory`
 - Pretty-printed JSON array, parsed/written incrementally (character-by-character) rather than all at once.
 
 ```json
@@ -46,6 +49,7 @@ work with [`MODE_ALL`](../guides/record-modes.md#all).
 
 ## `blackhole`
 
+- **Factory:** `\VCR\Storage\BlackholeStorageFactory`
 - Discards everything. `storeRecording()` and `purge()` are no-ops, `isNew()` always returns `true`, and the
   iterator is always empty — nothing is ever replayed.
 
@@ -53,6 +57,28 @@ work with [`MODE_ALL`](../guides/record-modes.md#all).
 > created, even after `insertCassette()`.
 
 - Useful for smoke-testing library-hook behaviour without leaving cassette files behind.
+
+## Custom storage backend
+
+> **🆕 Since 1.12**
+
+Any backend — not just files on disk — can serialize cassettes as long as it implements
+`\VCR\Storage\StorageFactoryInterface`:
+
+```php
+interface StorageFactoryInterface
+{
+    public function create(string $cassettePath, string $cassetteName): StorageInterface;
+}
+```
+
+`create()` returns a `\VCR\Storage\StorageInterface` — an `\Iterator` over recorded request/response pairs plus
+`storeRecording()` and `isNew()`. Implement `\VCR\Storage\PurgeableStorageInterface` (adds `purge()`) instead if
+the backend should support [`MODE_ALL`](../guides/record-modes.md#all).
+
+The three built-ins above are ordinary `StorageFactoryInterface` implementations and a good template to
+start from. See [Custom storage backend](../howto/custom-storage.md) for two runnable examples, including one
+backed by a database.
 
 ## Cassette file naming
 

--- a/docs/reference/vcr-facade.md
+++ b/docs/reference/vcr-facade.md
@@ -30,7 +30,7 @@
 - **Params:** `$cassetteName` — file name (no extension needed) relative to the configured cassette path.
   May contain path separators to nest cassettes in subfolders.
 - **Throws:** `\LogicException` if [`mode`](configuration.md#mode) is `all` and the configured storage doesn't
-  implement `PurgeableStorage`.
+  implement `PurgeableStorageInterface`.
 - Creates the storage + cassette, purges it first if mode is `all`, and enables library hooks.
 
 ```php

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -52,6 +52,10 @@ string.
 built-in storages (`Yaml`, `Json`, `Blackhole`) satisfy both interface generations, so existing
 `instanceof PurgeableStorage` checks keep working unchanged.
 
+If you previously injected a custom storage by subclassing `Configuration` and overriding `getStorage()`,
+switch to `setStorageFactory()` — the class name returned by `getStorage()` is no longer used to construct the
+storage, so an overridden `getStorage()` is now silently ignored.
+
 ## Current status
 
 php-vcr has stayed within the `1.x` line since its first release — no major version bump has happened yet, so

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -4,7 +4,8 @@
 > [GitHub Releases](https://github.com/php-vcr/php-vcr/releases); this page collects upgrade steps by impact
 > when a major happens.
 
-**On this page:** [How this page works](#how-this-page-works) · [Current status](#current-status)
+**On this page:** [How this page works](#how-this-page-works) · [Deprecations](#deprecations) ·
+[Current status](#current-status)
 
 ## How this page works
 
@@ -17,12 +18,47 @@ Every entry, once one exists, follows the same shape:
 New entries land here in the same PR as the breaking change itself — see the documentation requirement in
 [CONTRIBUTING.md](https://github.com/php-vcr/php-vcr/blob/master/CONTRIBUTING.md).
 
+Deprecation entries follow the same shape but mark something that still works in `1.x` and is only removed in
+the next major — no upgrade is required until then, but new code should prefer the replacement.
+
+## Deprecations
+
+### Deprecated in 1.12
+
+**Impact: Low** — nothing breaks in `1.x`; the deprecated API keeps working until the next major.
+
+Name-based storage selection (`setStorage()`/`getStorage()`) and the suffixless `Storage`/`PurgeableStorage`
+interfaces are deprecated in favour of the typed [`StorageFactoryInterface`](reference/configuration.md#storage-factory)
+contract — see [Custom storage backend](howto/custom-storage.md) for why a factory replaces a class-name
+string.
+
+| Deprecated | Replacement |
+|---|---|
+| `Configuration::setStorage('json')` | `Configuration::setStorageFactory(new \VCR\Storage\JsonStorageFactory())` |
+| `Configuration::getStorage()` | `Configuration::getStorageFactory()` |
+| `VCR\Storage\Storage` | `VCR\Storage\StorageInterface` |
+| `VCR\Storage\PurgeableStorage` | `VCR\Storage\PurgeableStorageInterface` |
+
+```php
+// before
+\VCR\VCR::configure()->setStorage('json');
+
+// after
+\VCR\VCR::configure()->setStorageFactory(new \VCR\Storage\JsonStorageFactory());
+```
+
+`getStorage()` still works for the three built-in storages, but throws `VCRException` once a custom
+`StorageFactoryInterface` is configured — its resulting storage class can't be resolved ahead of time. The
+built-in storages (`Yaml`, `Json`, `Blackhole`) satisfy both interface generations, so existing
+`instanceof PurgeableStorage` checks keep working unchanged.
+
 ## Current status
 
 php-vcr has stayed within the `1.x` line since its first release — no major version bump has happened yet, so
 there are no breaking upgrade steps to document. Minor and patch releases are required to stay
 backwards-compatible; see the full changelog on
-[GitHub Releases](https://github.com/php-vcr/php-vcr/releases) for what shipped in each one.
+[GitHub Releases](https://github.com/php-vcr/php-vcr/releases) for what shipped in each one, and
+[Deprecations](#deprecations) above for what to migrate away from ahead of the next one.
 
 ---
 ← [Documentation home](index.md)

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace VCR;
 
-use VCR\Storage\Storage;
+use VCR\Storage\StorageInterface;
 
 /**
  * A Cassette records and plays back pairs of Requests and Responses in a Storage.
@@ -12,12 +12,12 @@ use VCR\Storage\Storage;
 class Cassette
 {
     /**
-     * @param Storage<array> $storage
+     * @param StorageInterface<array> $storage
      */
     public function __construct(
         protected string $name,
         protected Configuration $config,
-        protected Storage $storage
+        protected StorageInterface $storage
     ) {
     }
 

--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace VCR;
 
+use VCR\Storage\Blackhole;
+use VCR\Storage\BlackholeStorageFactory;
+use VCR\Storage\Json;
+use VCR\Storage\JsonStorageFactory;
+use VCR\Storage\StorageFactoryInterface;
+use VCR\Storage\StorageInterface;
+use VCR\Storage\Yaml;
+use VCR\Storage\YamlStorageFactory;
 use VCR\Util\Assertion;
 
 /**
@@ -16,6 +24,28 @@ use VCR\Util\Assertion;
  */
 class Configuration
 {
+    /**
+     * Storage names accepted by the deprecated setStorage().
+     *
+     * @var array<string, class-string<StorageFactoryInterface>>
+     */
+    private const DEPRECATED_STORAGE_FACTORIES = [
+        'blackhole' => BlackholeStorageFactory::class,
+        'json' => JsonStorageFactory::class,
+        'yaml' => YamlStorageFactory::class,
+    ];
+
+    /**
+     * Storage class the deprecated getStorage() reports per built-in factory.
+     *
+     * @var array<class-string<StorageFactoryInterface>, class-string<StorageInterface>>
+     */
+    private const DEPRECATED_STORAGE_CLASSES = [
+        BlackholeStorageFactory::class => Blackhole::class,
+        JsonStorageFactory::class => Json::class,
+        YamlStorageFactory::class => Yaml::class,
+    ];
+
     private string $cassettePath = 'tests/fixtures';
 
     /**
@@ -46,30 +76,12 @@ class Configuration
     ];
 
     /**
-     * Name of the enabled storage.
+     * Factory creating the Storage for an inserted cassette.
      *
-     * Only one storage can be enabled at a time.
-     * By default YAML is enabled.
-     *
-     * @var string enabled storage name
+     * Only one factory is active at a time. Created lazily in
+     * getStorageFactory() so the default stays a plain YAML storage.
      */
-    private $enabledStorage = 'yaml';
-
-    /**
-     * List of enabled storages.
-     *
-     * Format:
-     * array(
-     *  'name' => 'class name'
-     * )
-     *
-     * @var array<string, class-string> List of available storages
-     */
-    private $availableStorages = [
-        'blackhole' => 'VCR\Storage\Blackhole',
-        'json' => 'VCR\Storage\Json',
-        'yaml' => 'VCR\Storage\Yaml',
-    ];
+    private ?StorageFactoryInterface $storageFactory = null;
 
     /**
      * A value of null means all RequestMatchers are enabled.
@@ -223,13 +235,50 @@ class Configuration
     /**
      * Returns the class name of the storage to use.
      *
-     * Objects are created in the VCRFactory.
-     *
      * @return string class name of the storage to use
+     *
+     * @throws VCRException if a custom storage factory is configured, whose
+     *                      storage class cannot be resolved up front
+     *
+     * @deprecated since 1.12, use {@see self::getStorageFactory()}. Removed in
+     *             the next major.
      */
     public function getStorage(): string
     {
-        return $this->availableStorages[$this->enabledStorage];
+        $factoryClass = \get_class($this->getStorageFactory());
+
+        if (!isset(self::DEPRECATED_STORAGE_CLASSES[$factoryClass])) {
+            throw new VCRException(\sprintf('Cannot resolve a storage class name for storage factory "%s". Please use getStorageFactory() instead.', $factoryClass), 0);
+        }
+
+        return self::DEPRECATED_STORAGE_CLASSES[$factoryClass];
+    }
+
+    /**
+     * Returns the StorageFactory used to create a Storage per cassette.
+     *
+     * Defaults to a YAML storage when no factory was configured.
+     */
+    public function getStorageFactory(): StorageFactoryInterface
+    {
+        if (null === $this->storageFactory) {
+            $this->storageFactory = new YamlStorageFactory();
+        }
+
+        return $this->storageFactory;
+    }
+
+    /**
+     * Sets the StorageFactory used to create a Storage per cassette.
+     *
+     * Implement StorageFactoryInterface to plug in a custom storage backend
+     * together with its own dependencies.
+     */
+    public function setStorageFactory(StorageFactoryInterface $storageFactory): self
+    {
+        $this->storageFactory = $storageFactory;
+
+        return $this;
     }
 
     /**
@@ -285,13 +334,17 @@ class Configuration
 
     /**
      * @throws VCRException if a invalid storage name is given
+     *
+     * @deprecated since 1.12, use {@see self::setStorageFactory()}. Removed in
+     *             the next major.
      */
     public function setStorage(string $storageName): self
     {
-        Assertion::keyExists($this->availableStorages, $storageName, "Storage '{$storageName}' not available.");
-        $this->enabledStorage = $storageName;
+        Assertion::keyExists(self::DEPRECATED_STORAGE_FACTORIES, $storageName, "Storage '{$storageName}' not available.");
 
-        return $this;
+        $factoryClass = self::DEPRECATED_STORAGE_FACTORIES[$storageName];
+
+        return $this->setStorageFactory(new $factoryClass());
     }
 
     /**

--- a/src/VCR/Storage/BlackholeStorageFactory.php
+++ b/src/VCR/Storage/BlackholeStorageFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+/**
+ * Creates the Blackhole storage backend, which discards everything.
+ *
+ * Cassette path and name are irrelevant — Blackhole never touches the
+ * filesystem.
+ */
+class BlackholeStorageFactory implements StorageFactoryInterface
+{
+    public function create(string $cassettePath, string $cassetteName): StorageInterface
+    {
+        return new Blackhole();
+    }
+}

--- a/src/VCR/Storage/JsonStorageFactory.php
+++ b/src/VCR/Storage/JsonStorageFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+/**
+ * Creates the JSON storage backend.
+ */
+class JsonStorageFactory implements StorageFactoryInterface
+{
+    public function create(string $cassettePath, string $cassetteName): StorageInterface
+    {
+        return new Json($cassettePath, $cassetteName);
+    }
+}

--- a/src/VCR/Storage/PurgeableStorage.php
+++ b/src/VCR/Storage/PurgeableStorage.php
@@ -12,9 +12,8 @@ namespace VCR\Storage;
  */
 interface PurgeableStorage extends Storage, PurgeableStorageInterface
 {
-    // Extends Storage (in addition to PurgeableStorageInterface) to maintain the type hierarchy:
-    // VCRFactory::createStorage() asserts that storage classes are subclasses of Storage.
-    // Concrete implementations (Yaml, Json, Blackhole) extend AbstractStorage which implements
-    // PurgeableStorage; they must remain subtypes of Storage for VCRFactory's runtime check.
-    // Removing Storage from the hierarchy would break type assertions without compile-time signal.
+    // Extends Storage (in addition to PurgeableStorageInterface) purely for backwards compatibility:
+    // pre-1.12 user code may type-hint against Storage or check "instanceof \VCR\Storage\Storage".
+    // Dropping Storage from this hierarchy would silently break that code, since Yaml/Json/Blackhole
+    // are the concrete classes such checks target.
 }

--- a/src/VCR/Storage/PurgeableStorage.php
+++ b/src/VCR/Storage/PurgeableStorage.php
@@ -12,4 +12,9 @@ namespace VCR\Storage;
  */
 interface PurgeableStorage extends Storage, PurgeableStorageInterface
 {
+    // Extends Storage (in addition to PurgeableStorageInterface) to maintain the type hierarchy:
+    // VCRFactory::createStorage() asserts that storage classes are subclasses of Storage.
+    // Concrete implementations (Yaml, Json, Blackhole) extend AbstractStorage which implements
+    // PurgeableStorage; they must remain subtypes of Storage for VCRFactory's runtime check.
+    // Removing Storage from the hierarchy would break type assertions without compile-time signal.
 }

--- a/src/VCR/Storage/PurgeableStorage.php
+++ b/src/VCR/Storage/PurgeableStorage.php
@@ -7,13 +7,9 @@ namespace VCR\Storage;
 /**
  * Storage that can be purged, i.e. reset to its empty/default state.
  *
- * Under record mode "all" the cassette is purged on insert so every run
- * starts from a clean recording.
+ * @deprecated since 1.12, use {@see PurgeableStorageInterface}. Kept as a
+ *             backwards-compatible alias, removed in the next major.
  */
-interface PurgeableStorage extends Storage
+interface PurgeableStorage extends Storage, PurgeableStorageInterface
 {
-    /**
-     * Purge all stored recordings and reset the storage to its empty state.
-     */
-    public function purge(): void;
 }

--- a/src/VCR/Storage/PurgeableStorageInterface.php
+++ b/src/VCR/Storage/PurgeableStorageInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+/**
+ * Storage that can be purged, i.e. reset to its empty/default state.
+ *
+ * Under record mode "all" the cassette is purged on insert so every run
+ * starts from a clean recording.
+ */
+interface PurgeableStorageInterface extends StorageInterface
+{
+    /**
+     * Purge all stored recordings and reset the storage to its empty state.
+     */
+    public function purge(): void;
+}

--- a/src/VCR/Storage/Storage.php
+++ b/src/VCR/Storage/Storage.php
@@ -7,17 +7,9 @@ namespace VCR\Storage;
 /**
  * Interface for reading and storing records.
  *
- * A Storage can be iterated using standard loops.
- * New recordings can be stored.
- *
- * @phpstan-extends \Iterator<int, array>
+ * @deprecated since 1.12, use {@see StorageInterface}. Kept as a
+ *             backwards-compatible alias, removed in the next major.
  */
-interface Storage extends \Iterator
+interface Storage extends StorageInterface
 {
-    /**
-     * @param array<string,int|string|array<string,mixed>|null> $recording
-     */
-    public function storeRecording(array $recording): void;
-
-    public function isNew(): bool;
 }

--- a/src/VCR/Storage/StorageFactoryInterface.php
+++ b/src/VCR/Storage/StorageFactoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+/**
+ * Creates a Storage bound to a concrete cassette.
+ *
+ * Implement this to plug in a custom storage backend, for example one backed
+ * by a database. Own dependencies (connections, clients, ...) are injected
+ * into the factory and handed on to the created Storage. Register the factory
+ * via \VCR\Configuration::setStorageFactory().
+ */
+interface StorageFactoryInterface
+{
+    /**
+     * @param string $cassettePath directory the cassette lives in
+     * @param string $cassetteName file name or identifier of the cassette
+     *
+     * @return StorageInterface storage bound to the given cassette
+     */
+    public function create(string $cassettePath, string $cassetteName): StorageInterface;
+}

--- a/src/VCR/Storage/StorageInterface.php
+++ b/src/VCR/Storage/StorageInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+/**
+ * Interface for reading and storing records.
+ *
+ * A Storage can be iterated using standard loops.
+ * New recordings can be stored.
+ *
+ * @phpstan-extends \Iterator<int, array>
+ */
+interface StorageInterface extends \Iterator
+{
+    /**
+     * Appends a single recording to the storage.
+     *
+     * @param array<string,int|string|array<string,mixed>|null> $recording
+     */
+    public function storeRecording(array $recording): void;
+
+    /**
+     * Whether this Storage started out empty — the cassette did not exist yet, or was just purged.
+     */
+    public function isNew(): bool;
+}

--- a/src/VCR/Storage/YamlStorageFactory.php
+++ b/src/VCR/Storage/YamlStorageFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+/**
+ * Creates the YAML storage backend.
+ */
+class YamlStorageFactory implements StorageFactoryInterface
+{
+    public function create(string $cassettePath, string $cassetteName): StorageInterface
+    {
+        return new Yaml($cassettePath, $cassetteName);
+    }
+}

--- a/src/VCR/VCRFactory.php
+++ b/src/VCR/VCRFactory.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace VCR;
 
-use Assert\Assertion;
 use VCR\LibraryHooks\CurlHook;
 use VCR\LibraryHooks\SoapHook;
 use VCR\LibraryHooks\StreamWrapperHook;
-use VCR\Storage\Storage;
+use VCR\Storage\StorageInterface;
 use VCR\Util\StreamProcessor;
 
 class VCRFactory
@@ -41,21 +40,13 @@ class VCRFactory
         return new StreamProcessor($this->config);
     }
 
-    /** @return Storage<array> */
-    protected function createStorage(string $cassetteName): Storage
+    /** @return StorageInterface<array> */
+    protected function createStorage(string $cassetteName): StorageInterface
     {
-        $dsn = $this->config->getCassettePath();
-        $className = $this->config->getStorage();
-        Assertion::subclassOf(
-            $className,
-            Storage::class,
-            \sprintf('Storage class "%s" is not a subclass of "%s".', $className, Storage::class)
+        return $this->config->getStorageFactory()->create(
+            $this->config->getCassettePath(),
+            $cassetteName
         );
-
-        /** @var Storage $storage */
-        $storage = new $className($dsn, $cassetteName);
-
-        return $storage;
     }
 
     protected function createVCRLibraryHooksSoapHook(): SoapHook

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -12,8 +12,8 @@ use VCR\Event\BeforeHttpRequestEvent;
 use VCR\Event\BeforePlaybackEvent;
 use VCR\Event\BeforeRecordEvent;
 use VCR\Event\Event;
-use VCR\Storage\PurgeableStorage;
-use VCR\Storage\Storage;
+use VCR\Storage\PurgeableStorageInterface;
+use VCR\Storage\StorageInterface;
 use VCR\Util\Assertion;
 use VCR\Util\HttpClient;
 
@@ -129,8 +129,8 @@ class Videorecorder
         $storage = $this->createStorage($cassetteName);
 
         if (VCR::MODE_ALL === $this->config->getMode()) {
-            if (!$storage instanceof PurgeableStorage) {
-                throw new \LogicException(\sprintf('Storage "%s" does not support MODE_ALL: implement PurgeableStorage to enable purge on cassette insert.', $storage::class));
+            if (!$storage instanceof PurgeableStorageInterface) {
+                throw new \LogicException(\sprintf('Storage "%s" does not support MODE_ALL: implement PurgeableStorageInterface to enable purge on cassette insert.', $storage::class));
             }
             $storage->purge();
         }
@@ -208,9 +208,9 @@ class Videorecorder
     }
 
     /**
-     * @return Storage<array>
+     * @return StorageInterface<array>
      */
-    protected function createStorage(string $cassetteName): Storage
+    protected function createStorage(string $cassetteName): StorageInterface
     {
         return $this->factory->get('Storage', [$cassetteName]);
     }

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -6,6 +6,11 @@ namespace VCR\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use VCR\Configuration;
+use VCR\Storage\BlackholeStorageFactory;
+use VCR\Storage\JsonStorageFactory;
+use VCR\Storage\StorageFactoryInterface;
+use VCR\Storage\StorageInterface;
+use VCR\Storage\YamlStorageFactory;
 use VCR\VCR;
 use VCR\VCRException;
 
@@ -135,6 +140,41 @@ final class ConfigurationTest extends TestCase
         $this->assertContains('Iterator', (array) class_implements($class));
         $this->assertContains('Traversable', (array) class_implements($class));
         $this->assertContains('VCR\Storage\AbstractStorage', (array) class_parents($class));
+    }
+
+    public function testDefaultStorageFactoryIsYaml(): void
+    {
+        $this->assertInstanceOf(YamlStorageFactory::class, $this->config->getStorageFactory());
+    }
+
+    public function testSetStorageFactoryIsFluentAndReturnsTheSameInstance(): void
+    {
+        $factory = new JsonStorageFactory();
+
+        $this->assertSame($this->config, $this->config->setStorageFactory($factory));
+        $this->assertSame($factory, $this->config->getStorageFactory());
+    }
+
+    public function testSetStorageSelectsTheMatchingBuiltinFactory(): void
+    {
+        $this->config->setStorage('blackhole');
+
+        $this->assertInstanceOf(BlackholeStorageFactory::class, $this->config->getStorageFactory());
+    }
+
+    public function testGetStorageThrowsForACustomStorageFactory(): void
+    {
+        $this->config->setStorageFactory(new class implements StorageFactoryInterface {
+            public function create(string $cassettePath, string $cassetteName): StorageInterface
+            {
+                throw new \LogicException('Not needed for this test.');
+            }
+        });
+
+        $this->expectException(VCRException::class);
+        $this->expectExceptionMessage('Please use getStorageFactory() instead.');
+
+        $this->config->getStorage();
     }
 
     public function testWhitelist(): void

--- a/tests/Unit/Storage/BlackholeStorageFactoryTest.php
+++ b/tests/Unit/Storage/BlackholeStorageFactoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Blackhole;
+use VCR\Storage\BlackholeStorageFactory;
+use VCR\Storage\StorageFactoryInterface;
+
+final class BlackholeStorageFactoryTest extends TestCase
+{
+    public function testImplementsStorageFactoryInterface(): void
+    {
+        $this->assertInstanceOf(StorageFactoryInterface::class, new BlackholeStorageFactory());
+    }
+
+    public function testCreateReturnsBlackholeStorageAndIgnoresTheCassetteLocation(): void
+    {
+        $storage = (new BlackholeStorageFactory())->create('/does/not/exist/', 'test-cassette');
+
+        $this->assertInstanceOf(Blackhole::class, $storage);
+    }
+}

--- a/tests/Unit/Storage/JsonStorageFactoryTest.php
+++ b/tests/Unit/Storage/JsonStorageFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Json;
+use VCR\Storage\JsonStorageFactory;
+use VCR\Storage\StorageFactoryInterface;
+
+final class JsonStorageFactoryTest extends TestCase
+{
+    public function testImplementsStorageFactoryInterface(): void
+    {
+        $this->assertInstanceOf(StorageFactoryInterface::class, new JsonStorageFactory());
+    }
+
+    public function testCreateReturnsJsonStorageForTheGivenCassette(): void
+    {
+        vfsStream::setup('testDir');
+
+        $storage = (new JsonStorageFactory())->create(vfsStream::url('testDir').'/', 'test-cassette');
+
+        $this->assertInstanceOf(Json::class, $storage);
+        $this->assertTrue($storage->isNew(), 'A freshly created cassette should be new.');
+    }
+}

--- a/tests/Unit/Storage/YamlStorageFactoryTest.php
+++ b/tests/Unit/Storage/YamlStorageFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\StorageFactoryInterface;
+use VCR\Storage\Yaml;
+use VCR\Storage\YamlStorageFactory;
+
+final class YamlStorageFactoryTest extends TestCase
+{
+    public function testImplementsStorageFactoryInterface(): void
+    {
+        $this->assertInstanceOf(StorageFactoryInterface::class, new YamlStorageFactory());
+    }
+
+    public function testCreateReturnsYamlStorageForTheGivenCassette(): void
+    {
+        vfsStream::setup('testDir');
+
+        $storage = (new YamlStorageFactory())->create(vfsStream::url('testDir').'/', 'test-cassette');
+
+        $this->assertInstanceOf(Yaml::class, $storage);
+        $this->assertTrue($storage->isNew(), 'A freshly created cassette should be new.');
+    }
+}

--- a/tests/Unit/VCRFactoryTest.php
+++ b/tests/Unit/VCRFactoryTest.php
@@ -6,6 +6,8 @@ namespace VCR\Tests\Unit;
 
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
+use VCR\Storage\StorageFactoryInterface;
+use VCR\Storage\StorageInterface;
 use VCR\VCRFactory;
 
 final class VCRFactoryTest extends TestCase
@@ -62,5 +64,34 @@ final class VCRFactoryTest extends TestCase
             ['json', 'VCR\Storage\Json'],
             ['yaml', 'VCR\Storage\Yaml'],
         ];
+    }
+
+    public function testCreateStorageUsesTheConfiguredStorageFactory(): void
+    {
+        $expectedStorage = $this->createMock(StorageInterface::class);
+        $storageFactory = new class($expectedStorage) implements StorageFactoryInterface {
+            private StorageInterface $storage;
+
+            public function __construct(StorageInterface $storage)
+            {
+                $this->storage = $storage;
+            }
+
+            public function create(string $cassettePath, string $cassetteName): StorageInterface
+            {
+                return $this->storage;
+            }
+        };
+
+        $configuration = VCRFactory::get('VCR\Configuration');
+        $configuration->setStorageFactory($storageFactory);
+
+        try {
+            $instance = VCRFactory::get('Storage', [(string) random_int(0, getrandmax())]);
+
+            $this->assertSame($expectedStorage, $instance);
+        } finally {
+            $configuration->setStorage('yaml');
+        }
     }
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Feature
| Fixes            | Fix #199
| BC break?        | no
| Deprecation?     | yes — `Configuration::setStorage()`/`getStorage()` and `VCR\Storage\Storage`/`PurgeableStorage` are deprecated since 1.12 in favor of `setStorageFactory()`/`getStorageFactory()` and `StorageInterface`/`PurgeableStorageInterface`; removal targeted for the next major
| New dependency?  | no
| Docs updated?    | yes
| License          | MIT

Adds a typed extension point for plugging in a custom storage backend (e.g. a database-backed one), addressing the long-standing request in #199. Previously the only storages available were the three hardcoded names (`yaml`/`json`/`blackhole`), and construction went through an untyped `new $className($cassettePath, $cassetteName)` — there was no way to inject a storage with its own dependencies (a DB connection, a client, etc.).

A new `StorageFactoryInterface::create(string $cassettePath, string $cassetteName): StorageInterface` is now the single point of storage construction. `Configuration` holds exactly one factory:

```php
\VCR\VCR::configure()->setStorageFactory(new MyDatabaseStorageFactory($pdo));
```

The three built-in storages (`YamlStorageFactory`, `JsonStorageFactory`, `BlackholeStorageFactory`) now go through the same mechanism. The old name-based API keeps working unchanged as a deprecated layer:

```php
// before (still works, now deprecated)
\VCR\VCR::configure()->setStorage('json');

// after
\VCR\VCR::configure()->setStorageFactory(new \VCR\Storage\JsonStorageFactory());
```

Also introduces an `*Interface`-suffixed naming convention inside `VCR\Storage`: the canonical `StorageInterface`/`PurgeableStorageInterface`/`StorageFactoryInterface`, with the old suffixless `Storage`/`PurgeableStorage` kept as deprecated aliases for backwards compatibility (existing `implements Storage`/`instanceof Storage` code keeps working).

New how-to guide at `docs/howto/custom-storage.md` walks through both a minimal in-memory example and a PDO/SQLite-backed one with an injected dependency; `docs/upgrading.md` gained a "Deprecations" section documenting the migration path.

Verified locally on the full Docker matrix: `workspace80` (PHPStan level 8, PHP-CS-Fixer, editorconfig-checker, PHPUnit with `--prefer-lowest` and highest deps) and `workspace85` (PHPUnit with `--prefer-lowest` and highest deps), all green. Both how-to code examples were run against a throwaway path-repo harness (record → replay) before being committed.