### PR TITLE
feat: add an encrypted storage decorator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
         "phpstan/extension-installer": "^1.1",
         "editorconfig-checker/editorconfig-checker": "^10.3"
     },
+    "suggest": {
+        "ext-sodium": "Required for the encrypted storage decorator"
+    },
     "autoload": {
         "psr-4": {
             "VCR\\": "src/VCR/"

--- a/context7.json
+++ b/context7.json
@@ -15,6 +15,7 @@
     "Inject a custom storage backend (e.g. database-backed) via VCR::configure()->setStorageFactory(new MyFactory()), implementing StorageFactoryInterface::create(): StorageInterface",
     "By default requests are matched by method and url only — enable additional matchers (host, headers, body, post_fields, query_string) via VCR::configure()->enableRequestMatchers([...])",
     "Redacting a request body in a VCR_BEFORE_RECORD listener breaks replay unless the body/post_fields matchers are also narrowed to ignore the redacted parts",
-    "With curl/soap hooks, call VCR::turnOn(); VCR::turnOff(); once at bootstrap, right after the autoloader — this registers the stream wrapper that later rewrites curl_*/SoapClient calls; skipping it disables interception"
+    "With curl/soap hooks, call VCR::turnOn(); VCR::turnOff(); once at bootstrap, right after the autoloader — this registers the stream wrapper that later rewrites curl_*/SoapClient calls; skipping it disables interception",
+    "Encrypt sensitive cassette fields (bodies, Authorization/Cookie/etc. headers) at rest via VCR::configure()->setStorageFactory(EncryptedStorageFactory::withKey(new YamlStorageFactory(), $key)); requires ext-sodium"
   ]
 }

--- a/docs/howto/filter-sensitive-data.md
+++ b/docs/howto/filter-sensitive-data.md
@@ -3,7 +3,9 @@
 > One-liner: mutate the `Request` in a `VCR_BEFORE_RECORD` listener before it's written to disk — but redacting
 > the body means you must also stop matching on it, or replay breaks.
 
-**On this page:** [Redact a header](#redact-a-header) · [Redact the body](#redact-the-body) · [What you can't redact this way](#what-you-cant-redact-this-way)
+**On this page:** [Redact a header](#redact-a-header) · [Redact the body](#redact-the-body) ·
+[What you can't redact this way](#what-you-cant-redact-this-way) ·
+[Encrypt instead of redacting](#encrypt-instead-of-redacting)
 
 Cassettes are plain files that typically end up committed to your repo — don't let an auth token, API key, or
 cookie leak into one. `VCR_BEFORE_RECORD` fires with the real `Request`/`Response` right before they're
@@ -65,6 +67,29 @@ hook that parses it as such; a raw form-urlencoded body sent via `file_get_conte
 back *in the response body* (rather than being sent in the request), this event can't strip it before it's
 written to the cassette. In that case, either have your test server/fixture avoid echoing the secret back, or
 post-process the cassette file after recording.
+
+## Encrypt instead of redacting
+
+> **🆕 Since 1.13**
+
+Redaction has a sharp edge, [documented above](#redact-the-body): once the body on disk no longer matches the
+body of the real incoming request, the `body`/`post_fields` matchers must be narrowed too, or replay breaks.
+The [`encrypted` storage backend](../reference/storage-backends.md#encrypted) sidesteps this entirely — it
+decrypts a recording in `current()`, which runs before `Cassette::playback()` applies the matchers, so matching
+always sees plaintext while only ciphertext ever reaches disk:
+
+```php
+$key = \VCR\Storage\Encryption\EncryptionKey::fromBase64($_SERVER['VCR_CASSETTE_KEY']);
+
+\VCR\VCR::configure()->setStorageFactory(
+    \VCR\Storage\EncryptedStorageFactory::withKey(new \VCR\Storage\YamlStorageFactory(), $key)
+);
+```
+
+This also covers the response-body case above, which redaction through `VCR_BEFORE_RECORD` can't reach at
+all — `response.body` is encrypted by default. See [Storage Backends → encrypted](../reference/storage-backends.md#encrypted)
+for the full configuration, the fields covered by default, and its limitations (query-string secrets stay
+readable, and a lost key makes a cassette unrecoverable).
 
 ---
 ← [Use with Codeception](use-with-codeception.md) · Next: [Custom request matcher](custom-request-matcher.md) →

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -62,6 +62,8 @@ Every entry below follows the same shape: **Values · Default · Description · 
 Wrap another factory with `\VCR\Storage\EncryptedStorageFactory` to encrypt sensitive fields on disk (see
 [Storage Backends → encrypted](storage-backends.md#encrypted)):
 
+> **🆕 Since 1.13**
+
 ```php
 $key = \VCR\Storage\Encryption\EncryptionKey::fromBase64($_SERVER['VCR_CASSETTE_KEY']);
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -59,6 +59,17 @@ Every entry below follows the same shape: **Values · Default · Description · 
 > that's a known PCRE backtrack-limit issue with the YAML parser (raise `pcre.backtrack_limit` in `php.ini`, or
 > use JSON).
 
+Wrap another factory with `\VCR\Storage\EncryptedStorageFactory` to encrypt sensitive fields on disk (see
+[Storage Backends → encrypted](storage-backends.md#encrypted)):
+
+```php
+$key = \VCR\Storage\Encryption\EncryptionKey::fromBase64($_SERVER['VCR_CASSETTE_KEY']);
+
+\VCR\VCR::configure()->setStorageFactory(
+    \VCR\Storage\EncryptedStorageFactory::withKey(new \VCR\Storage\YamlStorageFactory(), $key)
+);
+```
+
 ## `storage`
 
 - **Setter/Getter:** `setStorage(string $name): self` / `getStorage(): string` (returns the resolved class name)

--- a/docs/reference/storage-backends.md
+++ b/docs/reference/storage-backends.md
@@ -2,11 +2,12 @@
 
 > One-liner: cassettes are files on disk, serialized as YAML (default), JSON, or nowhere at all (Blackhole).
 
-**On this page:** [yaml](#yaml) · [json](#json) · [blackhole](#blackhole) ·
+**On this page:** [yaml](#yaml) · [json](#json) · [blackhole](#blackhole) · [encrypted](#encrypted) ·
 [Custom storage backend](#custom-storage-backend) · [Cassette file naming](#cassette-file-naming)
 
-Select via [`setStorageFactory()`](configuration.md#storage-factory). All three implement
-`PurgeableStorageInterface`, so all three work with [`MODE_ALL`](../guides/record-modes.md#all).
+Select via [`setStorageFactory()`](configuration.md#storage-factory). `yaml`, `json`, and `blackhole`
+implement `PurgeableStorageInterface` directly, so all three work with [`MODE_ALL`](../guides/record-modes.md#all);
+`encrypted` wraps one of them and works with `MODE_ALL` whenever the wrapped backend does.
 
 ## `yaml`
 
@@ -57,6 +58,76 @@ Select via [`setStorageFactory()`](configuration.md#storage-factory). All three 
 > created, even after `insertCassette()`.
 
 - Useful for smoke-testing library-hook behaviour without leaving cassette files behind.
+
+## `encrypted`
+
+> **🆕 Since 1.13**
+
+- **Factory:** `\VCR\Storage\EncryptedStorageFactory` — wraps another storage factory so every cassette it
+  writes has its sensitive fields encrypted, and every cassette it reads is decrypted before request matching
+  runs.
+- Requires `ext-sodium`; encrypts with XChaCha20-Poly1305, keyed by a 32-byte `EncryptionKey`.
+- `method`, `url`, and status stay in plaintext on purpose — the cassette is still reviewable in a diff.
+
+```php
+$key = \VCR\Storage\Encryption\EncryptionKey::fromBase64($_SERVER['VCR_CASSETTE_KEY']);
+
+\VCR\VCR::configure()->setStorageFactory(
+    \VCR\Storage\EncryptedStorageFactory::withKey(new \VCR\Storage\YamlStorageFactory(), $key)
+);
+```
+
+Generate a key once and keep it outside the repository — losing it makes every cassette encrypted with it
+unrecoverable:
+
+```php
+$key = \VCR\Storage\Encryption\EncryptionKey::generate();
+echo $key->toBase64(); // store this, e.g. as the VCR_CASSETTE_KEY environment variable
+```
+
+A recorded cassette looks like this — the request body and the `Authorization` header are replaced by an
+opaque `vcr:enc:v1:...` value, while `method` and `url` stay readable:
+
+```yaml
+-
+    request:
+        method: POST
+        url: 'http://example.com/post'
+        headers:
+            Authorization: 'vcr:enc:v1:lQDi6mIvZalIRRBCbPFAC5kslFL6PZh3YQfc+ojigif6k/rdDP+zcqsB10UMQEXM0sZS...'
+        body: 'vcr:enc:v1:FGnejCxN3ST4WPgtgd5ZY+QnqmY2zVx63Kf7QJ/9OLGUFX+7yVeifQr3gfLztL8tPD6MXsll1RFsig=='
+    response:
+        status: { code: 200, message: OK }
+        body: 'vcr:enc:v1:lQVZ9S4OFm/oOyNLaSjv2vDKl0ifq8ZbBxl9nvXLQHAwyYSN/jvZjF5qvhiOTm0agNjjz6pH5BoFegy...'
+    index: 0
+```
+
+### Policy defaults
+
+`\VCR\Storage\Encryption\EncryptionPolicy` decides which fields are encrypted. Unless a custom policy is
+passed as the third argument to `EncryptedStorageFactory::withKey()`, it encrypts:
+
+- **Fields:** `request.body` · `request.post_fields` · `request.post_files` · `response.body`
+- **Headers** (matched case-insensitively, in both the request and the response):
+  `Authorization` · `Proxy-Authorization` · `Cookie` · `Set-Cookie` · `X-Api-Key`
+
+```php
+\VCR\Storage\EncryptedStorageFactory::withKey(
+    new \VCR\Storage\YamlStorageFactory(),
+    $key,
+    new \VCR\Storage\Encryption\EncryptionPolicy(['response.body'], [])
+);
+```
+
+> **⚠️ Limitations**
+>
+> - Secrets in the query string stay in plaintext — `url` is intentionally left readable.
+> - Identical values in the same field produce identical ciphertext, the cost of a deterministic nonce (it
+>   keeps a re-recorded cassette byte-identical instead of producing a spurious diff).
+> - A cassette written with a since-lost key cannot be decrypted again — keep the key itself out of the
+>   repository, and keep a backup of it.
+
+Works with both `yaml` and `json` as the wrapped backend.
 
 ## Custom storage backend
 

--- a/docs/reference/storage-backends.md
+++ b/docs/reference/storage-backends.md
@@ -107,7 +107,8 @@ opaque `vcr:enc:v1:...` value, while `method` and `url` stay readable:
 `\VCR\Storage\Encryption\EncryptionPolicy` decides which fields are encrypted. Unless a custom policy is
 passed as the third argument to `EncryptedStorageFactory::withKey()`, it encrypts:
 
-- **Fields:** `request.body` · `request.post_fields` · `request.post_files` · `response.body`
+- **Fields:** `request.body` · `request.post_fields` · `request.post_files` · `response.body` ·
+  `response.curl_info.request_header`
 - **Headers** (matched case-insensitively, in both the request and the response):
   `Authorization` · `Proxy-Authorization` · `Cookie` · `Set-Cookie` · `X-Api-Key`
 
@@ -126,6 +127,8 @@ passed as the third argument to `EncryptedStorageFactory::withKey()`, it encrypt
 >   keeps a re-recorded cassette byte-identical instead of producing a spurious diff).
 > - A cassette written with a since-lost key cannot be decrypted again — keep the key itself out of the
 >   repository, and keep a backup of it.
+> - Other `curl_info` sub-fields besides `request_header` (e.g. timing data) are not covered by the default
+>   policy — they generally don't carry secrets.
 
 Works with both `yaml` and `json` as the wrapped backend.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -401,3 +401,27 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Unit/VideorecorderTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''RuntimeException'' and VCR\\Storage\\Encryption\\DecryptionFailedException will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/Unit/Storage/Encryption/DecryptionFailedExceptionTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''VCR\\\\Storage\\\\Encryption\\\\CipherInterface'' and VCR\\Storage\\Encryption\\SodiumCipher will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/Unit/Storage/Encryption/SodiumCipherTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''RuntimeException'' and VCR\\Storage\\Encryption\\UnsupportedSchemeException will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/Unit/Storage/Encryption/UnsupportedSchemeExceptionTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotInstanceOf\(\) with arguments ''VCR\\\\Storage\\\\Encryption\\\\DecryptionFailedException'', VCR\\Storage\\Encryption\\UnsupportedSchemeException and ''.*'' will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/Unit/Storage/Encryption/UnsupportedSchemeExceptionTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -425,3 +425,21 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Unit/Storage/Encryption/UnsupportedSchemeExceptionTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''VCR\\\\Storage\\\\StorageInterface'' and VCR\\Storage\\EncryptedStorage will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/Unit/Storage/EncryptedStorageTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''VCR\\\\Storage\\\\PurgeableStorageInterface'' and VCR\\Storage\\PurgeableEncryptedStorage will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/Unit/Storage/EncryptedStorageTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''VCR\\\\Storage\\\\EncryptedStorage'' and VCR\\Storage\\PurgeableEncryptedStorage will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/Unit/Storage/EncryptedStorageTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -443,3 +443,9 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Unit/Storage/EncryptedStorageTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''VCR\\\\Storage\\\\StorageFactoryInterface'' and VCR\\Storage\\EncryptedStorageFactory will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/Unit/Storage/EncryptedStorageFactoryTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -421,7 +421,7 @@ parameters:
 			path: tests/Unit/Storage/Encryption/UnsupportedSchemeExceptionTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotInstanceOf\(\) with arguments ''VCR\\\\Storage\\\\Encryption\\\\DecryptionFailedException'', VCR\\Storage\\Encryption\\UnsupportedSchemeException and ''.*'' will always evaluate to true\.$#'
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotInstanceOf\(\) with arguments ''VCR\\\\Storage\\\\Encryption\\\\DecryptionFailedException'', VCR\\Storage\\Encryption\\UnsupportedSchemeException and ''A cassette written…'' will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Unit/Storage/Encryption/UnsupportedSchemeExceptionTest.php

--- a/src/VCR/Storage/EncryptedStorage.php
+++ b/src/VCR/Storage/EncryptedStorage.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+use VCR\Storage\Encryption\CipherInterface;
+use VCR\Storage\Encryption\EncryptionPolicy;
+
+/**
+ * Encrypts sensitive fields on the way to the wrapped storage and decrypts them on the way back.
+ *
+ * Decryption happens in current(), which runs before Cassette::playback() applies the request
+ * matchers — so matching keeps working on plaintext while only ciphertext reaches the disk.
+ */
+class EncryptedStorage implements StorageInterface
+{
+    private StorageInterface $storage;
+
+    private CipherInterface $cipher;
+
+    private EncryptionPolicy $policy;
+
+    public function __construct(StorageInterface $storage, CipherInterface $cipher, EncryptionPolicy $policy)
+    {
+        $this->storage = $storage;
+        $this->cipher = $cipher;
+        $this->policy = $policy;
+    }
+
+    public function storeRecording(array $recording): void
+    {
+        $this->storage->storeRecording($this->policy->encrypt($recording, $this->cipher));
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function current(): ?array
+    {
+        /** @var array<string,mixed>|null $current */
+        $current = $this->storage->current();
+
+        if (!\is_array($current)) {
+            return null;
+        }
+
+        return $this->policy->decrypt($current, $this->cipher);
+    }
+
+    public function next(): void
+    {
+        $this->storage->next();
+    }
+
+    public function key(): int
+    {
+        return $this->storage->key();
+    }
+
+    public function rewind(): void
+    {
+        $this->storage->rewind();
+    }
+
+    public function valid(): bool
+    {
+        return $this->storage->valid();
+    }
+
+    public function isNew(): bool
+    {
+        return $this->storage->isNew();
+    }
+}

--- a/src/VCR/Storage/EncryptedStorageFactory.php
+++ b/src/VCR/Storage/EncryptedStorageFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+use VCR\Storage\Encryption\CipherInterface;
+use VCR\Storage\Encryption\EncryptionKey;
+use VCR\Storage\Encryption\EncryptionPolicy;
+use VCR\Storage\Encryption\SodiumCipher;
+
+/**
+ * Wraps another storage factory so every cassette it creates is encrypted.
+ */
+class EncryptedStorageFactory implements StorageFactoryInterface
+{
+    private StorageFactoryInterface $storageFactory;
+
+    private CipherInterface $cipher;
+
+    private EncryptionPolicy $policy;
+
+    public function __construct(
+        StorageFactoryInterface $storageFactory,
+        CipherInterface $cipher,
+        ?EncryptionPolicy $policy = null
+    ) {
+        $this->storageFactory = $storageFactory;
+        $this->cipher = $cipher;
+        $this->policy = $policy ?? new EncryptionPolicy();
+    }
+
+    public static function withKey(
+        StorageFactoryInterface $storageFactory,
+        EncryptionKey $key,
+        ?EncryptionPolicy $policy = null
+    ): self {
+        return new self($storageFactory, new SodiumCipher($key), $policy);
+    }
+
+    public function create(string $cassettePath, string $cassetteName): StorageInterface
+    {
+        $storage = $this->storageFactory->create($cassettePath, $cassetteName);
+
+        if ($storage instanceof PurgeableStorageInterface) {
+            return new PurgeableEncryptedStorage($storage, $this->cipher, $this->policy);
+        }
+
+        return new EncryptedStorage($storage, $this->cipher, $this->policy);
+    }
+}

--- a/src/VCR/Storage/Encryption/CipherInterface.php
+++ b/src/VCR/Storage/Encryption/CipherInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Encryption;
+
+/**
+ * Encrypts and decrypts a single cassette field.
+ *
+ * The field path is bound into the ciphertext, so a value cannot be moved to another field without
+ * decryption failing.
+ */
+interface CipherInterface
+{
+    /**
+     * Encrypts a single value and marks the result so it can be recognised again.
+     *
+     * @param string $plaintext the raw value as it would otherwise be written to the cassette
+     * @param string $fieldPath dot path of the field the value belongs to, bound into the ciphertext
+     *
+     * @return string marked ciphertext, safe to write to a cassette
+     */
+    public function encrypt(string $plaintext, string $fieldPath): string;
+
+    /**
+     * Decrypts a value previously produced by encrypt().
+     *
+     * @param string $ciphertext marked ciphertext as read from the cassette
+     * @param string $fieldPath  dot path of the field the value was read from; must be the same path
+     *                           that was used to encrypt it
+     *
+     * @return string the original plaintext
+     *
+     * @throws DecryptionFailedException  if the key is wrong, the value was altered, or it belongs
+     *                                    to a different field
+     * @throws UnsupportedSchemeException if the value was written by a newer encryption scheme
+     */
+    public function decrypt(string $ciphertext, string $fieldPath): string;
+
+    /**
+     * Tells whether a value carries the encryption marker.
+     *
+     * Values without the marker are passed through untouched, which keeps cassettes readable that
+     * were recorded before encryption was enabled.
+     *
+     * @param string $value value as read from the cassette
+     */
+    public function isEncrypted(string $value): bool;
+}

--- a/src/VCR/Storage/Encryption/DecryptionFailedException.php
+++ b/src/VCR/Storage/Encryption/DecryptionFailedException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Encryption;
+
+class DecryptionFailedException extends \RuntimeException
+{
+    public static function forField(string $fieldPath): self
+    {
+        return new self(\sprintf(
+            'Could not decrypt "%s". The key may be wrong, the cassette may have been altered, or the value may belong to a different field.',
+            $fieldPath
+        ));
+    }
+
+    public static function malformed(string $fieldPath): self
+    {
+        return new self(\sprintf('The encrypted value in "%s" is malformed.', $fieldPath));
+    }
+}

--- a/src/VCR/Storage/Encryption/EncryptionKey.php
+++ b/src/VCR/Storage/Encryption/EncryptionKey.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Encryption;
+
+use VCR\Util\Assertion;
+
+/**
+ * A 32 byte master key from which two role-specific subkeys are derived.
+ *
+ * The nonce is derived from the plaintext, so the key doing that derivation must not be the key that
+ * encrypts — otherwise one key would serve two roles.
+ */
+class EncryptionKey
+{
+    private const CONTEXT = 'vcrenc01';
+
+    private const SUBKEY_ENCRYPTION = 1;
+
+    private const SUBKEY_NONCE = 2;
+
+    /**
+     * Nullable because sodium_memzero() in __destruct() nullifies this by-reference argument.
+     */
+    private ?string $master;
+
+    private function __construct(string $master)
+    {
+        $this->master = $master;
+    }
+
+    /**
+     * @param string $master raw 32 byte key
+     *
+     * @throws \VCR\VCRException if the key does not have the required length
+     */
+    public static function fromBinary(string $master): self
+    {
+        Assertion::length(
+            $master,
+            \SODIUM_CRYPTO_KDF_KEYBYTES,
+            \sprintf('An encryption key must be exactly %d bytes.', \SODIUM_CRYPTO_KDF_KEYBYTES),
+            null,
+            '8bit'
+        );
+
+        return new self($master);
+    }
+
+    /**
+     * @throws \VCR\VCRException if the input is not base64 or does not decode to the required length
+     */
+    public static function fromBase64(string $master): self
+    {
+        $decoded = base64_decode($master, true);
+
+        Assertion::string($decoded, 'An encryption key must be valid base64.');
+
+        return self::fromBinary($decoded);
+    }
+
+    public static function generate(): self
+    {
+        return new self(sodium_crypto_kdf_keygen());
+    }
+
+    public function encryptionKey(): string
+    {
+        Assertion::notNull($this->master, 'The master key must be available.');
+
+        return sodium_crypto_kdf_derive_from_key(
+            \SODIUM_CRYPTO_KDF_KEYBYTES,
+            self::SUBKEY_ENCRYPTION,
+            self::CONTEXT,
+            $this->master
+        );
+    }
+
+    public function nonceKey(): string
+    {
+        Assertion::notNull($this->master, 'The master key must be available.');
+
+        return sodium_crypto_kdf_derive_from_key(
+            \SODIUM_CRYPTO_KDF_KEYBYTES,
+            self::SUBKEY_NONCE,
+            self::CONTEXT,
+            $this->master
+        );
+    }
+
+    public function toBase64(): string
+    {
+        Assertion::notNull($this->master, 'The master key must be available.');
+
+        return base64_encode($this->master);
+    }
+
+    public function __destruct()
+    {
+        sodium_memzero($this->master);
+    }
+}

--- a/src/VCR/Storage/Encryption/EncryptionPolicy.php
+++ b/src/VCR/Storage/Encryption/EncryptionPolicy.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Encryption;
+
+/**
+ * Decides which parts of a recording are encrypted and walks the recording array accordingly.
+ *
+ * Method, URL and status stay readable on purpose — otherwise a cassette diff carries no information
+ * at all.
+ */
+class EncryptionPolicy
+{
+    public const DEFAULT_FIELD_PATHS = [
+        'request.body',
+        'request.post_fields',
+        'request.post_files',
+        'response.body',
+    ];
+
+    public const DEFAULT_HEADER_NAMES = [
+        'Authorization',
+        'Proxy-Authorization',
+        'Cookie',
+        'Set-Cookie',
+        'X-Api-Key',
+    ];
+
+    private const TAG_STRING = 's:';
+
+    private const TAG_JSON = 'j:';
+
+    private const HEADER_CONTAINERS = ['request', 'response'];
+
+    /**
+     * @var string[]
+     */
+    private array $fieldPaths;
+
+    /**
+     * @var string[]
+     */
+    private array $headerNames;
+
+    /**
+     * @param string[]|null $fieldPaths  dot paths, defaults to self::DEFAULT_FIELD_PATHS
+     * @param string[]|null $headerNames matched case-insensitively in request and response headers
+     */
+    public function __construct(?array $fieldPaths = null, ?array $headerNames = null)
+    {
+        $this->fieldPaths = $fieldPaths ?? self::DEFAULT_FIELD_PATHS;
+        $this->headerNames = array_map('strtolower', $headerNames ?? self::DEFAULT_HEADER_NAMES);
+    }
+
+    /**
+     * @param array<string,mixed> $recording
+     *
+     * @return array<string,mixed>
+     */
+    public function encrypt(array $recording, CipherInterface $cipher): array
+    {
+        foreach ($this->resolvePaths($recording) as $path) {
+            $recording = $this->replace($recording, $path, function ($value) use ($cipher, $path) {
+                return $cipher->encrypt($this->tag($value, $path), $path);
+            });
+        }
+
+        return $recording;
+    }
+
+    /**
+     * @param array<string,mixed> $recording
+     *
+     * @return array<string,mixed>
+     */
+    public function decrypt(array $recording, CipherInterface $cipher): array
+    {
+        foreach ($this->resolvePaths($recording) as $path) {
+            $recording = $this->replace($recording, $path, function ($value) use ($cipher, $path) {
+                if (!\is_string($value) || !$cipher->isEncrypted($value)) {
+                    return $value;
+                }
+
+                return $this->untag($cipher->decrypt($value, $path), $path);
+            });
+        }
+
+        return $recording;
+    }
+
+    /**
+     * @param array<string,mixed> $recording
+     *
+     * @return string[]
+     */
+    private function resolvePaths(array $recording): array
+    {
+        $paths = $this->fieldPaths;
+
+        foreach (self::HEADER_CONTAINERS as $container) {
+            $headers = $recording[$container]['headers'] ?? null;
+
+            if (!\is_array($headers)) {
+                continue;
+            }
+
+            foreach (array_keys($headers) as $name) {
+                if (\in_array(strtolower((string) $name), $this->headerNames, true)) {
+                    $paths[] = $container.'.headers.'.$name;
+                }
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * @param array<string,mixed>    $recording
+     * @param \Closure(mixed): mixed $transform
+     *
+     * @return array<string,mixed>
+     */
+    private function replace(array $recording, string $path, \Closure $transform): array
+    {
+        $segments = explode('.', $path);
+        $lastIndex = \count($segments) - 1;
+        $cursor = &$recording;
+
+        foreach ($segments as $depth => $segment) {
+            if (!\is_array($cursor) || !\array_key_exists($segment, $cursor)) {
+                unset($cursor);
+
+                return $recording;
+            }
+
+            if ($depth === $lastIndex) {
+                $cursor[$segment] = $transform($cursor[$segment]);
+                unset($cursor);
+
+                return $recording;
+            }
+
+            $cursor = &$cursor[$segment];
+        }
+
+        unset($cursor);
+
+        return $recording;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function tag($value, string $path): string
+    {
+        if (\is_string($value)) {
+            return self::TAG_STRING.$value;
+        }
+
+        $encoded = json_encode($value);
+
+        if (!\is_string($encoded)) {
+            throw new \RuntimeException(\sprintf('The value in "%s" cannot be encoded for encryption.', $path));
+        }
+
+        return self::TAG_JSON.$encoded;
+    }
+
+    /**
+     * @return mixed
+     */
+    private function untag(string $plaintext, string $path)
+    {
+        $tag = substr($plaintext, 0, 2);
+        $payload = substr($plaintext, 2);
+
+        if (self::TAG_STRING === $tag) {
+            return $payload;
+        }
+
+        if (self::TAG_JSON === $tag) {
+            return json_decode($payload, true);
+        }
+
+        throw DecryptionFailedException::malformed($path);
+    }
+}

--- a/src/VCR/Storage/Encryption/EncryptionPolicy.php
+++ b/src/VCR/Storage/Encryption/EncryptionPolicy.php
@@ -17,6 +17,7 @@ class EncryptionPolicy
         'request.post_fields',
         'request.post_files',
         'response.body',
+        'response.curl_info.request_header',
     ];
 
     public const DEFAULT_HEADER_NAMES = [
@@ -60,10 +61,9 @@ class EncryptionPolicy
      */
     public function encrypt(array $recording, CipherInterface $cipher): array
     {
-        foreach ($this->resolvePaths($recording) as $path) {
-            $recording = $this->replace($recording, $path, function ($value) use ($cipher, $path) {
-                return $cipher->encrypt($this->tag($value, $path), $path);
-            });
+        foreach ($this->resolvePaths($recording) as $segments) {
+            $path = implode('.', $segments);
+            $recording = $this->replace($recording, $segments, fn ($value) => $cipher->encrypt($this->tag($value, $path), $path));
         }
 
         return $recording;
@@ -76,8 +76,9 @@ class EncryptionPolicy
      */
     public function decrypt(array $recording, CipherInterface $cipher): array
     {
-        foreach ($this->resolvePaths($recording) as $path) {
-            $recording = $this->replace($recording, $path, function ($value) use ($cipher, $path) {
+        foreach ($this->resolvePaths($recording) as $segments) {
+            $path = implode('.', $segments);
+            $recording = $this->replace($recording, $segments, function ($value) use ($cipher, $path) {
                 if (!\is_string($value) || !$cipher->isEncrypted($value)) {
                     return $value;
                 }
@@ -90,13 +91,19 @@ class EncryptionPolicy
     }
 
     /**
+     * Resolves every field this policy covers for the given recording into its segment path.
+     *
+     * Header names are carried through as a single opaque segment rather than being dot-joined,
+     * since HTTP header names are themselves allowed to contain literal dots (e.g. "X.Api.Secret")
+     * and re-splitting a joined string on "." would misinterpret such a name as several segments.
+     *
      * @param array<string,mixed> $recording
      *
-     * @return string[]
+     * @return array<int, string[]>
      */
     private function resolvePaths(array $recording): array
     {
-        $paths = $this->fieldPaths;
+        $paths = array_map(static fn (string $fieldPath): array => explode('.', $fieldPath), $this->fieldPaths);
 
         foreach (self::HEADER_CONTAINERS as $container) {
             $headers = $recording[$container]['headers'] ?? null;
@@ -107,7 +114,7 @@ class EncryptionPolicy
 
             foreach (array_keys($headers) as $name) {
                 if (\in_array(strtolower((string) $name), $this->headerNames, true)) {
-                    $paths[] = $container.'.headers.'.$name;
+                    $paths[] = [$container, 'headers', (string) $name];
                 }
             }
         }
@@ -117,13 +124,13 @@ class EncryptionPolicy
 
     /**
      * @param array<string,mixed>    $recording
+     * @param string[]               $segments
      * @param \Closure(mixed): mixed $transform
      *
      * @return array<string,mixed>
      */
-    private function replace(array $recording, string $path, \Closure $transform): array
+    private function replace(array $recording, array $segments, \Closure $transform): array
     {
-        $segments = explode('.', $path);
         $lastIndex = \count($segments) - 1;
         $cursor = &$recording;
 
@@ -149,10 +156,7 @@ class EncryptionPolicy
         return $recording;
     }
 
-    /**
-     * @param mixed $value
-     */
-    private function tag($value, string $path): string
+    private function tag(mixed $value, string $path): string
     {
         if (\is_string($value)) {
             return self::TAG_STRING.$value;
@@ -167,10 +171,7 @@ class EncryptionPolicy
         return self::TAG_JSON.$encoded;
     }
 
-    /**
-     * @return mixed
-     */
-    private function untag(string $plaintext, string $path)
+    private function untag(string $plaintext, string $path): mixed
     {
         $tag = substr($plaintext, 0, 2);
         $payload = substr($plaintext, 2);

--- a/src/VCR/Storage/Encryption/SodiumCipher.php
+++ b/src/VCR/Storage/Encryption/SodiumCipher.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Encryption;
+
+/**
+ * XChaCha20-Poly1305 with a nonce derived from the plaintext.
+ *
+ * Deriving the nonce instead of drawing it at random keeps a re-recorded cassette byte-identical, so
+ * re-recording produces no git diff. The cost is that equal plaintexts within the same field produce
+ * equal ciphertexts.
+ */
+class SodiumCipher implements CipherInterface
+{
+    private const MARKER = 'vcr:enc:';
+
+    private const SCHEME = 'v1';
+
+    private EncryptionKey $key;
+
+    public function __construct(EncryptionKey $key)
+    {
+        if (!\function_exists('sodium_crypto_aead_xchacha20poly1305_ietf_encrypt')) {
+            throw new \RuntimeException('The encrypted storage requires ext-sodium, which is not loaded.');
+        }
+
+        $this->key = $key;
+    }
+
+    public function encrypt(string $plaintext, string $fieldPath): string
+    {
+        $additionalData = $this->additionalData($fieldPath);
+        $nonce = sodium_crypto_generichash(
+            $additionalData."\0".$plaintext,
+            $this->key->nonceKey(),
+            \SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES
+        );
+
+        $ciphertext = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt(
+            $plaintext,
+            $additionalData,
+            $nonce,
+            $this->key->encryptionKey()
+        );
+
+        return self::MARKER.self::SCHEME.':'.base64_encode($nonce.$ciphertext);
+    }
+
+    public function decrypt(string $ciphertext, string $fieldPath): string
+    {
+        $payload = substr($ciphertext, \strlen(self::MARKER));
+        $separator = strpos($payload, ':');
+
+        if (false === $separator) {
+            throw DecryptionFailedException::malformed($fieldPath);
+        }
+
+        $scheme = substr($payload, 0, $separator);
+
+        if (self::SCHEME !== $scheme) {
+            throw UnsupportedSchemeException::forScheme($scheme, $fieldPath);
+        }
+
+        $binary = base64_decode(substr($payload, $separator + 1), true);
+
+        if (!\is_string($binary) || \strlen($binary) <= \SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES) {
+            throw DecryptionFailedException::malformed($fieldPath);
+        }
+
+        $plaintext = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt(
+            substr($binary, \SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES),
+            $this->additionalData($fieldPath),
+            substr($binary, 0, \SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES),
+            $this->key->encryptionKey()
+        );
+
+        if (!\is_string($plaintext)) {
+            throw DecryptionFailedException::forField($fieldPath);
+        }
+
+        return $plaintext;
+    }
+
+    public function isEncrypted(string $value): bool
+    {
+        return str_starts_with($value, self::MARKER);
+    }
+
+    private function additionalData(string $fieldPath): string
+    {
+        return self::SCHEME.'|'.$fieldPath;
+    }
+}

--- a/src/VCR/Storage/Encryption/UnsupportedSchemeException.php
+++ b/src/VCR/Storage/Encryption/UnsupportedSchemeException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Encryption;
+
+class UnsupportedSchemeException extends \RuntimeException
+{
+    public static function forScheme(string $scheme, string $fieldPath): self
+    {
+        return new self(\sprintf(
+            'The value in "%s" uses encryption scheme "%s", which this version of php-vcr cannot read.',
+            $fieldPath,
+            $scheme
+        ));
+    }
+}

--- a/src/VCR/Storage/PurgeableEncryptedStorage.php
+++ b/src/VCR/Storage/PurgeableEncryptedStorage.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+use VCR\Storage\Encryption\CipherInterface;
+use VCR\Storage\Encryption\EncryptionPolicy;
+
+/**
+ * Encrypted storage over an inner storage that can be purged.
+ *
+ * Kept separate from EncryptedStorage because the wrapped storage is only sometimes purgeable —
+ * implementing PurgeableStorageInterface unconditionally and throwing at runtime would break
+ * substitutability.
+ */
+class PurgeableEncryptedStorage extends EncryptedStorage implements PurgeableStorageInterface
+{
+    private PurgeableStorageInterface $storage;
+
+    public function __construct(PurgeableStorageInterface $storage, CipherInterface $cipher, EncryptionPolicy $policy)
+    {
+        parent::__construct($storage, $cipher, $policy);
+
+        $this->storage = $storage;
+    }
+
+    public function purge(): void
+    {
+        $this->storage->purge();
+    }
+}

--- a/tests/Integration/AbstractIntegrationTestCase.php
+++ b/tests/Integration/AbstractIntegrationTestCase.php
@@ -6,19 +6,31 @@ namespace VCR\Tests\Integration;
 
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
+use VCR\Storage\YamlStorageFactory;
+use VCR\VCR;
 
 abstract class AbstractIntegrationTestCase extends TestCase
 {
     protected function setUp(): void
     {
         vfsStream::setup('testDir');
-        \VCR\VCR::configure()
+
+        // Reset to the real Configuration defaults before every test, not just cassette path/hooks:
+        // VCR::configure() is a process-wide singleton, so a test that narrows the mode, the storage
+        // factory, or the request matchers would otherwise leak that into every test that runs after it
+        // in the same PHPUnit process.
+        VCR::configure()
             ->setCassettePath(vfsStream::url('testDir'))
-            ->enableLibraryHooks(['stream_wrapper', 'curl', 'soap']);
+            ->enableLibraryHooks(['stream_wrapper', 'curl', 'soap'])
+            ->setMode(VCR::MODE_NEW_EPISODES)
+            ->setStorageFactory(new YamlStorageFactory())
+            ->enableRequestMatchers([
+                'method', 'url', 'host', 'headers', 'body', 'post_fields', 'query_string', 'soap_operation',
+            ]);
     }
 
     protected function tearDown(): void
     {
-        \VCR\VCR::turnOff();
+        VCR::turnOff();
     }
 }

--- a/tests/Integration/Storage/EncryptedStorageIntegrationTest.php
+++ b/tests/Integration/Storage/EncryptedStorageIntegrationTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Storage;
+
+use org\bovigo\vfs\vfsStream;
+use VCR\Storage\EncryptedStorageFactory;
+use VCR\Storage\Encryption\DecryptionFailedException;
+use VCR\Storage\Encryption\EncryptionKey;
+use VCR\Storage\Encryption\EncryptionPolicy;
+use VCR\Storage\JsonStorageFactory;
+use VCR\Storage\YamlStorageFactory;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
+use VCR\VCR;
+
+final class EncryptedStorageIntegrationTest extends AbstractHttpServerIntegrationTestCase
+{
+    private const SECRET = 'hunter2-do-not-commit';
+
+    private EncryptionKey $key;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\extension_loaded('sodium')) {
+            $this->markTestSkipped('The encrypted storage requires ext-sodium, which is not loaded.');
+        }
+
+        $this->key = EncryptionKey::fromBinary(str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES));
+
+        VCR::configure()
+            ->setStorageFactory(EncryptedStorageFactory::withKey(new YamlStorageFactory(), $this->key))
+            ->enableRequestMatchers(['method', 'url', 'body', 'post_fields']);
+    }
+
+    private function post(): int
+    {
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'header' => "Content-Type: application/x-www-form-urlencoded\r\nAuthorization: Bearer ".self::SECRET."\r\n",
+                'content' => http_build_query(['password' => self::SECRET]),
+                'ignore_errors' => true,
+            ],
+        ]);
+
+        file_get_contents(self::$baseUrl.'/post', false, $context);
+
+        return 200;
+    }
+
+    private function get(): int
+    {
+        file_get_contents(self::$baseUrl.'/get?token='.self::SECRET);
+
+        return 200;
+    }
+
+    private function cassettePath(string $cassette): string
+    {
+        return vfsStream::url('testDir').'/'.$cassette;
+    }
+
+    private function cassetteContents(string $cassette): string
+    {
+        return (string) file_get_contents($this->cassettePath($cassette));
+    }
+
+    public function testRecordsCiphertextAndReplaysPlaintext(): void
+    {
+        $this->recordAndReplay('encrypted-post', fn (): int => $this->post());
+
+        $raw = $this->cassetteContents('encrypted-post');
+
+        $this->assertStringNotContainsString(self::SECRET, $raw, 'The secret must never hit the disk.');
+        $this->assertStringContainsString('vcr:enc:v1:', $raw);
+    }
+
+    public function testUrlStaysReadableForReview(): void
+    {
+        $this->recordAndReplay('readable-post', fn (): int => $this->post());
+
+        $this->assertStringContainsString('/post', $this->cassetteContents('readable-post'));
+    }
+
+    public function testReplayWorksWithBodyMatchersEnabled(): void
+    {
+        VCR::configure()->enableRequestMatchers(['method', 'url', 'body', 'post_fields', 'headers']);
+
+        $this->recordAndReplay('matcher-post', fn (): int => $this->post());
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testReRecordingProducesBytewiseIdenticalCassettes(): void
+    {
+        $this->recordAndReplay('deterministic-post', fn (): int => $this->post());
+        preg_match_all('/vcr:enc:v1:[A-Za-z0-9+\/=]+/', $this->cassetteContents('deterministic-post'), $first);
+
+        // A distinct cassette name avoids VCRFactory's per-name Storage cache, same reasoning as
+        // testReplayingWithTheWrongKeyFails. The assertion below is scoped to the ciphertext values
+        // rather than the whole file because response.curl_info (e.g. local_port) is a fresh,
+        // non-reproducible value on every real HTTP round-trip and has nothing to do with the
+        // encryption feature's determinism guarantee.
+        VCR::turnOn();
+        VCR::insertCassette('deterministic-post-2nd');
+        $this->post();
+        VCR::turnOff();
+        preg_match_all('/vcr:enc:v1:[A-Za-z0-9+\/=]+/', $this->cassetteContents('deterministic-post-2nd'), $second);
+
+        $this->assertNotEmpty($first[0], 'Expected at least one encrypted field in the recorded cassette.');
+        $this->assertSame($first[0], $second[0], 'A re-recorded cassette must produce byte-identical ciphertext for its encrypted fields.');
+    }
+
+    public function testReplayingWithTheWrongKeyFails(): void
+    {
+        $this->recordAndReplay('wrong-key-post', fn (): int => $this->post());
+
+        // A distinct cassette name avoids VCRFactory's per-name Storage cache, which would
+        // otherwise hand back the instance already bound to the correct key.
+        file_put_contents($this->cassettePath('wrong-key-post-replay'), $this->cassetteContents('wrong-key-post'));
+
+        VCR::configure()->setStorageFactory(
+            EncryptedStorageFactory::withKey(
+                new YamlStorageFactory(),
+                EncryptionKey::fromBinary(str_repeat("\x7f", \SODIUM_CRYPTO_KDF_KEYBYTES))
+            )
+        );
+
+        $this->expectException(DecryptionFailedException::class);
+
+        VCR::turnOn();
+        VCR::insertCassette('wrong-key-post-replay');
+        $this->post();
+    }
+
+    public function testMovingCiphertextToAnotherFieldBreaksReplay(): void
+    {
+        $this->recordAndReplay('tampered-post', fn (): int => $this->post());
+
+        $raw = $this->cassetteContents('tampered-post');
+        $this->assertSame(1, preg_match('/(vcr:enc:v1:[A-Za-z0-9+\/=]+)/', $raw, $matches));
+        $tampered = preg_replace('/(vcr:enc:v1:[A-Za-z0-9+\/=]+)/', $matches[1], $raw);
+
+        // A distinct cassette name avoids VCRFactory's per-name Storage cache; otherwise the
+        // tampered bytes below are never re-parsed, see testReplayingWithTheWrongKeyFails.
+        file_put_contents($this->cassettePath('tampered-post-replay'), (string) $tampered);
+
+        $this->expectException(DecryptionFailedException::class);
+
+        VCR::turnOn();
+        VCR::insertCassette('tampered-post-replay');
+        $this->post();
+    }
+
+    public function testAPlaintextCassetteStaysReplayable(): void
+    {
+        VCR::configure()->setStorageFactory(new YamlStorageFactory());
+
+        $this->recordAndReplay('plaintext-post', fn (): int => $this->post());
+
+        VCR::configure()->setStorageFactory(
+            EncryptedStorageFactory::withKey(new YamlStorageFactory(), $this->key)
+        );
+
+        VCR::turnOn();
+        VCR::insertCassette('plaintext-post');
+        $status = $this->post();
+        VCR::turnOff();
+
+        $this->assertSame(200, $status, 'Cassettes recorded before encryption must keep working.');
+    }
+
+    public function testRequestsWithoutSensitiveFieldsAreRecordedUnchanged(): void
+    {
+        $this->recordAndReplay('plain-get', fn (): int => $this->get());
+
+        $raw = $this->cassetteContents('plain-get');
+
+        $this->assertStringContainsString(self::SECRET, $raw, 'Query string secrets are a documented limitation.');
+    }
+
+    public function testACustomPolicyIsApplied(): void
+    {
+        VCR::configure()->setStorageFactory(
+            EncryptedStorageFactory::withKey(
+                new YamlStorageFactory(),
+                $this->key,
+                new EncryptionPolicy(['response.body'], [])
+            )
+        );
+
+        $this->recordAndReplay('custom-policy-post', fn (): int => $this->post());
+
+        $raw = $this->cassetteContents('custom-policy-post');
+
+        $this->assertStringContainsString(self::SECRET, $raw, 'The request body is outside this policy.');
+        $this->assertStringContainsString('vcr:enc:v1:', $raw, 'The response body is inside it.');
+    }
+
+    public function testWorksOverJsonStorageAsWell(): void
+    {
+        VCR::configure()->setStorageFactory(
+            EncryptedStorageFactory::withKey(new JsonStorageFactory(), $this->key)
+        );
+
+        $this->recordAndReplay('encrypted-json-post', fn (): int => $this->post());
+
+        $raw = $this->cassetteContents('encrypted-json-post');
+
+        $this->assertStringNotContainsString(self::SECRET, $raw);
+        $this->assertStringContainsString('vcr:enc:v1:', $raw);
+    }
+
+    public function testRecordModeAllPurgesAndReRecords(): void
+    {
+        $this->recordAndReplay('mode-all-post', fn (): int => $this->post());
+
+        VCR::configure()->setMode(VCR::MODE_ALL);
+
+        $countBefore = $this->server()->getRequestCount();
+        VCR::turnOn();
+        VCR::insertCassette('mode-all-post');
+        $this->post();
+        VCR::turnOff();
+
+        $this->assertSame($countBefore + 1, $this->server()->getRequestCount(), 'MODE_ALL must re-record.');
+        $this->assertStringNotContainsString(self::SECRET, $this->cassetteContents('mode-all-post'));
+    }
+}

--- a/tests/Integration/Storage/EncryptedStorageIntegrationTest.php
+++ b/tests/Integration/Storage/EncryptedStorageIntegrationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace VCR\Tests\Integration\Storage;
 
 use org\bovigo\vfs\vfsStream;
+use VCR\LibraryHooks\StreamWrapperHook;
 use VCR\Storage\EncryptedStorageFactory;
 use VCR\Storage\Encryption\DecryptionFailedException;
 use VCR\Storage\Encryption\EncryptionKey;
@@ -46,16 +47,47 @@ final class EncryptedStorageIntegrationTest extends AbstractHttpServerIntegratio
             ],
         ]);
 
-        file_get_contents(self::$baseUrl.'/post', false, $context);
-
-        return 200;
+        return $this->performAndReadStatus(self::$baseUrl.'/post', $context);
     }
 
     private function get(): int
     {
-        file_get_contents(self::$baseUrl.'/get?token='.self::SECRET);
+        return $this->performAndReadStatus(self::$baseUrl.'/get?token='.self::SECRET, stream_context_create());
+    }
 
-        return 200;
+    /**
+     * @param resource $context
+     */
+    private function performAndReadStatus(string $url, $context): int
+    {
+        $stream = fopen($url, 'r', false, $context);
+
+        if (false === $stream) {
+            throw new \RuntimeException(\sprintf('Unable to open a stream to "%s".', $url));
+        }
+
+        // StreamWrapperHook::streamGetMetaData() reports the real response header lines whether
+        // the stream was served by VCR's own wrapper (replay) or PHP's native http wrapper
+        // (recording, since library hooks are disabled around the real outbound request).
+        $meta = StreamWrapperHook::streamGetMetaData($stream);
+        fclose($stream);
+
+        /** @var string[] $responseHeaders */
+        $responseHeaders = \is_array($meta['wrapper_data'] ?? null) ? $meta['wrapper_data'] : [];
+
+        return $this->statusFromResponseHeaders($responseHeaders);
+    }
+
+    /**
+     * @param string[] $responseHeaders
+     */
+    private function statusFromResponseHeaders(array $responseHeaders): int
+    {
+        if (!isset($responseHeaders[0]) || !preg_match('#^HTTP/\S+\s+(\d{3})#', $responseHeaders[0], $matches)) {
+            throw new \RuntimeException('Unable to determine the HTTP status code from the response headers.');
+        }
+
+        return (int) $matches[1];
     }
 
     private function cassettePath(string $cassette): string
@@ -161,15 +193,23 @@ final class EncryptedStorageIntegrationTest extends AbstractHttpServerIntegratio
 
         $this->recordAndReplay('plaintext-post', fn (): int => $this->post());
 
+        // A distinct cassette name avoids VCRFactory's per-name Storage cache, which would
+        // otherwise hand back the already-cached plain Yaml storage from the phase above, same
+        // reasoning as testReplayingWithTheWrongKeyFails.
+        file_put_contents($this->cassettePath('plaintext-post-replay'), $this->cassetteContents('plaintext-post'));
+
         VCR::configure()->setStorageFactory(
             EncryptedStorageFactory::withKey(new YamlStorageFactory(), $this->key)
         );
 
+        $countBefore = $this->server()->getRequestCount();
+
         VCR::turnOn();
-        VCR::insertCassette('plaintext-post');
+        VCR::insertCassette('plaintext-post-replay');
         $status = $this->post();
         VCR::turnOff();
 
+        $this->assertSame($countBefore, $this->server()->getRequestCount(), 'Replay must not hit the server.');
         $this->assertSame(200, $status, 'Cassettes recorded before encryption must keep working.');
     }
 

--- a/tests/Unit/Storage/EncryptedStorageFactoryTest.php
+++ b/tests/Unit/Storage/EncryptedStorageFactoryTest.php
@@ -22,6 +22,10 @@ final class EncryptedStorageFactoryTest extends TestCase
 
     protected function setUp(): void
     {
+        if (!\extension_loaded('sodium')) {
+            $this->markTestSkipped('The encrypted storage requires ext-sodium, which is not loaded.');
+        }
+
         vfsStream::setup('testDir');
         $this->key = EncryptionKey::fromBinary(str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES));
     }

--- a/tests/Unit/Storage/EncryptedStorageFactoryTest.php
+++ b/tests/Unit/Storage/EncryptedStorageFactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\EncryptedStorage;
+use VCR\Storage\EncryptedStorageFactory;
+use VCR\Storage\Encryption\EncryptionKey;
+use VCR\Storage\Encryption\EncryptionPolicy;
+use VCR\Storage\Encryption\SodiumCipher;
+use VCR\Storage\JsonStorageFactory;
+use VCR\Storage\PurgeableEncryptedStorage;
+use VCR\Storage\StorageFactoryInterface;
+use VCR\Storage\YamlStorageFactory;
+
+final class EncryptedStorageFactoryTest extends TestCase
+{
+    private EncryptionKey $key;
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        $this->key = EncryptionKey::fromBinary(str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES));
+    }
+
+    public function testImplementsStorageFactoryInterface(): void
+    {
+        $factory = EncryptedStorageFactory::withKey(new YamlStorageFactory(), $this->key);
+
+        $this->assertInstanceOf(StorageFactoryInterface::class, $factory);
+    }
+
+    public function testWrapsAPurgeableStorageInThePurgeableVariant(): void
+    {
+        $factory = EncryptedStorageFactory::withKey(new YamlStorageFactory(), $this->key);
+
+        $storage = $factory->create(vfsStream::url('testDir').'/', 'yaml-cassette');
+
+        $this->assertInstanceOf(PurgeableEncryptedStorage::class, $storage);
+    }
+
+    public function testWorksOverJsonStorageAsWell(): void
+    {
+        $factory = EncryptedStorageFactory::withKey(new JsonStorageFactory(), $this->key);
+
+        $storage = $factory->create(vfsStream::url('testDir').'/', 'json-cassette');
+
+        $this->assertInstanceOf(EncryptedStorage::class, $storage);
+    }
+
+    public function testAcceptsAnExplicitCipherAndPolicy(): void
+    {
+        $factory = new EncryptedStorageFactory(
+            new YamlStorageFactory(),
+            new SodiumCipher($this->key),
+            new EncryptionPolicy(['response.body'], [])
+        );
+
+        $storage = $factory->create(vfsStream::url('testDir').'/', 'explicit-cassette');
+
+        $this->assertInstanceOf(EncryptedStorage::class, $storage);
+    }
+
+    public function testCreatedStorageWrapsTheGivenCassette(): void
+    {
+        $factory = EncryptedStorageFactory::withKey(new YamlStorageFactory(), $this->key);
+
+        $storage = $factory->create(vfsStream::url('testDir').'/', 'fresh-cassette');
+
+        $this->assertTrue($storage->isNew(), 'A freshly created cassette should be new.');
+    }
+
+    public function testEachCassetteGetsItsOwnStorage(): void
+    {
+        $factory = EncryptedStorageFactory::withKey(new YamlStorageFactory(), $this->key);
+
+        $first = $factory->create(vfsStream::url('testDir').'/', 'first-cassette');
+        $second = $factory->create(vfsStream::url('testDir').'/', 'second-cassette');
+
+        $this->assertNotSame($first, $second);
+    }
+}

--- a/tests/Unit/Storage/EncryptedStorageTest.php
+++ b/tests/Unit/Storage/EncryptedStorageTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\EncryptedStorage;
+use VCR\Storage\Encryption\EncryptionKey;
+use VCR\Storage\Encryption\EncryptionPolicy;
+use VCR\Storage\Encryption\SodiumCipher;
+use VCR\Storage\PurgeableEncryptedStorage;
+use VCR\Storage\PurgeableStorageInterface;
+use VCR\Storage\StorageInterface;
+use VCR\Storage\Yaml;
+
+final class EncryptedStorageTest extends TestCase
+{
+    private SodiumCipher $cipher;
+
+    private Yaml $inner;
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        $this->cipher = new SodiumCipher(
+            EncryptionKey::fromBinary(str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES))
+        );
+        $this->inner = new Yaml(vfsStream::url('testDir').'/', 'encrypted_test');
+    }
+
+    private function storage(): EncryptedStorage
+    {
+        return new EncryptedStorage($this->inner, $this->cipher, new EncryptionPolicy());
+    }
+
+    private function rawCassette(): string
+    {
+        return (string) file_get_contents(vfsStream::url('testDir').'/encrypted_test');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(int $index = 0): array
+    {
+        return [
+            'request' => [
+                'method' => 'POST',
+                'url' => 'https://api.example.com/login',
+                'headers' => ['Authorization' => 'Bearer secret'],
+                'body' => 'hunter2',
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+                'body' => 'welcome',
+            ],
+            'index' => $index,
+        ];
+    }
+
+    public function testImplementsStorageInterface(): void
+    {
+        $this->assertInstanceOf(StorageInterface::class, $this->storage());
+    }
+
+    public function testWritesCiphertextToTheInnerStorage(): void
+    {
+        $this->storage()->storeRecording($this->recording());
+
+        $raw = $this->rawCassette();
+
+        $this->assertStringNotContainsString('hunter2', $raw);
+        $this->assertStringNotContainsString('Bearer secret', $raw);
+        $this->assertStringContainsString('vcr:enc:v1:', $raw);
+    }
+
+    public function testUrlAndMethodStayReadableOnDisk(): void
+    {
+        $this->storage()->storeRecording($this->recording());
+
+        $raw = $this->rawCassette();
+
+        $this->assertStringContainsString('https://api.example.com/login', $raw);
+        $this->assertStringContainsString('POST', $raw);
+    }
+
+    public function testIteratingReturnsPlaintext(): void
+    {
+        $storage = $this->storage();
+        $storage->storeRecording($this->recording());
+
+        $storage->rewind();
+        $storage->valid();
+
+        $this->assertSame($this->recording(), $storage->current());
+    }
+
+    public function testIteratingSeveralRecordingsReturnsThemInOrder(): void
+    {
+        $storage = $this->storage();
+        $storage->storeRecording($this->recording(0));
+        $storage->storeRecording($this->recording(1));
+
+        $collected = [];
+        foreach ($storage as $recording) {
+            $collected[] = $recording;
+        }
+
+        $this->assertSame([$this->recording(0), $this->recording(1)], $collected);
+    }
+
+    public function testKeyIsDelegated(): void
+    {
+        $storage = $this->storage();
+        $storage->storeRecording($this->recording());
+
+        $storage->rewind();
+        $storage->next();
+
+        $this->assertSame($this->inner->key(), $storage->key());
+    }
+
+    public function testIsNewIsDelegated(): void
+    {
+        $this->assertSame($this->inner->isNew(), $this->storage()->isNew());
+    }
+
+    public function testPurgeableVariantIsAPurgeableStorage(): void
+    {
+        $storage = new PurgeableEncryptedStorage($this->inner, $this->cipher, new EncryptionPolicy());
+
+        $this->assertInstanceOf(PurgeableStorageInterface::class, $storage);
+        $this->assertInstanceOf(EncryptedStorage::class, $storage);
+    }
+
+    public function testPurgeClearsTheInnerStorage(): void
+    {
+        $storage = new PurgeableEncryptedStorage($this->inner, $this->cipher, new EncryptionPolicy());
+        $storage->storeRecording($this->recording());
+
+        $storage->purge();
+        $storage->rewind();
+
+        $this->assertFalse($storage->valid());
+    }
+
+    public function testPlainVariantIsNotPurgeable(): void
+    {
+        $this->assertNotInstanceOf(PurgeableStorageInterface::class, $this->storage());
+    }
+}

--- a/tests/Unit/Storage/EncryptedStorageTest.php
+++ b/tests/Unit/Storage/EncryptedStorageTest.php
@@ -23,6 +23,10 @@ final class EncryptedStorageTest extends TestCase
 
     protected function setUp(): void
     {
+        if (!\extension_loaded('sodium')) {
+            $this->markTestSkipped('The encrypted storage requires ext-sodium, which is not loaded.');
+        }
+
         vfsStream::setup('testDir');
         $this->cipher = new SodiumCipher(
             EncryptionKey::fromBinary(str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES))

--- a/tests/Unit/Storage/Encryption/DecryptionFailedExceptionTest.php
+++ b/tests/Unit/Storage/Encryption/DecryptionFailedExceptionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Encryption;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Encryption\DecryptionFailedException;
+
+final class DecryptionFailedExceptionTest extends TestCase
+{
+    public function testIsARuntimeException(): void
+    {
+        $this->assertInstanceOf(\RuntimeException::class, DecryptionFailedException::forField('request.body'));
+    }
+
+    public function testForFieldNamesTheAffectedField(): void
+    {
+        $exception = DecryptionFailedException::forField('request.headers.Authorization');
+
+        $this->assertStringContainsString('request.headers.Authorization', $exception->getMessage());
+    }
+
+    public function testForFieldListsThePlausibleCauses(): void
+    {
+        $message = DecryptionFailedException::forField('request.body')->getMessage();
+
+        $this->assertStringContainsString('key', $message);
+        $this->assertStringContainsString('altered', $message);
+        $this->assertStringContainsString('different field', $message);
+    }
+
+    public function testMalformedNamesTheAffectedField(): void
+    {
+        $exception = DecryptionFailedException::malformed('response.body');
+
+        $this->assertStringContainsString('response.body', $exception->getMessage());
+        $this->assertStringContainsString('malformed', $exception->getMessage());
+    }
+}

--- a/tests/Unit/Storage/Encryption/EncryptionKeyTest.php
+++ b/tests/Unit/Storage/Encryption/EncryptionKeyTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Encryption;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Encryption\EncryptionKey;
+use VCR\VCRException;
+
+final class EncryptionKeyTest extends TestCase
+{
+    public function testGenerateProducesSubkeysOfTheExpectedLength(): void
+    {
+        $key = EncryptionKey::generate();
+
+        $this->assertSame(\SODIUM_CRYPTO_KDF_KEYBYTES, \strlen($key->encryptionKey()));
+        $this->assertSame(\SODIUM_CRYPTO_KDF_KEYBYTES, \strlen($key->nonceKey()));
+    }
+
+    public function testGenerateProducesADifferentKeyEachTime(): void
+    {
+        $this->assertNotSame(
+            EncryptionKey::generate()->toBase64(),
+            EncryptionKey::generate()->toBase64()
+        );
+    }
+
+    public function testEncryptionAndNonceSubkeysDiffer(): void
+    {
+        $key = EncryptionKey::generate();
+
+        $this->assertNotSame(
+            $key->encryptionKey(),
+            $key->nonceKey(),
+            'Deriving the nonce with the encryption key would reuse one key in two roles.'
+        );
+    }
+
+    public function testSubkeyDerivationIsDeterministic(): void
+    {
+        $master = str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES);
+
+        $this->assertSame(
+            EncryptionKey::fromBinary($master)->encryptionKey(),
+            EncryptionKey::fromBinary($master)->encryptionKey()
+        );
+        $this->assertSame(
+            EncryptionKey::fromBinary($master)->nonceKey(),
+            EncryptionKey::fromBinary($master)->nonceKey()
+        );
+    }
+
+    public function testDifferentMasterKeysProduceDifferentSubkeys(): void
+    {
+        $first = EncryptionKey::fromBinary(str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES));
+        $second = EncryptionKey::fromBinary(str_repeat("\x7f", \SODIUM_CRYPTO_KDF_KEYBYTES));
+
+        $this->assertNotSame($first->encryptionKey(), $second->encryptionKey());
+    }
+
+    public function testBase64RoundTripPreservesTheSubkeys(): void
+    {
+        $key = EncryptionKey::generate();
+
+        $restored = EncryptionKey::fromBase64($key->toBase64());
+
+        $this->assertSame($key->encryptionKey(), $restored->encryptionKey());
+        $this->assertSame($key->nonceKey(), $restored->nonceKey());
+    }
+
+    public function testAcceptsAMasterKeyContainingNullBytes(): void
+    {
+        $master = str_repeat("\x00", \SODIUM_CRYPTO_KDF_KEYBYTES);
+
+        $this->assertSame(
+            \SODIUM_CRYPTO_KDF_KEYBYTES,
+            \strlen(EncryptionKey::fromBinary($master)->encryptionKey())
+        );
+    }
+
+    public function testFromBinaryRejectsAKeyThatIsTooShort(): void
+    {
+        $this->expectException(VCRException::class);
+        $this->expectExceptionMessage('must be exactly 32 bytes');
+
+        EncryptionKey::fromBinary('too-short');
+    }
+
+    public function testFromBinaryRejectsAKeyThatIsTooLong(): void
+    {
+        $this->expectException(VCRException::class);
+
+        EncryptionKey::fromBinary(str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES + 1));
+    }
+
+    public function testFromBase64RejectsInputThatIsNotBase64(): void
+    {
+        $this->expectException(VCRException::class);
+        $this->expectExceptionMessage('valid base64');
+
+        EncryptionKey::fromBase64('not valid base64 !!');
+    }
+
+    public function testFromBase64RejectsValidBase64OfTheWrongLength(): void
+    {
+        $this->expectException(VCRException::class);
+        $this->expectExceptionMessage('must be exactly 32 bytes');
+
+        EncryptionKey::fromBase64(base64_encode('short'));
+    }
+}

--- a/tests/Unit/Storage/Encryption/EncryptionPolicyTest.php
+++ b/tests/Unit/Storage/Encryption/EncryptionPolicyTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Encryption;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Encryption\DecryptionFailedException;
+use VCR\Storage\Encryption\EncryptionKey;
+use VCR\Storage\Encryption\EncryptionPolicy;
+use VCR\Storage\Encryption\SodiumCipher;
+
+final class EncryptionPolicyTest extends TestCase
+{
+    private SodiumCipher $cipher;
+
+    protected function setUp(): void
+    {
+        $this->cipher = new SodiumCipher(
+            EncryptionKey::fromBinary(str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES))
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(): array
+    {
+        return [
+            'request' => [
+                'method' => 'POST',
+                'url' => 'https://api.example.com/login',
+                'headers' => [
+                    'Host' => 'api.example.com',
+                    'authorization' => 'Bearer secret',
+                    'X-Trace-Id' => 'abc-123',
+                ],
+                'body' => '{"password":"hunter2"}',
+                'post_fields' => ['user' => 'alice', 'password' => 'hunter2'],
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+                'headers' => ['Set-Cookie' => 'session=abc', 'Content-Type' => 'application/json'],
+                'body' => 'welcome',
+            ],
+            'index' => 0,
+        ];
+    }
+
+    public function testEncryptsTheDefaultBodyFields(): void
+    {
+        $encrypted = (new EncryptionPolicy())->encrypt($this->recording(), $this->cipher);
+
+        $this->assertStringStartsWith('vcr:enc:v1:', $encrypted['request']['body']);
+        $this->assertStringStartsWith('vcr:enc:v1:', $encrypted['response']['body']);
+    }
+
+    public function testEncryptsTheDefaultHeaders(): void
+    {
+        $encrypted = (new EncryptionPolicy())->encrypt($this->recording(), $this->cipher);
+
+        $this->assertStringStartsWith('vcr:enc:v1:', $encrypted['request']['headers']['authorization']);
+        $this->assertStringStartsWith('vcr:enc:v1:', $encrypted['response']['headers']['Set-Cookie']);
+    }
+
+    public function testLeavesRoutingFieldsReadable(): void
+    {
+        $encrypted = (new EncryptionPolicy())->encrypt($this->recording(), $this->cipher);
+
+        $this->assertSame('POST', $encrypted['request']['method']);
+        $this->assertSame('https://api.example.com/login', $encrypted['request']['url']);
+        $this->assertSame(['code' => 200, 'message' => 'OK'], $encrypted['response']['status']);
+        $this->assertSame(0, $encrypted['index']);
+    }
+
+    public function testLeavesHeadersOutsideTheListReadable(): void
+    {
+        $encrypted = (new EncryptionPolicy())->encrypt($this->recording(), $this->cipher);
+
+        $this->assertSame('api.example.com', $encrypted['request']['headers']['Host']);
+        $this->assertSame('abc-123', $encrypted['request']['headers']['X-Trace-Id']);
+        $this->assertSame('application/json', $encrypted['response']['headers']['Content-Type']);
+    }
+
+    public function testHeaderNamesMatchCaseInsensitively(): void
+    {
+        $policy = new EncryptionPolicy([], ['AUTHORIZATION']);
+
+        $encrypted = $policy->encrypt($this->recording(), $this->cipher);
+
+        $this->assertStringStartsWith('vcr:enc:v1:', $encrypted['request']['headers']['authorization']);
+    }
+
+    public function testRoundTripRestoresTheOriginalRecording(): void
+    {
+        $policy = new EncryptionPolicy();
+        $original = $this->recording();
+
+        $restored = $policy->decrypt($policy->encrypt($original, $this->cipher), $this->cipher);
+
+        $this->assertSame($original, $restored);
+    }
+
+    public function testArrayFieldsAreStoredAsStringsAndRestoredAsArrays(): void
+    {
+        $policy = new EncryptionPolicy();
+
+        $encrypted = $policy->encrypt($this->recording(), $this->cipher);
+        $this->assertIsString($encrypted['request']['post_fields']);
+
+        $restored = $policy->decrypt($encrypted, $this->cipher);
+        $this->assertSame(['user' => 'alice', 'password' => 'hunter2'], $restored['request']['post_fields']);
+    }
+
+    public function testNestedArrayFieldsSurviveTheRoundTrip(): void
+    {
+        $policy = new EncryptionPolicy(['request.post_files'], []);
+        $recording = [
+            'request' => ['post_files' => [['fieldName' => 'file', 'contentType' => 'text/plain']]],
+            'index' => 0,
+        ];
+
+        $restored = $policy->decrypt($policy->encrypt($recording, $this->cipher), $this->cipher);
+
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testMissingFieldsAreSkipped(): void
+    {
+        $recording = ['request' => ['method' => 'GET', 'url' => 'https://example.com'], 'index' => 0];
+
+        $encrypted = (new EncryptionPolicy())->encrypt($recording, $this->cipher);
+
+        $this->assertSame($recording, $encrypted);
+    }
+
+    public function testRecordingWithoutHeadersIsHandled(): void
+    {
+        $recording = ['request' => ['method' => 'GET', 'url' => 'https://example.com', 'body' => 'x'], 'index' => 0];
+
+        $encrypted = (new EncryptionPolicy())->encrypt($recording, $this->cipher);
+
+        $this->assertStringStartsWith('vcr:enc:v1:', $encrypted['request']['body']);
+    }
+
+    public function testNonArrayHeadersAreIgnored(): void
+    {
+        $recording = ['request' => ['headers' => 'not-an-array', 'body' => 'x'], 'index' => 0];
+
+        $encrypted = (new EncryptionPolicy())->encrypt($recording, $this->cipher);
+
+        $this->assertSame('not-an-array', $encrypted['request']['headers']);
+    }
+
+    public function testPlaintextFieldsArePassedThroughOnDecrypt(): void
+    {
+        $recording = $this->recording();
+
+        $restored = (new EncryptionPolicy())->decrypt($recording, $this->cipher);
+
+        $this->assertSame($recording, $restored, 'A cassette recorded without encryption must stay readable.');
+    }
+
+    public function testPartiallyEncryptedRecordingsAreHandled(): void
+    {
+        $policy = new EncryptionPolicy();
+        $recording = $this->recording();
+        $recording['request']['body'] = $this->cipher->encrypt('s:{"password":"hunter2"}', 'request.body');
+
+        $restored = $policy->decrypt($recording, $this->cipher);
+
+        $this->assertSame('{"password":"hunter2"}', $restored['request']['body']);
+        $this->assertSame('welcome', $restored['response']['body']);
+    }
+
+    public function testCustomFieldPathsReplaceTheDefaults(): void
+    {
+        $policy = new EncryptionPolicy(['response.body'], []);
+
+        $encrypted = $policy->encrypt($this->recording(), $this->cipher);
+
+        $this->assertStringStartsWith('vcr:enc:v1:', $encrypted['response']['body']);
+        $this->assertSame('{"password":"hunter2"}', $encrypted['request']['body']);
+    }
+
+    public function testEmptyListsEncryptNothing(): void
+    {
+        $recording = $this->recording();
+
+        $this->assertSame($recording, (new EncryptionPolicy([], []))->encrypt($recording, $this->cipher));
+    }
+
+    public function testDefaultsAreExposedAsConstants(): void
+    {
+        $this->assertContains('request.body', EncryptionPolicy::DEFAULT_FIELD_PATHS);
+        $this->assertContains('request.post_fields', EncryptionPolicy::DEFAULT_FIELD_PATHS);
+        $this->assertContains('request.post_files', EncryptionPolicy::DEFAULT_FIELD_PATHS);
+        $this->assertContains('response.body', EncryptionPolicy::DEFAULT_FIELD_PATHS);
+        $this->assertContains('Authorization', EncryptionPolicy::DEFAULT_HEADER_NAMES);
+        $this->assertContains('Set-Cookie', EncryptionPolicy::DEFAULT_HEADER_NAMES);
+    }
+
+    public function testEachFieldIsEncryptedUnderItsOwnPath(): void
+    {
+        $recording = ['request' => ['body' => 'same'], 'response' => ['body' => 'same'], 'index' => 0];
+
+        $encrypted = (new EncryptionPolicy())->encrypt($recording, $this->cipher);
+
+        $this->assertNotSame(
+            $encrypted['request']['body'],
+            $encrypted['response']['body'],
+            'Identical values in different fields must not produce identical ciphertext.'
+        );
+    }
+
+    public function testAnUnknownTypeTagIsRejected(): void
+    {
+        $recording = [
+            'request' => ['body' => $this->cipher->encrypt('x:garbage', 'request.body')],
+            'index' => 0,
+        ];
+
+        $this->expectException(DecryptionFailedException::class);
+
+        (new EncryptionPolicy())->decrypt($recording, $this->cipher);
+    }
+
+    public function testDecryptingWithTheWrongKeyFails(): void
+    {
+        $policy = new EncryptionPolicy();
+        $encrypted = $policy->encrypt($this->recording(), $this->cipher);
+        $other = new SodiumCipher(EncryptionKey::fromBinary(str_repeat("\x7f", \SODIUM_CRYPTO_KDF_KEYBYTES)));
+
+        $this->expectException(DecryptionFailedException::class);
+
+        $policy->decrypt($encrypted, $other);
+    }
+}

--- a/tests/Unit/Storage/Encryption/EncryptionPolicyTest.php
+++ b/tests/Unit/Storage/Encryption/EncryptionPolicyTest.php
@@ -16,6 +16,10 @@ final class EncryptionPolicyTest extends TestCase
 
     protected function setUp(): void
     {
+        if (!\extension_loaded('sodium')) {
+            $this->markTestSkipped('The encrypted storage requires ext-sodium, which is not loaded.');
+        }
+
         $this->cipher = new SodiumCipher(
             EncryptionKey::fromBinary(str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES))
         );
@@ -234,5 +238,40 @@ final class EncryptionPolicyTest extends TestCase
         $this->expectException(DecryptionFailedException::class);
 
         $policy->decrypt($encrypted, $other);
+    }
+
+    public function testEncryptsTheOutboundCurlRequestHeaderTrace(): void
+    {
+        $recording = $this->recording();
+        $recording['response']['curl_info'] = [
+            'request_header' => "GET / HTTP/1.1\r\nAuthorization: Bearer secret\r\n\r\n",
+        ];
+
+        $encrypted = (new EncryptionPolicy())->encrypt($recording, $this->cipher);
+
+        $this->assertStringStartsWith('vcr:enc:v1:', $encrypted['response']['curl_info']['request_header']);
+        $this->assertStringNotContainsString('Bearer secret', $encrypted['response']['curl_info']['request_header']);
+
+        $restored = (new EncryptionPolicy())->decrypt($encrypted, $this->cipher);
+
+        $this->assertSame(
+            "GET / HTTP/1.1\r\nAuthorization: Bearer secret\r\n\r\n",
+            $restored['response']['curl_info']['request_header']
+        );
+    }
+
+    public function testHeaderNamesContainingDotsAreHandledCorrectly(): void
+    {
+        $policy = new EncryptionPolicy([], ['X.Api.Secret']);
+        $recording = $this->recording();
+        $recording['request']['headers']['X.Api.Secret'] = 'top-secret';
+
+        $encrypted = $policy->encrypt($recording, $this->cipher);
+
+        $this->assertStringStartsWith('vcr:enc:v1:', $encrypted['request']['headers']['X.Api.Secret']);
+
+        $restored = $policy->decrypt($encrypted, $this->cipher);
+
+        $this->assertSame('top-secret', $restored['request']['headers']['X.Api.Secret']);
     }
 }

--- a/tests/Unit/Storage/Encryption/SodiumCipherTest.php
+++ b/tests/Unit/Storage/Encryption/SodiumCipherTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Encryption;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Encryption\CipherInterface;
+use VCR\Storage\Encryption\DecryptionFailedException;
+use VCR\Storage\Encryption\EncryptionKey;
+use VCR\Storage\Encryption\SodiumCipher;
+use VCR\Storage\Encryption\UnsupportedSchemeException;
+
+final class SodiumCipherTest extends TestCase
+{
+    private EncryptionKey $key;
+
+    private SodiumCipher $cipher;
+
+    protected function setUp(): void
+    {
+        $this->key = EncryptionKey::fromBinary(str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES));
+        $this->cipher = new SodiumCipher($this->key);
+    }
+
+    public function testImplementsCipherInterface(): void
+    {
+        $this->assertInstanceOf(CipherInterface::class, $this->cipher);
+    }
+
+    public function testRoundTripReturnsThePlaintext(): void
+    {
+        $encrypted = $this->cipher->encrypt('Bearer secret', 'request.headers.Authorization');
+
+        $this->assertSame(
+            'Bearer secret',
+            $this->cipher->decrypt($encrypted, 'request.headers.Authorization')
+        );
+    }
+
+    public function testCiphertextCarriesTheSchemeMarker(): void
+    {
+        $encrypted = $this->cipher->encrypt('Bearer secret', 'request.headers.Authorization');
+
+        $this->assertStringStartsWith('vcr:enc:v1:', $encrypted);
+        $this->assertStringNotContainsString('Bearer secret', $encrypted);
+    }
+
+    public function testEncryptionIsDeterministic(): void
+    {
+        $first = $this->cipher->encrypt('Bearer secret', 'request.headers.Authorization');
+        $second = $this->cipher->encrypt('Bearer secret', 'request.headers.Authorization');
+
+        $this->assertSame($first, $second, 'A re-recorded cassette must stay byte-identical.');
+    }
+
+    public function testDifferentPlaintextsProduceDifferentCiphertext(): void
+    {
+        $this->assertNotSame(
+            $this->cipher->encrypt('one', 'request.body'),
+            $this->cipher->encrypt('two', 'request.body')
+        );
+    }
+
+    public function testSameValueInDifferentFieldsYieldsDifferentCiphertext(): void
+    {
+        $header = $this->cipher->encrypt('secret', 'request.headers.Authorization');
+        $body = $this->cipher->encrypt('secret', 'request.body');
+
+        $this->assertNotSame($header, $body, 'The field path must feed the nonce derivation.');
+    }
+
+    public function testDecryptingUnderADifferentFieldPathFails(): void
+    {
+        $encrypted = $this->cipher->encrypt('Bearer secret', 'request.headers.Authorization');
+
+        $this->expectException(DecryptionFailedException::class);
+        $this->expectExceptionMessage('request.body');
+
+        $this->cipher->decrypt($encrypted, 'request.body');
+    }
+
+    public function testDecryptingTamperedCiphertextFails(): void
+    {
+        $encrypted = $this->cipher->encrypt('Bearer secret', 'request.body');
+        $tampered = substr($encrypted, 0, -4).'AAAA';
+
+        $this->expectException(DecryptionFailedException::class);
+
+        $this->cipher->decrypt($tampered, 'request.body');
+    }
+
+    public function testDecryptingWithADifferentKeyFails(): void
+    {
+        $encrypted = $this->cipher->encrypt('Bearer secret', 'request.body');
+        $other = new SodiumCipher(EncryptionKey::fromBinary(str_repeat("\x7f", \SODIUM_CRYPTO_KDF_KEYBYTES)));
+
+        $this->expectException(DecryptionFailedException::class);
+
+        $other->decrypt($encrypted, 'request.body');
+    }
+
+    public function testMissingSchemeSeparatorIsReportedAsMalformed(): void
+    {
+        $this->expectException(DecryptionFailedException::class);
+        $this->expectExceptionMessage('malformed');
+
+        $this->cipher->decrypt('vcr:enc:no-separator-here', 'request.body');
+    }
+
+    public function testPayloadShorterThanTheNonceIsReportedAsMalformed(): void
+    {
+        $this->expectException(DecryptionFailedException::class);
+        $this->expectExceptionMessage('malformed');
+
+        $this->cipher->decrypt('vcr:enc:v1:'.base64_encode('tiny'), 'request.body');
+    }
+
+    public function testPayloadThatIsNotBase64IsReportedAsMalformed(): void
+    {
+        $this->expectException(DecryptionFailedException::class);
+        $this->expectExceptionMessage('malformed');
+
+        $this->cipher->decrypt('vcr:enc:v1:not valid base64 !!', 'request.body');
+    }
+
+    public function testUnknownSchemeVersionIsReportedSeparately(): void
+    {
+        $this->expectException(UnsupportedSchemeException::class);
+        $this->expectExceptionMessage('v99');
+
+        $this->cipher->decrypt('vcr:enc:v99:'.base64_encode('whatever'), 'request.body');
+    }
+
+    public function testExceptionMessagesLeakNeitherPlaintextNorKey(): void
+    {
+        $encrypted = $this->cipher->encrypt('hunter2', 'request.body');
+
+        try {
+            $this->cipher->decrypt($encrypted, 'response.body');
+            $this->fail('Expected a DecryptionFailedException.');
+        } catch (DecryptionFailedException $exception) {
+            $this->assertStringNotContainsString('hunter2', $exception->getMessage());
+            $this->assertStringNotContainsString($this->key->toBase64(), $exception->getMessage());
+        }
+    }
+
+    public function testIsEncryptedDetectsTheMarker(): void
+    {
+        $this->assertTrue($this->cipher->isEncrypted('vcr:enc:v1:abc'));
+        $this->assertTrue($this->cipher->isEncrypted('vcr:enc:v99:abc'));
+        $this->assertFalse($this->cipher->isEncrypted('Bearer secret'));
+        $this->assertFalse($this->cipher->isEncrypted(''));
+    }
+
+    public function testBinaryPlaintextSurvivesTheRoundTrip(): void
+    {
+        $binary = random_bytes(64);
+
+        $this->assertSame(
+            $binary,
+            $this->cipher->decrypt($this->cipher->encrypt($binary, 'response.body'), 'response.body')
+        );
+    }
+
+    public function testEmptyPlaintextSurvivesTheRoundTrip(): void
+    {
+        $this->assertSame('', $this->cipher->decrypt($this->cipher->encrypt('', 'request.body'), 'request.body'));
+    }
+
+    public function testLargePlaintextSurvivesTheRoundTrip(): void
+    {
+        $large = str_repeat('a', 1024 * 256);
+
+        $this->assertSame(
+            $large,
+            $this->cipher->decrypt($this->cipher->encrypt($large, 'response.body'), 'response.body')
+        );
+    }
+}

--- a/tests/Unit/Storage/Encryption/SodiumCipherTest.php
+++ b/tests/Unit/Storage/Encryption/SodiumCipherTest.php
@@ -19,6 +19,10 @@ final class SodiumCipherTest extends TestCase
 
     protected function setUp(): void
     {
+        if (!\extension_loaded('sodium')) {
+            $this->markTestSkipped('The encrypted storage requires ext-sodium, which is not loaded.');
+        }
+
         $this->key = EncryptionKey::fromBinary(str_repeat("\x2a", \SODIUM_CRYPTO_KDF_KEYBYTES));
         $this->cipher = new SodiumCipher($this->key);
     }

--- a/tests/Unit/Storage/Encryption/UnsupportedSchemeExceptionTest.php
+++ b/tests/Unit/Storage/Encryption/UnsupportedSchemeExceptionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Encryption;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Encryption\UnsupportedSchemeException;
+
+final class UnsupportedSchemeExceptionTest extends TestCase
+{
+    public function testIsARuntimeException(): void
+    {
+        $this->assertInstanceOf(
+            \RuntimeException::class,
+            UnsupportedSchemeException::forScheme('v99', 'request.body')
+        );
+    }
+
+    public function testNamesBothTheSchemeAndTheField(): void
+    {
+        $exception = UnsupportedSchemeException::forScheme('v99', 'request.body');
+
+        $this->assertStringContainsString('v99', $exception->getMessage());
+        $this->assertStringContainsString('request.body', $exception->getMessage());
+    }
+
+    public function testIsNotADecryptionFailure(): void
+    {
+        $this->assertNotInstanceOf(
+            \VCR\Storage\Encryption\DecryptionFailedException::class,
+            UnsupportedSchemeException::forScheme('v99', 'request.body'),
+            'A cassette written by a newer php-vcr is a different problem than a wrong key.'
+        );
+    }
+}


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Feature
| Fixes            | Fix #501
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no <!-- ext-sodium is `suggest` only, never `require` -->
| Docs updated?    | yes
| License          | MIT

Cassettes belong in the repository, but they routinely contain bearer tokens, cookies and login
bodies. The current workaround is redacting values in a `VCR_BEFORE_RECORD` listener, which breaks
replay: once the request body is redacted, the `body`/`post_fields` matchers no longer match the
outgoing request.

`EncryptedStorage` wraps any existing storage (`Yaml`, `Json`, or a custom backend) and encrypts
configured sensitive fields on write, decrypting them again in `current()` — which runs before
`Cassette::playback()` applies the request matchers, so matching keeps working on plaintext while
only ciphertext ever reaches disk.

```php
use VCR\Storage\Encryption\EncryptionKey;
use VCR\Storage\EncryptedStorageFactory;
use VCR\Storage\YamlStorageFactory;

VCR::configure()->setStorageFactory(
    EncryptedStorageFactory::withKey(
        new YamlStorageFactory(),
        EncryptionKey::fromBase64(getenv('VCR_CASSETTE_KEY'))
    )
);
```

Resulting cassette — `method`/`url` stay readable, sensitive fields are opaque:

```yaml
-
    request:
        method: POST
        url: 'https://api.example.com/login'
        headers:
            Authorization: 'vcr:enc:v1:3Fq2kZ...'
        body: 'vcr:enc:v1:9aXkLm...'
    response:
        status: { code: 200, message: OK }
        body: 'vcr:enc:v1:Rt5wYh...'
    index: 0
```

Encryption uses XChaCha20-Poly1305 (`ext-sodium`). The nonce is derived from the plaintext and the
field path (bound as AEAD associated data), so a value cannot be moved to another field without
decryption failing, and re-recording an unchanged cassette produces byte-identical ciphertext — no
spurious git diff.

Builds on the storage factory hook added in 1.12 (#199).
