### PR TITLE
fix(docs): pad table delimiter rows for markdownlint MD060

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -8,5 +8,9 @@
   "MD024": {
     // duplicate headings — reference pages reuse headings like "## Getting set up" style entries
     "siblings_only": true
+  },
+  "MD060": {
+    // table column style — delimiter rows padded like the header/body rows
+    "style": "compact"
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ greens = good, greys/blues = neutral).
 **Type** — exactly one per issue/PR:
 
 | Label | Meaning |
-|---|---|
+| --- | --- |
 | `Bug` | Defect in shipped behaviour. |
 | `Feature` | New, user-visible capability. |
 | `Enhancement` | Refinement of existing behaviour/internals, no new surface. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,9 @@ inventing a new structure.
 
 The documentation has its own consistent look, applied on every page: emoji-prefixed callouts (as above),
 Mermaid diagrams for flows (rendered natively by GitHub), `<details>` blocks for long or optional content, and
-a breadcrumb/prev-next footer. Keep new pages visually consistent with existing ones.
+a breadcrumb/prev-next footer. Tables use the compact style — a single space padding every pipe, including
+the delimiter row (`| --- | --- |`, not `|---|---|`) — per the pinned `MD060` rule in `.markdownlint.jsonc`.
+Keep new pages visually consistent with existing ones.
 
 ### Previewing the rendered site
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ You're in the docs. Full pitch, badges and a 30-second example live in the
 [README](https://github.com/php-vcr/php-vcr#readme) — this page is just the map.
 
 | | |
-|---|---|
+| --- | --- |
 | 📦 **[Getting Started](getting-started.md)** | Install, turn VCR on, record your first cassette. |
 | 🧭 **[Requirements](requirements.md)** | PHP/extension support matrix, tested HTTP libraries. |
 | 🔍 **[How VCR works](guides/how-vcr-works.md)** | The two interception mechanisms — and why bootstrap order matters. |

--- a/docs/reference/request-response.md
+++ b/docs/reference/request-response.md
@@ -11,7 +11,7 @@ new Request(string $method, ?string $url, array $headers = [])
 ```
 
 | Getters | Setters |
-|---|---|
+| --- | --- |
 | `getMethod()` (honours `CURLOPT_CUSTOMREQUEST`) | `setMethod(string)` (uppercases) |
 | `getUrl()` | `setUrl(?string)` (also sets the `Host` header) |
 | `getHost()` (host:port; throws `InvalidHostException` if unparsable) | — |
@@ -39,7 +39,7 @@ new Response($status, array $headers = [], ?string $body = null, array $curlInfo
 ```
 
 | Getters |
-|---|
+| --- |
 | `getStatusCode(): int`, `getStatusMessage(): string`, `getHttpVersion(): mixed` |
 | `getHeaders(): array`, `getHeader(string $key): ?string` |
 | `getContentType(): ?string` |

--- a/docs/reference/vcr-facade.md
+++ b/docs/reference/vcr-facade.md
@@ -65,7 +65,7 @@
 ## Mode constants
 
 | Constant | Value | See |
-|---|---|---|
+| --- | --- | --- |
 | `VCR::MODE_NEW_EPISODES` | `'new_episodes'` | [Record Modes](../guides/record-modes.md#new_episodes) |
 | `VCR::MODE_ONCE` | `'once'` | [Record Modes](../guides/record-modes.md#once) |
 | `VCR::MODE_NONE` | `'none'` | [Record Modes](../guides/record-modes.md#none) |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -18,7 +18,7 @@ allowed dependency versions.
 ## Extensions
 
 | Extension | Required | Why |
-|---|---|---|
+| --- | --- | --- |
 | `curl` | Always | Used both by the `curl` hook and internally to perform real HTTP requests when recording. |
 | `soap` | Only for the `soap` hook | `SoapHook` throws `BadMethodCallException` at construction if `SoapClient` doesn't exist. |
 | `xml` (`ext-dom`) | Only for the `soap` hook | Same constructor check, via `DOMDocument`. |
@@ -40,7 +40,7 @@ php-vcr intercepts at the level of PHP's stream wrapper and `curl_*`/`SoapClient
 any library built on top of them — these are the ones actually exercised by the test suite:
 
 | Library | Hook | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `file_get_contents()`, `fopen()`, `fread()`, … | `stream_wrapper` | Any function that goes through PHP's `http`/`https` stream wrapper. |
 | `Symfony\Component\HttpClient\NativeHttpClient` | `stream_wrapper` | Uses stream wrappers under the hood. |
 | `ext-curl` (`curl_init`/`curl_exec`/`curl_multi_*`/…) | `curl` | Direct curl function calls. |

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -33,7 +33,7 @@ contract — see [Custom storage backend](howto/custom-storage.md) for why a fac
 string.
 
 | Deprecated | Replacement |
-|---|---|
+| --- | --- |
 | `Configuration::setStorage('json')` | `Configuration::setStorageFactory(new \VCR\Storage\JsonStorageFactory())` |
 | `Configuration::getStorage()` | `Configuration::getStorageFactory()` |
 | `VCR\Storage\Storage` | `VCR\Storage\StorageInterface` |


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | CI
| Fixes            | <!-- no issue filed; unblocks #497 -->
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| Docs updated?    | n/a
| License          | MIT

`DavidAnson/markdownlint-cli2-action` v24 (see #497) pulls in markdownlint 0.41, which adds the
new `MD060/table-column-style` rule. Its default `any` style requires every row of a table to
share one style, but our delimiter rows (`|---|---|`) were tight while the header/body rows were
padded — no single style matched, so the `Documentation` CI job failed with 36 errors across 6
files as soon as #497 picked up the new action version.

This pins `MD060` to the `compact` style in `.markdownlint.jsonc`, pads the affected delimiter
rows to match, and records the convention in `CONTRIBUTING.md`.

Once this merges, #497 can be rebased and its `Documentation` check will pass.