### PR TITLE
Declaratively redact sensitive data from cassettes without breaking replay

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -13,9 +13,12 @@
     "Record modes are once (default), new_episodes, and none — set via VCR::configure()->setMode()",
     "Built-in storage formats are yaml (default), json, and blackhole, selected via VCR::configure()->setStorage() — deprecated since 1.12 in favor of setStorageFactory()",
     "Inject a custom storage backend (e.g. database-backed) via VCR::configure()->setStorageFactory(new MyFactory()), implementing StorageFactoryInterface::create(): StorageInterface",
-    "By default requests are matched by method and url only — enable additional matchers (host, headers, body, post_fields, query_string) via VCR::configure()->enableRequestMatchers([...])",
-    "Redacting a request body in a VCR_BEFORE_RECORD listener breaks replay unless the body/post_fields matchers are also narrowed to ignore the redacted parts",
+    "All 8 request matchers (method, url, host, headers, body, post_fields, query_string, soap_operation) are enabled by default — narrow them via VCR::configure()->enableRequestMatchers([...])",
+    "Redacting a request body via a VCR_BEFORE_RECORD listener breaks replay unless the body/post_fields matchers are also narrowed to ignore the redacted parts",
     "With curl/soap hooks, call VCR::turnOn(); VCR::turnOff(); once at bootstrap, right after the autoloader — this registers the stream wrapper that later rewrites curl_*/SoapClient calls; skipping it disables interception",
-    "Encrypt sensitive cassette fields (bodies, Authorization/Cookie/etc. headers) at rest via VCR::configure()->setStorageFactory(EncryptedStorageFactory::withKey(new YamlStorageFactory(), $key)); requires ext-sodium"
+    "Encrypt sensitive cassette fields (bodies, Authorization/Cookie/etc. headers) at rest via VCR::configure()->setStorageFactory(EncryptedStorageFactory::withKey(new YamlStorageFactory(), $key)); requires ext-sodium",
+    "Declaratively redact sensitive fields via VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules)); reversible rules restore on read before matchers run, so replay isn't broken",
+    "Field redaction rules (header/queryParameter/postField/host) take the REAL secret as source: the cassette stores a derived placeholder, restored before matching. Omitting the source blanks the value and needs allowIrreversibleRequestRedaction().",
+    "Every replay re-resolves a redaction rule's source, so the secret must be available in every environment that reads the cassette, not just the one that recorded it — otherwise playback fails with MissingSecretException naming the placeholder"
   ]
 }

--- a/docs/howto/custom-redaction-rule.md
+++ b/docs/howto/custom-redaction-rule.md
@@ -1,0 +1,265 @@
+# Custom Redaction Rule
+
+> One-liner: reach for a callback rule first, drop to a full `RedactionRuleInterface` implementation only when a
+> rule needs its own reversibility contract, and to a custom storage decorator only when redaction itself isn't
+> the right shape for the problem.
+>
+> **🆕 Since 1.13**
+
+**On this page:** [Level 1: a callback rule](#level-1-a-callback-rule) ·
+[Level 2: a custom RedactionRuleInterface](#level-2-a-custom-redactionruleinterface) ·
+[Level 3: your own storage decorator](#level-3-your-own-storage-decorator)
+
+[`RedactionRules`](../reference/storage-backends.md#redacting) covers header-, query-parameter-, post-field-,
+host-, and whole-value redaction out of the box (see [Filter sensitive data](filter-sensitive-data.md)). Use
+this page when none of that fits — a body format only your API uses, a JSON field buried inside it, or redaction
+logic bespoke enough that a declarative rule isn't the right shape at all.
+
+## Level 1: a callback rule
+
+`body()` and `postFields()` accept an arbitrary callback and are the smallest extension point — no interface to
+implement, just a function:
+
+```php
+$rules = \VCR\Storage\Redaction\RedactionRules::create()
+    ->allowIrreversibleRequestRedaction()
+    ->body(function (string $body): string {
+        return (string) preg_replace('/"ssn":"\d{3}-\d{2}-\d{4}"/', '"ssn":"REDACTED"', $body);
+    }, \VCR\Storage\Redaction\Scope::REQUEST);
+```
+
+A callback rule is always **irreversible** — the callback's transformation is arbitrary, so there is nothing to
+invert on replay. `RedactionRules::add()` enforces that: registering a request-scoped irreversible rule throws
+`MissingReplacementException` unless `allowIrreversibleRequestRedaction()` has already been called, and once it
+has, the matcher the rule invalidates (`body`, here) has to be dropped — call
+`enableRequestMatchers($rules->safeRequestMatchers())` rather than hand-picking the list yourself, so a rule
+added later isn't silently left unaccounted for.
+
+Response-scoped callbacks never need the opt-in — the response is never matched against, so there's no matcher
+to invalidate:
+
+```php
+$rules->body(fn (string $body): string => 'scrubbed', \VCR\Storage\Redaction\Scope::RESPONSE);
+```
+
+## Level 2: a custom `RedactionRuleInterface`
+
+Implement `\VCR\Storage\Redaction\RedactionRuleInterface` directly when a callback isn't enough — typically
+because the rule needs to be **reversible** (so it doesn't force a matcher out of the picture) but a callback
+can't express that, since `BodyCallbackRule`/`PostFieldsCallbackRule` are hard-coded irreversible. The contract:
+
+```php
+interface RedactionRuleInterface
+{
+    public function scope(): string;
+    public function isReversible(): bool;
+    public function affectedMatchers(): array;
+    public function redact(array $recording): array;
+    public function restore(array $recording): array;
+}
+```
+
+`affectedMatchers()` is the contract that keeps `RedactionRules::safeRequestMatchers()`/
+`invalidatedRequestMatchers()` honest.
+
+`RedactionRules` calls it on **every** registered rule, whatever `isReversible()` says. Its return value only
+*matters*, though, when `isReversible()` returns `false`: an irreversible rule is the only kind that can force a
+matcher out of `safeRequestMatchers()`. A reversible rule returns `[]`, because `restore()` has already put the
+original value back by the time the matchers run — there is nothing left for them to get wrong.
+
+So, concretely:
+
+- **`isReversible(): false`** — list every default matcher key (of the 8 in
+  [Request Matchers](../reference/request-matchers.md)) that your `redact()` breaks for a request those matchers
+  would otherwise compare correctly. Under-report and replay fails with nothing pointing back here; over-report
+  and a matcher is dropped for no reason.
+- **`isReversible(): true`** — return `[]`. Leaving a stale non-empty list on a rule that has become reversible
+  costs a matcher that would have worked fine.
+
+Do not verify this by eye. Write a test that runs a recording through your `redact()`, then your `restore()`, and
+compares the result against a live request through the real `RequestMatcher` callbacks — the built-in rules do
+exactly that, because an `affectedMatchers()` assertion only checks what a rule *claims* about itself.
+
+The example below redacts a field *inside* a JSON request body — something none of the built-ins reach, since
+`postField()` only targets `request.post_fields`, not arbitrary JSON. It follows the same shape
+`HeaderRule`/`QueryParameterRule`/`PostFieldRule` use internally, which is worth copying rather than inventing:
+
+1. The source resolves to the **real** secret — `\VCR\Storage\Redaction\SecretSource` wraps it and turns `getenv()`'s `false` for an unset variable into a `MissingSecretException` naming the placeholder, instead of a `TypeError`.
+2. `redact()` writes a **placeholder** derived from the rule's own identity, never a random one, so re-recording the cassette produces byte-identical output rather than a spurious diff.
+3. `restore()` resolves the source again and writes the real secret back, before the matchers run.
+4. `redact()` — and only `redact()` — rejects a value that already carries the placeholder. Doing that check in the shared rewrite helper would make `restore()` throw on the placeholder it is there to replace.
+
+```php
+namespace App\Redaction;
+
+use VCR\Storage\RecordingPath;
+use VCR\Storage\Redaction\PlaceholderCollisionException;
+use VCR\Storage\Redaction\RedactionRuleInterface;
+use VCR\Storage\Redaction\Scope;
+use VCR\Storage\Redaction\SecretSource;
+
+final class JsonBodyFieldRule implements RedactionRuleInterface
+{
+    private SecretSource $source;
+
+    private string $placeholder;
+
+    public function __construct(private string $field, callable $source)
+    {
+        $this->placeholder = '<<REDACTED:JSON_BODY_FIELD:'.$field.'>>';
+        $this->source = new SecretSource($this->placeholder, $source);
+    }
+
+    public function scope(): string
+    {
+        return Scope::REQUEST;
+    }
+
+    public function isReversible(): bool
+    {
+        return true;
+    }
+
+    public function affectedMatchers(): array
+    {
+        return [];
+    }
+
+    public function redact(array $recording): array
+    {
+        // Resolve here without using the result: a cassette redacted against a source that
+        // cannot be resolved could never be restored, and that belongs at record time.
+        $this->source->resolve($recording);
+
+        $body = RecordingPath::get($recording, ['request', 'body']);
+
+        if (\is_string($body) && str_contains($body, $this->placeholder)) {
+            throw PlaceholderCollisionException::forPlaceholder($this->placeholder, 'request.body');
+        }
+
+        return $this->rewrite($recording, $this->placeholder);
+    }
+
+    public function restore(array $recording): array
+    {
+        return $this->rewrite($recording, $this->source->resolve($recording));
+    }
+
+    private function rewrite(array $recording, string $value): array
+    {
+        return RecordingPath::replace($recording, ['request', 'body'], function ($body) use ($value) {
+            $decoded = json_decode((string) $body, true);
+
+            if (!\is_array($decoded) || !\array_key_exists($this->field, $decoded)) {
+                return $body;
+            }
+
+            $decoded[$this->field] = $value;
+
+            return json_encode($decoded);
+        });
+    }
+}
+```
+
+`\VCR\Storage\RecordingPath` is the helper the built-in rules use to read and write a specific field
+or header without hand-rolling array traversal: `resolvePaths()` turns dot paths (`'request.body'`) and header
+names into segment arrays, `replace()` rewrites the value found at a segment path (a no-op if any segment is
+missing), and `get()` reads one back — all operating on the same `array<string,mixed>` shape a recording has on
+the wire. `\VCR\Storage\Redaction\SecretSource` is the matching helper for the secret side: it accepts a
+literal string or a callable (with or without a `$recording` parameter — it decides by reflection, once), and
+`resolve()` either returns a non-empty string or throws `MissingSecretException`.
+
+Register it like any other rule via `add()`, pointing the source at wherever the **real** value lives:
+
+```php
+\VCR\VCR::configure()->setStorageFactory(
+    \VCR\Storage\RedactingStorageFactory::withRules(
+        new \VCR\Storage\YamlStorageFactory(),
+        \VCR\Storage\Redaction\RedactionRules::create()->add(
+            new \App\Redaction\JsonBodyFieldRule('requestId', fn () => getenv('API_REQUEST_ID'))
+        )
+    )
+);
+```
+
+This was verified directly: storing a recording whose JSON body carried a real, random-looking `requestId`
+produced a cassette with `<<REDACTED:JSON_BODY_FIELD:requestId>>` in its place and the real value nowhere on
+disk; reading that cassette back through `RedactingStorage` restored the real value, and the restored request
+matched a live request carrying that same real value against **all 8** default matchers, unchanged. Pointing the
+source at an unset environment variable failed with
+`The replacement source for placeholder "<<REDACTED:JSON_BODY_FIELD:requestId>>" resolved to an empty value.`
+rather than a type error.
+
+## Level 3: your own storage decorator
+
+`RedactingStorageFactory`/`RedactingStorage` are themselves just a `StorageFactoryInterface`/`StorageInterface`
+decorator — reach past `RedactionRuleInterface` entirely and write your own when the redact-on-write/
+restore-on-read shape doesn't fit. For example, tagging every recording with a sequence number as it's written,
+independent of any single rule's redact/restore pair:
+
+```php
+namespace App\Storage;
+
+use VCR\Storage\StorageInterface;
+
+final class SequentialTaggingStorage implements StorageInterface
+{
+    private int $recordedCount = 0;
+
+    public function __construct(private StorageInterface $storage)
+    {
+    }
+
+    public function storeRecording(array $recording): void
+    {
+        // Tag the response, never the request: request fields feed the request matchers, so
+        // adding anything there that a live replay request won't also carry breaks replay.
+        $recording['response']['headers']['X-Recorded-Sequence'] = 'call-'.++$this->recordedCount;
+
+        $this->storage->storeRecording($recording);
+    }
+
+    public function current(): ?array
+    {
+        return $this->storage->current();
+    }
+
+    public function key(): int
+    {
+        return $this->storage->key();
+    }
+
+    public function next(): void
+    {
+        $this->storage->next();
+    }
+
+    public function rewind(): void
+    {
+        $this->storage->rewind();
+    }
+
+    public function valid(): bool
+    {
+        return $this->storage->valid();
+    }
+
+    public function isNew(): bool
+    {
+        return $this->storage->isNew();
+    }
+}
+```
+
+Wrap it the same way `RedactingStorageFactory` wraps a factory — a small `StorageFactoryInterface` whose
+`create()` calls the inner factory and passes the result into the decorator. This was verified directly:
+recording and replaying through this decorator produced a cassette carrying the `X-Recorded-Sequence` response
+header, with replay unaffected since nothing on the request side changed.
+
+See [Custom storage backend](custom-storage.md) for the full `StorageFactoryInterface`/`StorageInterface`
+contracts, including `PurgeableStorageInterface` for [`MODE_ALL`](../guides/record-modes.md#all) support, and
+[Custom request matcher](custom-request-matcher.md) for the matcher side of the same extension pattern.
+
+---
+← [Custom matcher](custom-request-matcher.md) · Next: [Custom storage](custom-storage.md) →

--- a/docs/howto/custom-request-matcher.md
+++ b/docs/howto/custom-request-matcher.md
@@ -38,4 +38,4 @@ Now a request only replays if the method, path, **and** the custom header all ag
 (other headers, body, query string) is ignored for matching purposes.
 
 ---
-← [Filter sensitive data](filter-sensitive-data.md) · Next: [Custom storage](custom-storage.md) →
+← [Filter sensitive data](filter-sensitive-data.md) · Next: [Custom redaction rule](custom-redaction-rule.md) →

--- a/docs/howto/custom-storage.md
+++ b/docs/howto/custom-storage.md
@@ -272,4 +272,4 @@ ever supported the three built-in names. They're deprecated in favour of `setSto
 ```
 
 ---
-← [Custom matcher](custom-request-matcher.md) · Next: [Select library hooks](select-library-hooks.md) →
+← [Custom redaction rule](custom-redaction-rule.md) · Next: [Select library hooks](select-library-hooks.md) →

--- a/docs/howto/filter-sensitive-data.md
+++ b/docs/howto/filter-sensitive-data.md
@@ -1,18 +1,97 @@
 # Filter Sensitive Data
 
-> One-liner: mutate the `Request` in a `VCR_BEFORE_RECORD` listener before it's written to disk — but redacting
-> the body means you must also stop matching on it, or replay breaks.
+> One-liner: prefer declarative rules via `RedactingStorageFactory` — they redact on write and restore on read
+> before matchers run, so replay isn't broken. Reach for a `VCR_BEFORE_RECORD` listener only when a rule can't
+> express what you need.
 
-**On this page:** [Redact a header](#redact-a-header) · [Redact the body](#redact-the-body) ·
-[What you can't redact this way](#what-you-cant-redact-this-way) ·
+**On this page:** [Declarative redaction (recommended)](#declarative-redaction-recommended) ·
+[Redact via a listener (fallback)](#redact-via-a-listener-fallback) ·
 [Encrypt instead of redacting](#encrypt-instead-of-redacting)
 
 Cassettes are plain files that typically end up committed to your repo — don't let an auth token, API key, or
-cookie leak into one. `VCR_BEFORE_RECORD` fires with the real `Request`/`Response` right before they're
-serialized. Only the **request** side is mutable through this event (see below) — that already covers the
-most common leak: an `Authorization` header, or a secret sent in the request body.
+cookie leak into one.
 
-## Redact a header
+## Declarative redaction (recommended)
+
+> **🆕 Since 1.13**
+
+`RedactionRules` collects one or more rules and hands them to `RedactingStorageFactory`, which wraps another
+storage factory so every cassette it writes has sensitive fields redacted, and every cassette it reads has them
+restored *before* `Cassette::playback()` applies the request matchers:
+
+```php
+$rules = \VCR\Storage\Redaction\RedactionRules::create()
+    ->filterSensitiveData('<<AUTH_TOKEN>>', getenv('API_TOKEN'));
+
+\VCR\VCR::configure()->setStorageFactory(
+    \VCR\Storage\RedactingStorageFactory::withRules(new \VCR\Storage\YamlStorageFactory(), $rules)
+);
+```
+
+`filterSensitiveData()` walks the *entire* recording — headers, body, `post_fields`, even
+`response.curl_info.request_header` (the raw outgoing headers curl captures) — and replaces every occurrence of
+the secret with the placeholder, on both the request and response side. Because the swap is a literal,
+reversible string substitution, the cassette above still replays with all 8 default matchers enabled — no
+matcher narrowing required, unlike the listener route below.
+
+This was verified directly: a request carrying a real `Authorization: Bearer <secret>` header was recorded
+against a live dummy server with the rule above configured. The resulting cassette contained `<<AUTH_TOKEN>>`
+and never the secret, in both the request header and the response body (a test server that echoes the request
+back). With the dummy server then killed, replaying the same cassette reproduced the exact original response —
+proof that redaction and restoration round-trip correctly.
+
+If an unset `API_TOKEN` makes `getenv()` return `false`, the rule above fails with a `MissingSecretException`
+naming `<<AUTH_TOKEN>>` rather than a type error — a CI run without the secret configured tells you which one is
+missing.
+
+> **⚠️ The secret is needed to *replay*, not only to record.** Restoration resolves every configured source
+> again on every cassette read, so the environment replaying a cassette needs the same `API_TOKEN` (or whatever
+> the source reads) as the one that recorded it. Without it, playback fails with a `MissingSecretException`
+> naming the placeholder — it can't silently fall back to the placeholder, because the matchers would then
+> compare the placeholder against the real value a live request carries and never find the recording. This
+> applies to `filterSensitiveData()` and to `header()`/`postField()`/`queryParameter()`/`host()` used with a
+> source. Verified directly: a cassette recorded with the token set, then read back with it unset, fails with
+> `The replacement source for placeholder "<<REDACTED:HEADER:authorization>>" resolved to an empty value.` If a
+> CI job may not have the secret, don't redact against a source there — encrypt the cassette instead, or use
+> the irreversible form and narrow the matchers.
+
+`RedactionRules` has purpose-built methods beyond `filterSensitiveData()` for header-, query-parameter-,
+post-field-, and host-shaped secrets:
+
+```php
+$rules = \VCR\Storage\Redaction\RedactionRules::create()
+    ->header('X-Api-Key', getenv('API_KEY'), \VCR\Storage\Redaction\Scope::REQUEST)
+    ->queryParameter('signature', getenv('API_SIGNATURE'));
+```
+
+Given a source, these behave exactly like `filterSensitiveData()`: the source is the *real* value, the cassette
+stores a derived placeholder in its place, and the real value is restored on read — so all 8 matchers stay
+enabled. This was verified directly: the cassette came out carrying
+`X-Api-Key: '<<REDACTED:HEADER:x-api-key>>'` and `signature=<<REDACTED:QUERY_PARAMETER:signature>>`, with
+neither real value anywhere on disk, and the restored recording matched a live request carrying both real
+values against all 8 default matchers.
+
+`queryParameter()` and `host()` write their source into the URL verbatim — no percent-encoding is applied, the
+same as `filterSensitiveData()` — so give them the value in the form your HTTP client actually sends
+(`'a%20b'` if it encodes the space, `'a b'` if it doesn't). Encoding it for you would mean picking one client's
+convention, and the `query_string` matcher compares the raw query string byte-for-byte.
+
+Each also has an *irreversible* form (omit the source to blank the value with no way to restore it),
+gated behind `allowIrreversibleRequestRedaction()` plus narrowing matchers via `safeRequestMatchers()`. See
+[Storage Backends → redacting](../reference/storage-backends.md#redacting) for the full reference, and
+[Custom redaction rule](custom-redaction-rule.md) for writing your own rule when none of the built-ins fit.
+
+## Redact via a listener (fallback)
+
+Before 1.13, mutating the `Request` in a `VCR_BEFORE_RECORD` listener was the only way to redact. It still
+works and remains useful for a quick, one-off tweak that doesn't warrant wiring up `RedactionRules`, but it has
+a sharp edge declarative redaction doesn't: whatever a listener overwrites on the request is gone for good, so
+any request matcher that still compares against the original value breaks on replay — narrowing the matchers
+by hand is the caller's responsibility, not something the library enforces. `VCR_BEFORE_RECORD` fires with the
+real `Request`/`Response` right before they're serialized; only the **request** side is mutable through this
+event — see [What you can't redact this way](#what-you-cant-redact-this-way) below.
+
+### Redact a header
 
 ```php
 \VCR\VCR::getEventDispatcher()->addListener(
@@ -27,11 +106,22 @@ most common leak: an `Authorization` header, or a secret sent in the request bod
 ```
 
 Register this before `turnOn()`. The recorded cassette then contains `Authorization: REDACTED` instead of the
-real bearer token — while the real request that was actually sent (and its real response) are unaffected,
-since recording happens *after* the real HTTP call. Headers aren't part of request matching by default unless
-you rely on the `headers` matcher for this specific header, so redacting doesn't affect replay.
+real bearer token — while the real request that was actually sent (and its real response) are unaffected, since
+recording happens *after* the real HTTP call. **`headers` is one of the 8 default request matchers**
+(`RequestMatcher::matchHeaders()` does a strict whole-array comparison), so this breaks replay by default: the
+live request made during replay still carries the real header, which no longer equals the redacted value stored
+on the cassette. Drop `headers` from the enabled matchers whenever you redact a header this way:
 
-## Redact the body
+```php
+\VCR\VCR::configure()->enableRequestMatchers(['method', 'url', 'host', 'body', 'post_fields', 'query_string', 'soap_operation']);
+```
+
+> This was verified directly: with the `headers` matcher enabled (the default), replaying a cassette recorded
+> with the listener above fails because the live request's `Authorization` header no longer matches the
+> redacted one on disk; disabling the `headers` matcher fixes replay while the redacted value still never
+> touches the cassette.
+
+### Redact the body
 
 A secret sent as a POST field (`api_key=super-secret&name=test`) lives in `Request::getBody()` — the raw wire
 body — not necessarily in `getPostFields()` (that array is only populated when the request came in through a
@@ -60,23 +150,25 @@ hook that parses it as such; a raw form-urlencoded body sent via `file_get_conte
 > This was verified directly — redacting the body without narrowing the matchers reproducibly breaks replay
 > with a stream-wrapper error; narrowing the matchers first fixes it.
 
-## What you can't redact this way
+### What you can't redact this way
 
 `Response` (see [Request/Response reference](../reference/request-response.md)) exposes **only getters** —
 `BeforeRecordEvent::getResponse()` gives you a read-only view, with no setter to replace it. If a secret comes
 back *in the response body* (rather than being sent in the request), this event can't strip it before it's
-written to the cassette. In that case, either have your test server/fixture avoid echoing the secret back, or
-post-process the cassette file after recording.
+written to the cassette. In that case, use [declarative redaction](#declarative-redaction-recommended) instead
+— `body()`/`filterSensitiveData()` cover the response side too — or, failing that, have your test server/fixture
+avoid echoing the secret back, or post-process the cassette file after recording.
 
 ## Encrypt instead of redacting
 
 > **🆕 Since 1.13**
 
-Redaction has a sharp edge, [documented above](#redact-the-body): once the body on disk no longer matches the
-body of the real incoming request, the `body`/`post_fields` matchers must be narrowed too, or replay breaks.
-The [`encrypted` storage backend](../reference/storage-backends.md#encrypted) sidesteps this entirely — it
-decrypts a recording in `current()`, which runs before `Cassette::playback()` applies the matchers, so matching
-always sees plaintext while only ciphertext ever reaches disk:
+Redaction, declarative or via a listener, leaves a recognizable placeholder in the cassette — useful for keeping
+a diff reviewable, but the placeholder itself confirms *that* a secret was there. The
+[`encrypted` storage backend](../reference/storage-backends.md#encrypted) goes further and encrypts whole fields
+so nothing about their content is readable at all — it decrypts a recording in `current()`, which, like
+redaction's restoration step, runs before `Cassette::playback()` applies the matchers, so matching always sees
+plaintext while only ciphertext ever reaches disk:
 
 ```php
 $key = \VCR\Storage\Encryption\EncryptionKey::fromBase64($_SERVER['VCR_CASSETTE_KEY']);
@@ -86,10 +178,13 @@ $key = \VCR\Storage\Encryption\EncryptionKey::fromBase64($_SERVER['VCR_CASSETTE_
 );
 ```
 
-This also covers the response-body case above, which redaction through `VCR_BEFORE_RECORD` can't reach at
-all — `response.body` is encrypted by default. See [Storage Backends → encrypted](../reference/storage-backends.md#encrypted)
-for the full configuration, the fields covered by default, and its limitations (query-string secrets stay
-readable, and a lost key makes a cassette unrecoverable).
+The two compose: wrap `EncryptedStorageFactory` in `RedactingStorageFactory` to redact first and encrypt the
+result, which covers fields the encryption policy doesn't touch by default (a custom header, say) with a
+placeholder while still encrypting everything the policy does cover — see
+[Storage Backends → redacting](../reference/storage-backends.md#redacting) for a runnable example of that
+stack. See [Storage Backends → encrypted](../reference/storage-backends.md#encrypted) for the full
+configuration, the fields covered by default, and its limitations (query-string secrets stay readable, and a
+lost key makes a cassette unrecoverable).
 
 ---
 ← [Use with Codeception](use-with-codeception.md) · Next: [Custom request matcher](custom-request-matcher.md) →

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ You're in the docs. Full pitch, badges and a 30-second example live in the
 | 🎞️ **[Cassettes](guides/cassettes.md)** | What gets recorded, the file format, identical-request sequencing. |
 | 🎬 **[Record Modes](guides/record-modes.md)** | `new_episodes` / `once` / `none` / `all` — and when to use which. |
 | 🎯 **[Request Matching](guides/request-matching.md)** | How php-vcr decides a request "matches" a recording. |
-| 🧑‍🍳 **How-to** | [PHPUnit](howto/use-with-phpunit.md) · [Codeception](howto/use-with-codeception.md) · [Filter sensitive data](howto/filter-sensitive-data.md) · [Custom matcher](howto/custom-request-matcher.md) · [Custom storage](howto/custom-storage.md) · [Select hooks](howto/select-library-hooks.md) · [SOAP](howto/record-soap.md) |
+| 🧑‍🍳 **How-to** | [PHPUnit](howto/use-with-phpunit.md) · [Codeception](howto/use-with-codeception.md) · [Filter sensitive data](howto/filter-sensitive-data.md) · [Custom matcher](howto/custom-request-matcher.md) · [Custom redaction rule](howto/custom-redaction-rule.md) · [Custom storage](howto/custom-storage.md) · [Select hooks](howto/select-library-hooks.md) · [SOAP](howto/record-soap.md) |
 | 📖 **Reference** | [VCR facade](reference/vcr-facade.md) · [Configuration](reference/configuration.md) · [Request matchers](reference/request-matchers.md) · [Library hooks](reference/library-hooks.md) · [Storage backends](reference/storage-backends.md) · [Events](reference/events.md) · [Request/Response](reference/request-response.md) |
 | 🆙 **[Upgrading](upgrading.md)** | Breaking changes by version. |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -72,6 +72,21 @@ $key = \VCR\Storage\Encryption\EncryptionKey::fromBase64($_SERVER['VCR_CASSETTE_
 );
 ```
 
+Wrap another factory with `\VCR\Storage\RedactingStorageFactory` to redact sensitive fields declaratively — it
+redacts on write and restores reversible rules' redaction on read, before matchers run, so replay isn't broken
+(see [Storage Backends → redacting](storage-backends.md#redacting)):
+
+> **🆕 Since 1.13**
+
+```php
+$rules = \VCR\Storage\Redaction\RedactionRules::create()
+    ->filterSensitiveData('<<AUTH_TOKEN>>', getenv('API_TOKEN'));
+
+\VCR\VCR::configure()->setStorageFactory(
+    \VCR\Storage\RedactingStorageFactory::withRules(new \VCR\Storage\YamlStorageFactory(), $rules)
+);
+```
+
 ## `storage`
 
 - **Setter/Getter:** `setStorage(string $name): self` / `getStorage(): string` (returns the resolved class name)

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -45,8 +45,10 @@ All event classes live in `VCR\Event\` and extend Symfony's base `Event`. Consta
 - **Constant value:** `vcr.before_record`
 - **Dispatched:** right before the request/response pair is written to the cassette.
 - **Event class:** `BeforeRecordEvent` — `getRequest(): Request`, `getResponse(): Response`, `getCassette(): Cassette`
-- **Common use:** redact secrets before they hit disk — mutate the `Request`/`Response` object in your
-  listener (they're passed by reference). See [Filter sensitive data](../howto/filter-sensitive-data.md).
+- **Common use:** redact secrets before they hit disk — mutate the `Request` object in your listener (it's
+  passed by reference). `Response` exposes only getters, so nothing on the response side can be changed
+  through this event; use a [declarative redaction rule](../howto/filter-sensitive-data.md) instead for
+  response-side secrets.
 
 ---
 ← [Storage Backends](storage-backends.md) · Next: [Request/Response](request-response.md) →

--- a/docs/reference/storage-backends.md
+++ b/docs/reference/storage-backends.md
@@ -3,11 +3,12 @@
 > One-liner: cassettes are files on disk, serialized as YAML (default), JSON, or nowhere at all (Blackhole).
 
 **On this page:** [yaml](#yaml) · [json](#json) · [blackhole](#blackhole) · [encrypted](#encrypted) ·
-[Custom storage backend](#custom-storage-backend) · [Cassette file naming](#cassette-file-naming)
+[redacting](#redacting) · [Custom storage backend](#custom-storage-backend) ·
+[Cassette file naming](#cassette-file-naming)
 
 Select via [`setStorageFactory()`](configuration.md#storage-factory). `yaml`, `json`, and `blackhole`
 implement `PurgeableStorageInterface` directly, so all three work with [`MODE_ALL`](../guides/record-modes.md#all);
-`encrypted` wraps one of them and works with `MODE_ALL` whenever the wrapped backend does.
+`encrypted` and `redacting` each wrap one of them and work with `MODE_ALL` whenever the wrapped backend does.
 
 ## `yaml`
 
@@ -131,6 +132,158 @@ passed as the third argument to `EncryptedStorageFactory::withKey()`, it encrypt
 >   policy — they generally don't carry secrets.
 
 Works with both `yaml` and `json` as the wrapped backend.
+
+## `redacting`
+
+> **🆕 Since 1.13**
+
+- **Factory:** `\VCR\Storage\RedactingStorageFactory` — wraps another storage factory so every cassette it
+  writes has the fields matched by its rules redacted, and every cassette it reads has reversible rules'
+  redaction restored before request matching runs.
+- Rules are declared via `\VCR\Storage\Redaction\RedactionRules`, a fluent collection: `filterSensitiveData()`
+  for a literal secret value anywhere in the recording, `header()`/`allHeaders()`, `queryParameter()`,
+  `postField()`, `host()` for targeted fields, and `body()`/`postFields()` for an arbitrary callback. See
+  [Filter sensitive data](../howto/filter-sensitive-data.md) for the day-to-day usage and
+  [Custom redaction rule](../howto/custom-redaction-rule.md) for writing a new rule.
+- `withRules()` takes a caller-built `RedactionRules`; `withDefaults()` needs no configuration and strips the
+  standard sensitive response headers (`Set-Cookie`, `WWW-Authenticate`, `Proxy-Authenticate`).
+
+```php
+$rules = \VCR\Storage\Redaction\RedactionRules::create()
+    ->filterSensitiveData('<<AUTH_TOKEN>>', getenv('API_TOKEN'));
+
+\VCR\VCR::configure()->setStorageFactory(
+    \VCR\Storage\RedactingStorageFactory::withRules(new \VCR\Storage\YamlStorageFactory(), $rules)
+);
+```
+
+A recorded cassette looks like this — `filterSensitiveData()` walked the whole recording, so the secret sent as
+an `Authorization` header is replaced by the placeholder everywhere it appears, including inside the response
+body a test server echoed it back into:
+
+```yaml
+-
+    request:
+        method: POST
+        url: 'http://127.0.0.1:8098/'
+        headers:
+            Authorization: 'Bearer <<AUTH_TOKEN>>'
+            Content-Type: application/x-www-form-urlencoded
+        body: ping=pong
+    response:
+        status: { code: 200, message: OK }
+        headers:
+            X-Echo-Authorization: 'Bearer <<AUTH_TOKEN>>'
+            Content-Type: application/json
+        body: '{"method":"POST","headers":{"AUTHORIZATION":"Bearer <<AUTH_TOKEN>>"},"body":"ping=pong"}'
+    index: 0
+```
+
+### Reversibility
+
+Every rule reports `isReversible(): bool`.
+
+A **reversible** rule can put the original value back before the matchers run, so all 8 default request matchers
+keep working unmodified. That is `filterSensitiveData()`, and `header()`/`queryParameter()`/`postField()`/
+`host()` **given a source**. In that form the source is the *real* secret — read it from an environment variable
+or a secrets manager, don't hard-code it — and the rule writes a placeholder to the cassette in its place,
+resolving the source again on read to restore it:
+
+| Rule | Placeholder written to the cassette |
+| --- | --- |
+| `header('Authorization', …)` | `<<REDACTED:HEADER:authorization>>` (the name is lowercased — headers are case-insensitive) |
+| `postField('password', …)` | `<<REDACTED:POST_FIELD:password>>` |
+| `queryParameter('token', …)` | `<<REDACTED:QUERY_PARAMETER:token>>` (written into the URL unencoded) |
+| `host(…)` | `redacted-host.invalid` |
+
+The placeholder is derived from the rule's own identity, never randomised, so re-recording a cassette produces
+byte-identical output instead of a spurious diff. `host()` is the exception to the shape: its placeholder is
+written into `request.url`, which `parse_url()` still has to accept, so it is a hostname in the `.invalid` TLD
+[RFC 2606](https://www.rfc-editor.org/rfc/rfc2606) reserves for exactly this. `host()` also swaps the host out
+of the `Host` header rather than overwriting it, so an appended `:8443` survives the round trip — the host is
+located case-insensitively, so a header that spells it differently from the URL keeps its port too, though the
+host itself comes back in the source's casing rather than the header's own.
+
+> **⚠️ `queryParameter()` and `host()` write the source verbatim.** Neither percent-encodes it. There is no
+> encoding convention every HTTP client follows identically — `urlencode()` escapes `@` and writes a space as
+> `+`, `rawurlencode()` writes `%20`, and plenty of clients leave both alone — and the `query_string` matcher
+> compares the raw query string byte-for-byte, so any fixed encoder would break replay for some client. Supply
+> the source in the form your client actually puts on the wire: `'a%20b'` if it encodes the space, `'a b'` if it
+> doesn't. `filterSensitiveData()` has always worked this way; these two now match it.
+
+A source is either a literal string or a callable, optionally taking the recording being processed. `getenv()`
+returning `false` for an unset variable — and `null` — are accepted rather than rejected: they surface as a
+`MissingSecretException` naming the placeholder when the secret is actually needed, so a CI run without the
+secret configured fails with a readable message rather than a type error. Anything else (an int, a non-callable
+array) is a configuration mistake and is rejected with `InvalidRedactionRuleException` right where the rule is
+built, as is a scope string that is not one of `Scope`'s three values.
+
+An **irreversible** rule (`body()`, `postFields()`, or any of the field-targeted rules used *without* a source)
+permanently discards the original value and reports which request matchers it invalidates via
+`affectedMatchers()`.
+
+`RedactionRules::add()` enforces this at composition time: registering an irreversible, request-scoped rule
+throws `MissingReplacementException` unless `allowIrreversibleRequestRedaction()` was called first. Once a
+caller has opted in, `safeRequestMatchers()` returns the default matcher keys that remain reliable given every
+rule added so far — pass it straight to `enableRequestMatchers()`:
+
+```php
+$rules = \VCR\Storage\Redaction\RedactionRules::create()
+    ->allowIrreversibleRequestRedaction()
+    ->postField('card_number');
+
+\VCR\VCR::configure()
+    ->setStorageFactory(\VCR\Storage\RedactingStorageFactory::withRules(new \VCR\Storage\YamlStorageFactory(), $rules))
+    ->enableRequestMatchers($rules->safeRequestMatchers());
+```
+
+### Composing with `encrypted`
+
+Wrap `EncryptedStorageFactory` in `RedactingStorageFactory` to redact first, then encrypt the result — this
+covers fields the encryption policy doesn't touch by default (a custom header, say) with a placeholder, while
+still encrypting everything the policy does cover:
+
+```php
+$key = \VCR\Storage\Encryption\EncryptionKey::fromBase64($_SERVER['VCR_CASSETTE_KEY']);
+$rules = \VCR\Storage\Redaction\RedactionRules::create()->filterSensitiveData('<<AUTH_TOKEN>>', getenv('API_TOKEN'));
+
+\VCR\VCR::configure()->setStorageFactory(
+    \VCR\Storage\RedactingStorageFactory::withRules(
+        \VCR\Storage\EncryptedStorageFactory::withKey(new \VCR\Storage\YamlStorageFactory(), $key),
+        $rules
+    )
+);
+```
+
+This was verified directly: the secret never reached the disk either way, `request.body`/`response.body`
+(covered by the default encryption policy) came out as `vcr:enc:v1:...` ciphertext, and a custom response
+header outside that policy still carried the placeholder rather than the real secret — the placeholder inside
+policy-covered fields was itself encrypted as part of the surrounding field, since redaction runs before
+encryption in this composition order.
+
+> **⚠️ Limitations**
+>
+> - `body()`/`postFields()` callbacks and any field rule used without a replacement source are irreversible —
+>   the original value cannot be recovered once redacted, only the matcher gap it creates can be worked around.
+> - Every rule that writes a placeholder throws `PlaceholderCollisionException` if that placeholder already
+>   occurs in the value about to be redacted, and `MissingSecretException` if the source resolves to an empty
+>   value — both surface immediately rather than silently corrupting a cassette. The secret is resolved during
+>   `redact()` even though only `restore()` needs it, so an unresolvable source fails at record time instead of
+>   producing a cassette that can never be restored.
+> - **Every read resolves every source again.** A cassette redacted against a source can only be replayed where
+>   that source resolves — the same environment variable set, the same secrets manager reachable. Reading it
+>   without the secret fails with `MissingSecretException` naming the placeholder, at the point `current()`
+>   restores the recording, before matching even starts. There is no silent fallback to the placeholder: the
+>   matchers would then compare it against the real value a live request carries and never find the recording.
+> - `header()` owns the header's *whole* value, so its source has to resolve to all of it, prefix included
+>   (`'Bearer '.getenv('API_TOKEN')`). Concatenating a prefix onto an unset `getenv()` yields `'Bearer '` — a
+>   non-empty string — so the missing-secret guard cannot fire for it. When only part of a value is secret,
+>   reach for `filterSensitiveData()` on the token itself instead.
+> - Blanking a header, query parameter, or post field replaces its value with an empty string rather than
+>   removing the key — `RecordingPath` has no key-deletion primitive.
+> - `allHeaders()` can only blank. One source cannot stand for every header in scope — it would write the same
+>   value into all of them and restore that one value into all of them on read — so handing a source to the
+>   underlying wildcard rule is rejected with `InvalidRedactionRuleException` at construction.
 
 ## Custom storage backend
 

--- a/src/VCR/Storage/Encryption/EncryptionPolicy.php
+++ b/src/VCR/Storage/Encryption/EncryptionPolicy.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace VCR\Storage\Encryption;
 
+use VCR\Storage\RecordingPath;
+
 /**
  * Decides which parts of a recording are encrypted and walks the recording array accordingly.
  *
@@ -32,8 +34,6 @@ class EncryptionPolicy
 
     private const TAG_JSON = 'j:';
 
-    private const HEADER_CONTAINERS = ['request', 'response'];
-
     /**
      * @var string[]
      */
@@ -51,7 +51,7 @@ class EncryptionPolicy
     public function __construct(?array $fieldPaths = null, ?array $headerNames = null)
     {
         $this->fieldPaths = $fieldPaths ?? self::DEFAULT_FIELD_PATHS;
-        $this->headerNames = array_map('strtolower', $headerNames ?? self::DEFAULT_HEADER_NAMES);
+        $this->headerNames = $headerNames ?? self::DEFAULT_HEADER_NAMES;
     }
 
     /**
@@ -61,9 +61,9 @@ class EncryptionPolicy
      */
     public function encrypt(array $recording, CipherInterface $cipher): array
     {
-        foreach ($this->resolvePaths($recording) as $segments) {
+        foreach (RecordingPath::resolvePaths($recording, $this->fieldPaths, $this->headerNames) as $segments) {
             $path = implode('.', $segments);
-            $recording = $this->replace($recording, $segments, fn ($value) => $cipher->encrypt($this->tag($value, $path), $path));
+            $recording = RecordingPath::replace($recording, $segments, fn ($value) => $cipher->encrypt($this->tag($value, $path), $path));
         }
 
         return $recording;
@@ -76,9 +76,9 @@ class EncryptionPolicy
      */
     public function decrypt(array $recording, CipherInterface $cipher): array
     {
-        foreach ($this->resolvePaths($recording) as $segments) {
+        foreach (RecordingPath::resolvePaths($recording, $this->fieldPaths, $this->headerNames) as $segments) {
             $path = implode('.', $segments);
-            $recording = $this->replace($recording, $segments, function ($value) use ($cipher, $path) {
+            $recording = RecordingPath::replace($recording, $segments, function ($value) use ($cipher, $path) {
                 if (!\is_string($value) || !$cipher->isEncrypted($value)) {
                     return $value;
                 }
@@ -86,72 +86,6 @@ class EncryptionPolicy
                 return $this->untag($cipher->decrypt($value, $path), $path);
             });
         }
-
-        return $recording;
-    }
-
-    /**
-     * Resolves every field this policy covers for the given recording into its segment path.
-     *
-     * Header names are carried through as a single opaque segment rather than being dot-joined,
-     * since HTTP header names are themselves allowed to contain literal dots (e.g. "X.Api.Secret")
-     * and re-splitting a joined string on "." would misinterpret such a name as several segments.
-     *
-     * @param array<string,mixed> $recording
-     *
-     * @return array<int, string[]>
-     */
-    private function resolvePaths(array $recording): array
-    {
-        $paths = array_map(static fn (string $fieldPath): array => explode('.', $fieldPath), $this->fieldPaths);
-
-        foreach (self::HEADER_CONTAINERS as $container) {
-            $headers = $recording[$container]['headers'] ?? null;
-
-            if (!\is_array($headers)) {
-                continue;
-            }
-
-            foreach (array_keys($headers) as $name) {
-                if (\in_array(strtolower((string) $name), $this->headerNames, true)) {
-                    $paths[] = [$container, 'headers', (string) $name];
-                }
-            }
-        }
-
-        return $paths;
-    }
-
-    /**
-     * @param array<string,mixed>    $recording
-     * @param string[]               $segments
-     * @param \Closure(mixed): mixed $transform
-     *
-     * @return array<string,mixed>
-     */
-    private function replace(array $recording, array $segments, \Closure $transform): array
-    {
-        $lastIndex = \count($segments) - 1;
-        $cursor = &$recording;
-
-        foreach ($segments as $depth => $segment) {
-            if (!\is_array($cursor) || !\array_key_exists($segment, $cursor)) {
-                unset($cursor);
-
-                return $recording;
-            }
-
-            if ($depth === $lastIndex) {
-                $cursor[$segment] = $transform($cursor[$segment]);
-                unset($cursor);
-
-                return $recording;
-            }
-
-            $cursor = &$cursor[$segment];
-        }
-
-        unset($cursor);
 
         return $recording;
     }

--- a/src/VCR/Storage/PurgeableRedactingStorage.php
+++ b/src/VCR/Storage/PurgeableRedactingStorage.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+use VCR\Storage\Redaction\RedactionRules;
+
+/**
+ * Redacting storage over an inner storage that can be purged.
+ *
+ * Kept separate from RedactingStorage because the wrapped storage is only sometimes purgeable —
+ * implementing PurgeableStorageInterface unconditionally and throwing at runtime would break
+ * substitutability.
+ */
+class PurgeableRedactingStorage extends RedactingStorage implements PurgeableStorageInterface
+{
+    private PurgeableStorageInterface $storage;
+
+    public function __construct(PurgeableStorageInterface $storage, RedactionRules $rules)
+    {
+        parent::__construct($storage, $rules);
+
+        $this->storage = $storage;
+    }
+
+    public function purge(): void
+    {
+        $this->storage->purge();
+    }
+}

--- a/src/VCR/Storage/RecordingPath.php
+++ b/src/VCR/Storage/RecordingPath.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+/**
+ * Walks a recorded cassette entry (an associative array) along dot-separated field paths and
+ * header-name matches, so callers can read or rewrite the values found there.
+ *
+ * Shared between `EncryptionPolicy` and redaction rules, which both need to resolve which parts
+ * of a recording to touch and then either inspect or replace the value found at that location. It
+ * therefore lives next to both `Encryption` and `Redaction` rather than inside either of them:
+ * nothing here knows about ciphers or redaction rules, only about the array shape a recording has
+ * on the wire.
+ */
+final class RecordingPath
+{
+    private const HEADER_CONTAINERS = ['request', 'response'];
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Resolves field paths and header-name matches for the given recording into segment paths.
+     *
+     * Header names are carried through as a single opaque segment rather than being dot-joined,
+     * since HTTP header names are themselves allowed to contain literal dots (e.g. "X.Api.Secret")
+     * and re-splitting a joined string on "." would misinterpret such a name as several segments.
+     *
+     * @param array<string,mixed> $recording   the recording to resolve paths against
+     * @param string[]            $fieldPaths  dot paths, e.g. "request.body"
+     * @param string[]            $headerNames matched case-insensitively against header names found
+     *                                         in the "request" and "response" header containers
+     *
+     * @return array<int, string[]> one segment array per resolved path
+     */
+    public static function resolvePaths(array $recording, array $fieldPaths, array $headerNames): array
+    {
+        $paths = array_map(static fn (string $fieldPath): array => explode('.', $fieldPath), $fieldPaths);
+        $headerNames = array_map('strtolower', $headerNames);
+
+        foreach (self::HEADER_CONTAINERS as $container) {
+            $headers = $recording[$container]['headers'] ?? null;
+
+            if (!\is_array($headers)) {
+                continue;
+            }
+
+            foreach (array_keys($headers) as $name) {
+                if (\in_array(strtolower((string) $name), $headerNames, true)) {
+                    $paths[] = [$container, 'headers', (string) $name];
+                }
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Replaces the value at the given segment path with the result of applying $transform to it.
+     *
+     * Tolerant of missing segments: if any segment along the path does not exist, the recording is
+     * returned unchanged rather than raising an error.
+     *
+     * @param array<string,mixed>    $recording the recording to rewrite
+     * @param string[]               $segments  the segment path to replace the value at
+     * @param \Closure(mixed): mixed $transform receives the current value, returns the replacement
+     *
+     * @return array<string,mixed> the recording with the value at $segments replaced
+     */
+    public static function replace(array $recording, array $segments, \Closure $transform): array
+    {
+        $lastIndex = \count($segments) - 1;
+        $cursor = &$recording;
+
+        foreach ($segments as $depth => $segment) {
+            if (!\is_array($cursor) || !\array_key_exists($segment, $cursor)) {
+                unset($cursor);
+
+                return $recording;
+            }
+
+            if ($depth === $lastIndex) {
+                $cursor[$segment] = $transform($cursor[$segment]);
+                unset($cursor);
+
+                return $recording;
+            }
+
+            $cursor = &$cursor[$segment];
+        }
+
+        unset($cursor);
+
+        return $recording;
+    }
+
+    /**
+     * Reads the value at the given segment path.
+     *
+     * @param array<string,mixed> $recording the recording to read from
+     * @param string[]            $segments  the segment path to read the value at
+     *
+     * @return mixed the value found at $segments, or null if any segment along the path is missing
+     */
+    public static function get(array $recording, array $segments): mixed
+    {
+        $cursor = $recording;
+
+        foreach ($segments as $segment) {
+            if (!\is_array($cursor) || !\array_key_exists($segment, $cursor)) {
+                return null;
+            }
+
+            $cursor = $cursor[$segment];
+        }
+
+        return $cursor;
+    }
+}

--- a/src/VCR/Storage/RedactingStorage.php
+++ b/src/VCR/Storage/RedactingStorage.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+use VCR\Storage\Redaction\RedactionRules;
+
+/**
+ * Redacts sensitive fields on the way to the wrapped storage and restores them on the way back.
+ *
+ * Restoration happens in current(), which runs before Cassette::playback() applies the request
+ * matchers — so matching keeps working on the restored data while only the redacted data reaches
+ * the disk. storeRecording() applies every rule's redact() in registration order, each rule
+ * receiving the previous rule's output; current() applies restore() in the reverse order, so a
+ * chain of transforms is actually inverted rather than each rule trying (and failing) to undo a
+ * recording it never produced.
+ */
+class RedactingStorage implements StorageInterface
+{
+    private StorageInterface $storage;
+
+    private RedactionRules $rules;
+
+    public function __construct(StorageInterface $storage, RedactionRules $rules)
+    {
+        $this->storage = $storage;
+        $this->rules = $rules;
+    }
+
+    public function storeRecording(array $recording): void
+    {
+        foreach ($this->rules->rules() as $rule) {
+            $recording = $rule->redact($recording);
+        }
+
+        $this->storage->storeRecording($recording);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function current(): ?array
+    {
+        /** @var array<string,mixed>|null $current */
+        $current = $this->storage->current();
+
+        if (!\is_array($current)) {
+            return null;
+        }
+
+        foreach (array_reverse($this->rules->rules()) as $rule) {
+            $current = $rule->restore($current);
+        }
+
+        return $current;
+    }
+
+    public function next(): void
+    {
+        $this->storage->next();
+    }
+
+    public function key(): int
+    {
+        return $this->storage->key();
+    }
+
+    public function rewind(): void
+    {
+        $this->storage->rewind();
+    }
+
+    public function valid(): bool
+    {
+        return $this->storage->valid();
+    }
+
+    public function isNew(): bool
+    {
+        return $this->storage->isNew();
+    }
+}

--- a/src/VCR/Storage/RedactingStorageFactory.php
+++ b/src/VCR/Storage/RedactingStorageFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage;
+
+use VCR\Storage\Redaction\RedactionRules;
+use VCR\Storage\Redaction\Scope;
+
+/**
+ * Wraps another storage factory so every cassette it creates has sensitive fields redacted.
+ */
+class RedactingStorageFactory implements StorageFactoryInterface
+{
+    /**
+     * Standard sensitive response headers stripped by {@see self::withDefaults()}.
+     *
+     * @var list<string>
+     */
+    private const DEFAULT_SENSITIVE_RESPONSE_HEADERS = [
+        'Set-Cookie',
+        'WWW-Authenticate',
+        'Proxy-Authenticate',
+    ];
+
+    private StorageFactoryInterface $storageFactory;
+
+    private RedactionRules $rules;
+
+    public function __construct(StorageFactoryInterface $storageFactory, RedactionRules $rules)
+    {
+        $this->storageFactory = $storageFactory;
+        $this->rules = $rules;
+    }
+
+    public static function withRules(StorageFactoryInterface $storageFactory, RedactionRules $rules): self
+    {
+        return new self($storageFactory, $rules);
+    }
+
+    /**
+     * Builds a factory that strips the standard sensitive response headers with no configuration:
+     * `Set-Cookie`, `WWW-Authenticate`, `Proxy-Authenticate`.
+     */
+    public static function withDefaults(StorageFactoryInterface $storageFactory): self
+    {
+        $rules = RedactionRules::create();
+
+        foreach (self::DEFAULT_SENSITIVE_RESPONSE_HEADERS as $headerName) {
+            $rules->header($headerName, null, Scope::RESPONSE);
+        }
+
+        return new self($storageFactory, $rules);
+    }
+
+    public function create(string $cassettePath, string $cassetteName): StorageInterface
+    {
+        $storage = $this->storageFactory->create($cassettePath, $cassetteName);
+
+        if ($storage instanceof PurgeableStorageInterface) {
+            return new PurgeableRedactingStorage($storage, $this->rules);
+        }
+
+        return new RedactingStorage($storage, $this->rules);
+    }
+}

--- a/src/VCR/Storage/Redaction/InvalidRedactionRuleException.php
+++ b/src/VCR/Storage/Redaction/InvalidRedactionRuleException.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction;
+
+/**
+ * A redaction rule was configured with an argument it can never work with.
+ *
+ * Unlike `MissingSecretException`, which reports a secret that was well-configured but happened to
+ * resolve to nothing at record time, this signals a programming error at composition time: an empty
+ * placeholder, a secret source that is neither a string nor a callable, a scope string that is not
+ * one of `Scope`'s three values, or a replacement source handed to a rule that targets more than
+ * one field. Each of those would otherwise turn into a silent no-op, a corrupted cassette, or a raw
+ * `TypeError` far away from the line that configured the rule.
+ */
+class InvalidRedactionRuleException extends \InvalidArgumentException
+{
+    public static function emptyPlaceholder(): self
+    {
+        return new self('A redaction placeholder must not be empty, otherwise the redacted value cannot be told apart from the surrounding text.');
+    }
+
+    public static function unsupportedSecretSource(string $placeholder, string $givenType): self
+    {
+        return new self(\sprintf(
+            'The replacement source for placeholder "%s" must be a string or a callable, %s given.',
+            $placeholder,
+            $givenType
+        ));
+    }
+
+    public static function wildcardHeaderWithSource(string $wildcard): self
+    {
+        return new self(\sprintf(
+            'A header rule matching "%s" cannot take a replacement source: it would write that one value into every header in scope and restore it into all of them, so a recording with more than one header comes back corrupted. Name the header the source belongs to, or drop the source to blank every header instead.',
+            $wildcard
+        ));
+    }
+
+    public static function unsupportedScope(string $scope): self
+    {
+        return new self(\sprintf(
+            'The scope "%s" is not one of "%s", "%s" or "%s".',
+            $scope,
+            Scope::REQUEST,
+            Scope::RESPONSE,
+            Scope::BOTH
+        ));
+    }
+}

--- a/src/VCR/Storage/Redaction/MissingReplacementException.php
+++ b/src/VCR/Storage/Redaction/MissingReplacementException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction;
+
+class MissingReplacementException extends \RuntimeException
+{
+    public static function forRule(string $description): self
+    {
+        return new self(\sprintf(
+            'The redaction rule "%s" redacts request data but has no replacement source, which would break replay. Either supply a replacement source or call allowIrreversibleRequestRedaction().',
+            $description
+        ));
+    }
+}

--- a/src/VCR/Storage/Redaction/MissingSecretException.php
+++ b/src/VCR/Storage/Redaction/MissingSecretException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction;
+
+class MissingSecretException extends \RuntimeException
+{
+    public static function forPlaceholder(string $placeholder): self
+    {
+        return new self(\sprintf(
+            'The replacement source for placeholder "%s" resolved to an empty value.',
+            $placeholder
+        ));
+    }
+}

--- a/src/VCR/Storage/Redaction/Placeholder.php
+++ b/src/VCR/Storage/Redaction/Placeholder.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction;
+
+/**
+ * Builds the literal a field-targeted redaction rule writes to the cassette in place of a secret.
+ *
+ * `filterSensitiveData()` lets the caller pick the placeholder, because the caller is the one who
+ * has to recognise it in a cassette diff. The field-targeted rules cannot: their constructors were
+ * designed to take just a field name and a source, so the placeholder has to be derived. It is
+ * derived from the rule's own identity — never randomised — so that re-recording the same cassette
+ * produces byte-identical output instead of a spurious diff, the same reasoning behind the
+ * encryption backend's deterministic nonce.
+ *
+ * The shape is `<<REDACTED:KIND:name>>`: recognisable at a glance in a cassette, and unlikely to
+ * the point of absurdity to occur in real payload data. {@see self::assertAbsent()} turns "unlikely"
+ * into "checked" — a value that already contains the placeholder before redaction is rejected rather
+ * than silently corrupted, since restoring it afterwards would rewrite the caller's own text too.
+ */
+final class Placeholder
+{
+    private const FORMAT = '<<REDACTED:%s:%s>>';
+
+    /**
+     * The host counterpart of {@see self::FORMAT}.
+     *
+     * A host placeholder ends up inside `request.url`, which every rule applied afterwards — and
+     * `Request::fromArray()` on the next replay — still has to be able to run through `parse_url()`.
+     * Angle brackets and colons would make the URL unparseable, so the host placeholder is a
+     * hostname instead, in the `.invalid` TLD RFC 2606 reserves precisely so that it can never
+     * resolve to a real machine.
+     */
+    private const HOST = 'redacted-host.invalid';
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * The placeholder written in place of the named header's value.
+     *
+     * The name is lowercased because headers are matched case-insensitively: `Authorization` and
+     * `AUTHORIZATION` name the same header and therefore have to yield the same placeholder.
+     */
+    public static function forHeader(string $headerName): string
+    {
+        return \sprintf(self::FORMAT, 'HEADER', strtolower($headerName));
+    }
+
+    /**
+     * The placeholder written in place of the named post field's value.
+     */
+    public static function forPostField(string $fieldName): string
+    {
+        return \sprintf(self::FORMAT, 'POST_FIELD', $fieldName);
+    }
+
+    /**
+     * The placeholder written in place of the named query parameter's value.
+     */
+    public static function forQueryParameter(string $parameterName): string
+    {
+        return \sprintf(self::FORMAT, 'QUERY_PARAMETER', $parameterName);
+    }
+
+    /**
+     * The placeholder written in place of the request's host — see {@see self::HOST} for why it does
+     * not follow the shape the other three share.
+     */
+    public static function forHost(): string
+    {
+        return self::HOST;
+    }
+
+    /**
+     * Rejects a value that already carries the placeholder before it is redacted.
+     *
+     * @param string $placeholder the placeholder about to be written
+     * @param mixed  $value       the value about to be replaced; anything but a string trivially passes
+     * @param string $path        the dotted path of $value, named in the exception
+     *
+     * @throws PlaceholderCollisionException if $value already contains $placeholder
+     */
+    public static function assertAbsent(string $placeholder, $value, string $path): void
+    {
+        if (\is_string($value) && str_contains($value, $placeholder)) {
+            throw PlaceholderCollisionException::forPlaceholder($placeholder, $path);
+        }
+    }
+}

--- a/src/VCR/Storage/Redaction/PlaceholderCollisionException.php
+++ b/src/VCR/Storage/Redaction/PlaceholderCollisionException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction;
+
+class PlaceholderCollisionException extends \RuntimeException
+{
+    public static function forPlaceholder(string $placeholder, string $path): self
+    {
+        return new self(\sprintf(
+            'The value at "%s" already contains the placeholder "%s" before redaction.',
+            $path,
+            $placeholder
+        ));
+    }
+}

--- a/src/VCR/Storage/Redaction/RedactionRuleInterface.php
+++ b/src/VCR/Storage/Redaction/RedactionRuleInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction;
+
+/**
+ * A single, declarative rule that strips or masks sensitive data from a recorded cassette entry.
+ *
+ * Rules are composed by `RedactionRules` and applied to every recording written to (or read from)
+ * a cassette. A rule that is reversible can undo its own transformation on replay, so the original
+ * value is available again to the code under test; an irreversible rule permanently discards the
+ * original value and instead invalidates the request matchers that relied on it.
+ */
+interface RedactionRuleInterface
+{
+    /**
+     * The side(s) of the recorded interaction this rule inspects and rewrites.
+     *
+     * @return Scope::REQUEST|Scope::RESPONSE|Scope::BOTH
+     */
+    public function scope(): string;
+
+    /**
+     * Whether this rule can restore the original value on replay.
+     *
+     * A reversible rule's redaction can be undone by restore(); an irreversible rule permanently
+     * discards the original value.
+     */
+    public function isReversible(): bool;
+
+    /**
+     * Matcher keys this rule invalidates when it is not reversible.
+     *
+     * Only meaningful when isReversible() is false: since the original value is gone for good,
+     * any request matcher that would compare against it (e.g. "body", "post_fields") can no longer
+     * be relied on and must be excluded from matching.
+     *
+     * @return list<string> matcher keys, from the set of matchers Configuration knows about
+     */
+    public function affectedMatchers(): array;
+
+    /**
+     * Applies the redaction to a recording before it is written to the cassette.
+     *
+     * @param array<string,mixed> $recording the recording as it would otherwise be written
+     *
+     * @return array<string,mixed> the recording with this rule's redaction applied
+     */
+    public function redact(array $recording): array;
+
+    /**
+     * Reverses the redaction on a recording read back from the cassette.
+     *
+     * For a reversible rule, this restores the original value that redact() replaced. For an
+     * irreversible rule, this is a no-op: the recording is returned unchanged, since the original
+     * value was never retained.
+     *
+     * @param array<string,mixed> $recording the recording as read from the cassette
+     *
+     * @return array<string,mixed> the recording with this rule's redaction reversed
+     */
+    public function restore(array $recording): array;
+}

--- a/src/VCR/Storage/Redaction/RedactionRules.php
+++ b/src/VCR/Storage/Redaction/RedactionRules.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction;
+
+use VCR\Storage\Redaction\Rule\BodyCallbackRule;
+use VCR\Storage\Redaction\Rule\HeaderRule;
+use VCR\Storage\Redaction\Rule\HostRule;
+use VCR\Storage\Redaction\Rule\PostFieldRule;
+use VCR\Storage\Redaction\Rule\PostFieldsCallbackRule;
+use VCR\Storage\Redaction\Rule\QueryParameterRule;
+use VCR\Storage\Redaction\Rule\ValueSubstitutionRule;
+
+/**
+ * Fluent collection of redaction rules, and the single place their reversibility contract is
+ * enforced.
+ *
+ * This is the composition root every consumer touches directly: `RedactionRules::create()`
+ * followed by a chain of convenience methods (`header()`, `queryParameter()`, ...) or `add()` for
+ * a custom {@see RedactionRuleInterface} implementation. Every rule is checked at composition
+ * time, not at record time, so a configuration mistake surfaces immediately rather than silently
+ * corrupting a cassette: an irreversible rule that touches the request side would, on replay,
+ * leave the request matchers comparing against data that no longer matches what a live request
+ * carries. `allowIrreversibleRequestRedaction()` is the explicit escape hatch for callers who
+ * accept that risk and have narrowed their request matchers accordingly (see
+ * `safeRequestMatchers()`/`invalidatedRequestMatchers()`).
+ */
+final class RedactionRules
+{
+    /**
+     * Mirrors `Configuration::$availableRequestMatchers`' keys, in the same order. That property
+     * is private, so it cannot be referenced directly; this is the closest thing to a shared
+     * source of truth available without changing `Configuration`'s visibility.
+     *
+     * @var list<string>
+     */
+    private const DEFAULT_REQUEST_MATCHERS = [
+        'method',
+        'url',
+        'host',
+        'headers',
+        'body',
+        'post_fields',
+        'query_string',
+        'soap_operation',
+    ];
+
+    /**
+     * @var list<RedactionRuleInterface>
+     */
+    private array $rules = [];
+
+    private bool $irreversibleRequestRedactionAllowed = false;
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    /**
+     * Registers a redaction rule, enforcing the reversibility contract.
+     *
+     * A rule that cannot restore its own redaction and whose scope includes the request side is
+     * rejected unless {@see self::allowIrreversibleRequestRedaction()} has already been called:
+     * such a rule would permanently invalidate part of the request the configured matchers rely
+     * on, breaking replay. A response-only rule is never rejected, reversible or not, because the
+     * response is never matched against.
+     *
+     * @throws MissingReplacementException if the rule is irreversible, request-scoped, and the
+     *                                     opt-in has not been given
+     */
+    public function add(RedactionRuleInterface $rule): self
+    {
+        $scopeIncludesRequest = Scope::includes($rule->scope(), Scope::REQUEST);
+
+        if (!$rule->isReversible() && $scopeIncludesRequest && !$this->irreversibleRequestRedactionAllowed) {
+            throw MissingReplacementException::forRule($rule::class);
+        }
+
+        $this->rules[] = $rule;
+
+        return $this;
+    }
+
+    /**
+     * Opts into registering irreversible, request-scoped rules.
+     *
+     * Once called, {@see self::add()} no longer rejects such rules. Callers are expected to have
+     * accounted for the resulting matcher gap themselves, e.g. via {@see self::safeRequestMatchers()}.
+     */
+    public function allowIrreversibleRequestRedaction(): self
+    {
+        $this->irreversibleRequestRedactionAllowed = true;
+
+        return $this;
+    }
+
+    /**
+     * @param string|callable(): (string|null)|callable(array<string,mixed>): (string|null)|false|null $source
+     */
+    public function filterSensitiveData(string $placeholder, $source): self
+    {
+        return $this->add(new ValueSubstitutionRule($placeholder, $source));
+    }
+
+    /**
+     * @param string|callable(): (string|null)|callable(array<string,mixed>): (string|null)|false|null $source
+     * @param Scope::REQUEST|Scope::RESPONSE|Scope::BOTH                                               $scope
+     */
+    public function header(string $headerName, $source = null, string $scope = Scope::BOTH): self
+    {
+        return $this->add(new HeaderRule($headerName, $source, $scope));
+    }
+
+    /**
+     * @param Scope::REQUEST|Scope::RESPONSE|Scope::BOTH $scope
+     */
+    public function allHeaders(string $scope): self
+    {
+        return $this->add(HeaderRule::all($scope));
+    }
+
+    /**
+     * @param string|callable(): (string|null)|callable(array<string,mixed>): (string|null)|false|null $source
+     */
+    public function queryParameter(string $parameterName, $source = null): self
+    {
+        return $this->add(new QueryParameterRule($parameterName, $source));
+    }
+
+    /**
+     * @param string|callable(): (string|null)|callable(array<string,mixed>): (string|null)|false|null $source
+     */
+    public function postField(string $fieldName, $source = null): self
+    {
+        return $this->add(new PostFieldRule($fieldName, $source));
+    }
+
+    /**
+     * @param string|callable(): (string|null)|callable(array<string,mixed>): (string|null)|false|null $source
+     */
+    public function host($source = null): self
+    {
+        return $this->add(new HostRule($source));
+    }
+
+    /**
+     * @param callable(string): string                   $callback
+     * @param Scope::REQUEST|Scope::RESPONSE|Scope::BOTH $scope
+     */
+    public function body(callable $callback, string $scope): self
+    {
+        return $this->add(new BodyCallbackRule($callback, $scope));
+    }
+
+    /**
+     * @param callable(array<string,mixed>): array<string,mixed> $callback
+     */
+    public function postFields(callable $callback): self
+    {
+        return $this->add(new PostFieldsCallbackRule($callback));
+    }
+
+    /**
+     * The default request matcher keys that remain reliable given the rules added so far.
+     *
+     * @return list<string>
+     */
+    public function safeRequestMatchers(): array
+    {
+        $invalidated = $this->invalidatedRequestMatchers();
+
+        return array_values(array_filter(
+            self::DEFAULT_REQUEST_MATCHERS,
+            static fn (string $matcher): bool => !\in_array($matcher, $invalidated, true)
+        ));
+    }
+
+    /**
+     * The default request matcher keys invalidated by at least one added rule.
+     *
+     * @return list<string>
+     */
+    public function invalidatedRequestMatchers(): array
+    {
+        $affected = [];
+
+        foreach ($this->rules as $rule) {
+            foreach ($rule->affectedMatchers() as $matcher) {
+                $affected[$matcher] = true;
+            }
+        }
+
+        return array_values(array_filter(
+            self::DEFAULT_REQUEST_MATCHERS,
+            static fn (string $matcher): bool => isset($affected[$matcher])
+        ));
+    }
+
+    /**
+     * @return list<RedactionRuleInterface>
+     */
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+}

--- a/src/VCR/Storage/Redaction/Rule/BodyCallbackRule.php
+++ b/src/VCR/Storage/Redaction/Rule/BodyCallbackRule.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction\Rule;
+
+use VCR\Storage\RecordingPath;
+use VCR\Storage\Redaction\RedactionRuleInterface;
+use VCR\Storage\Redaction\Scope;
+
+/**
+ * Rewrites the request and/or response body through an arbitrary user-supplied callback.
+ *
+ * This is the escape hatch for redaction needs the other rules cannot express: the callback
+ * receives the current body verbatim and returns its replacement, with no assumption about
+ * format (JSON, XML, form-encoded, ...). Because the transformation is arbitrary, it is
+ * irreversible by nature: there is no way to recover the original body from the redacted one.
+ *
+ * Chaining several callbacks over the same body is not this class's responsibility. Registering
+ * multiple `BodyCallbackRule` instances already produces that behaviour, since `RedactionRules`
+ * applies each rule's `redact()` in registration order and each one sees the body the previous
+ * rule already rewrote.
+ */
+final class BodyCallbackRule implements RedactionRuleInterface
+{
+    /**
+     * @var callable(string): string
+     */
+    private $callback;
+
+    /**
+     * @var Scope::REQUEST|Scope::RESPONSE|Scope::BOTH
+     */
+    private string $scope;
+
+    /**
+     * @param callable(string): string $callback receives the current body, returns its replacement
+     * @param string                   $scope    which side(s) of the interaction to apply the callback to,
+     *                                           one of {@see Scope}'s three constants
+     *
+     * @throws \VCR\Storage\Redaction\InvalidRedactionRuleException if $scope is not a known scope
+     */
+    public function __construct(callable $callback, string $scope)
+    {
+        Scope::assertValid($scope);
+
+        $this->callback = $callback;
+        $this->scope = $scope;
+    }
+
+    public function scope(): string
+    {
+        return $this->scope;
+    }
+
+    public function isReversible(): bool
+    {
+        return false;
+    }
+
+    public function affectedMatchers(): array
+    {
+        return Scope::RESPONSE === $this->scope ? [] : ['body'];
+    }
+
+    public function redact(array $recording): array
+    {
+        if (Scope::includes($this->scope, Scope::REQUEST)) {
+            $recording = $this->applyCallback($recording, Scope::REQUEST);
+        }
+
+        if (Scope::includes($this->scope, Scope::RESPONSE)) {
+            $recording = $this->applyCallback($recording, Scope::RESPONSE);
+        }
+
+        return $recording;
+    }
+
+    /**
+     * No-op: the callback's transformation is arbitrary and cannot be inverted, so the original
+     * body is gone for good once redact() has run.
+     *
+     * @param array<string,mixed> $recording
+     *
+     * @return array<string,mixed>
+     */
+    public function restore(array $recording): array
+    {
+        return $recording;
+    }
+
+    /**
+     * @param array<string,mixed> $recording
+     *
+     * @return array<string,mixed>
+     */
+    private function applyCallback(array $recording, string $container): array
+    {
+        return RecordingPath::replace(
+            $recording,
+            [$container, 'body'],
+            fn (mixed $body): string => ($this->callback)(\is_string($body) ? $body : '')
+        );
+    }
+}

--- a/src/VCR/Storage/Redaction/Rule/HeaderRule.php
+++ b/src/VCR/Storage/Redaction/Rule/HeaderRule.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction\Rule;
+
+use VCR\Storage\RecordingPath;
+use VCR\Storage\Redaction\InvalidRedactionRuleException;
+use VCR\Storage\Redaction\Placeholder;
+use VCR\Storage\Redaction\RedactionRuleInterface;
+use VCR\Storage\Redaction\Scope;
+use VCR\Storage\Redaction\SecretSource;
+
+/**
+ * Redacts a single header, matched case-insensitively, or every header in scope via {@see self::all()}.
+ *
+ * With a replacement source, the source *is* the real header value — typically read from an
+ * environment variable or a secrets manager. `redact()` writes a placeholder in its place, so the
+ * cassette on disk never carries the secret, and `restore()` resolves the source again and writes it
+ * back before the request matchers run. Replay therefore compares the real value against the real
+ * value a live request carries, with the `headers` matcher left enabled. The source has to resolve
+ * to the header's *whole* value, prefix included (`'Bearer '.getenv('API_TOKEN')`, not just the
+ * token), because a header rule owns the whole value rather than a substring of it — reach for
+ * `filterSensitiveData()` when only part of a value is secret.
+ *
+ * The wildcard form is blanking-only for that reason: one source cannot stand for every header in
+ * scope, so it is rejected at construction rather than writing the same secret into all of them.
+ *
+ * Without a replacement source, the header's value is blanked to an empty string rather than the
+ * header being removed — `RecordingPath` has no key-deletion primitive, only in-place value
+ * replacement. This is legal unconditionally on the response side (nothing there is ever matched),
+ * but only legal on the request side once the owning `RedactionRules` has been told to accept the
+ * resulting matcher gap — this class only reports that gap honestly through
+ * `isReversible()`/`affectedMatchers()`, it does not enforce it.
+ *
+ * Known limitation: blanking is not removal. Code that checks header presence with
+ * `array_key_exists()`/`isset()` rather than truthiness (e.g. `Response::getHeader()` returning `''`
+ * instead of `null`) will observe the header as present-but-empty after redaction, not absent, on
+ * replay. There is currently no way to make a blanked header disappear entirely.
+ */
+final class HeaderRule implements RedactionRuleInterface
+{
+    private const WILDCARD = '*';
+
+    private const CONTAINERS = [Scope::REQUEST, Scope::RESPONSE];
+
+    private string $headerName;
+
+    private ?SecretSource $source;
+
+    private string $placeholder;
+
+    /**
+     * @var Scope::REQUEST|Scope::RESPONSE|Scope::BOTH
+     */
+    private string $scope;
+
+    /**
+     * @param string                                                                                   $headerName the header to redact, or `'*'` to redact every header in scope
+     * @param string|callable(): (string|null)|callable(array<string,mixed>): (string|null)|false|null $source     a literal replacement value, a callable that resolves
+     *                                                                                                             one, or null to blank the header instead; rejected
+     *                                                                                                             outright for `'*'`, which names more than one header
+     * @param string                                                                                   $scope      one of {@see Scope}'s three constants, rejected at construction if it is not
+     *
+     * @throws InvalidRedactionRuleException if $scope is not a known scope, if $source is neither a
+     *                                       string nor a callable, or if $source is given alongside
+     *                                       the wildcard header name
+     */
+    public function __construct(string $headerName, $source = null, string $scope = Scope::BOTH)
+    {
+        Scope::assertValid($scope);
+
+        // A single source stands for a single header's whole value. Spread across every header in
+        // scope it would write the same secret into all of them and restore that one value into all
+        // of them on read, quietly rewriting headers that were never sensitive to begin with.
+        if (self::WILDCARD === $headerName && null !== $source) {
+            throw InvalidRedactionRuleException::wildcardHeaderWithSource(self::WILDCARD);
+        }
+
+        $this->headerName = $headerName;
+        $this->scope = $scope;
+        $this->placeholder = Placeholder::forHeader($headerName);
+        $this->source = null === $source ? null : new SecretSource($this->placeholder, $source);
+    }
+
+    /**
+     * Builds a rule that redacts every header found within the given scope.
+     *
+     * @param string $scope one of {@see Scope}'s three constants
+     */
+    public static function all(string $scope): self
+    {
+        return new self(self::WILDCARD, null, $scope);
+    }
+
+    public function scope(): string
+    {
+        return $this->scope;
+    }
+
+    public function isReversible(): bool
+    {
+        return Scope::RESPONSE === $this->scope || null !== $this->source;
+    }
+
+    public function affectedMatchers(): array
+    {
+        return $this->isReversible() ? [] : ['headers'];
+    }
+
+    public function redact(array $recording): array
+    {
+        $paths = $this->matchingSegments($recording);
+        $source = $this->source;
+
+        if ([] === $paths) {
+            return $recording;
+        }
+
+        if (null === $source) {
+            return $this->writeAll($recording, $paths, static fn (): string => '');
+        }
+
+        // Resolving the secret here without using it is the point: a cassette redacted against a
+        // source that cannot be resolved could never be restored, and that failure belongs at
+        // record time rather than at the next replay, when the original value is long gone.
+        $source->resolve($recording);
+
+        return $this->writeAll($recording, $paths, function ($value, array $segments): string {
+            Placeholder::assertAbsent($this->placeholder, $value, implode('.', $segments));
+
+            return $this->placeholder;
+        });
+    }
+
+    public function restore(array $recording): array
+    {
+        $paths = $this->matchingSegments($recording);
+        $source = $this->source;
+
+        if (null === $source || [] === $paths) {
+            return $recording;
+        }
+
+        $secret = $source->resolve($recording);
+
+        return $this->writeAll($recording, $paths, static fn (): string => $secret);
+    }
+
+    /**
+     * @param array<string,mixed>               $recording
+     * @param array<int, string[]>              $paths
+     * @param \Closure(mixed, string[]): string $replacement receives the current value and the segment path it sits at
+     *
+     * @return array<string,mixed>
+     */
+    private function writeAll(array $recording, array $paths, \Closure $replacement): array
+    {
+        foreach ($paths as $segments) {
+            $recording = RecordingPath::replace(
+                $recording,
+                $segments,
+                static fn ($value): string => $replacement($value, $segments)
+            );
+        }
+
+        return $recording;
+    }
+
+    /**
+     * @param array<string,mixed> $recording
+     *
+     * @return array<int, string[]>
+     */
+    private function matchingSegments(array $recording): array
+    {
+        $headerNames = self::WILDCARD === $this->headerName
+            ? $this->headerNamesInScope($recording)
+            : [$this->headerName];
+
+        $segments = RecordingPath::resolvePaths($recording, [], $headerNames);
+
+        return array_values(array_filter(
+            $segments,
+            fn (array $segment): bool => Scope::includes($this->scope, $segment[0])
+        ));
+    }
+
+    /**
+     * @param array<string,mixed> $recording
+     *
+     * @return string[]
+     */
+    private function headerNamesInScope(array $recording): array
+    {
+        $names = [];
+
+        foreach (self::CONTAINERS as $container) {
+            if (!Scope::includes($this->scope, $container)) {
+                continue;
+            }
+
+            $headers = $recording[$container]['headers'] ?? null;
+
+            if (\is_array($headers)) {
+                foreach (array_keys($headers) as $name) {
+                    $names[] = (string) $name;
+                }
+            }
+        }
+
+        return $names;
+    }
+}

--- a/src/VCR/Storage/Redaction/Rule/HostRule.php
+++ b/src/VCR/Storage/Redaction/Rule/HostRule.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction\Rule;
+
+use VCR\Storage\RecordingPath;
+use VCR\Storage\Redaction\Placeholder;
+use VCR\Storage\Redaction\RedactionRuleInterface;
+use VCR\Storage\Redaction\Scope;
+use VCR\Storage\Redaction\SecretSource;
+use VCR\Storage\Redaction\UrlParts;
+
+/**
+ * Redacts the host consistently in both `request.url` and the `Host` header, if present.
+ *
+ * The host only ever exists on the request side, so this rule is always request-scoped. With a
+ * replacement source, the source *is* the real host: `redact()` writes a placeholder host in its
+ * place so the cassette never names the real machine, and `restore()` resolves the source again and
+ * writes it back before the request matchers run, so both the `host` and `headers` matchers keep
+ * comparing the real host against the real host a live request carries. The source resolves to the
+ * bare host, without a port — the URL's port component is not this rule's to rewrite, and is left
+ * exactly where it was — and is written into both locations verbatim, never percent-encoded, for
+ * the same reason {@see QueryParameterRule} writes its value raw: the matchers compare what is on
+ * the wire, so the caller supplies the value in the form the wire carries it.
+ *
+ * The `Host` header is rewritten by swapping the old host out of its value rather than overwriting
+ * it, so an appended `:8443` survives the round trip. The host is located case-insensitively, so a
+ * header that spells it differently from the URL still keeps everything around it; a header value
+ * that does not carry the host at all is overwritten wholesale instead, so the real host cannot
+ * survive in it either way.
+ *
+ * Without a source, the host is set to a fixed, non-empty value rather than blanked to an empty
+ * string. An empty host makes the URL unparseable (`parse_url()` returns `false` for a URL like
+ * `https://:8443/path`), which breaks `Request::fromArray()` on the next replay (it calls
+ * `getHost()` to backfill a missing `Host` header, which throws `InvalidHostException` once the URL
+ * can no longer be parsed) and can silently defeat *other* rules applied to the same recording: a
+ * `QueryParameterRule` running after an empty-host `HostRule` would see `parse_url()` fail and no-op
+ * instead of redacting its own target. The same constraint is why the reversible placeholder is a
+ * hostname rather than the `<<REDACTED:...>>` shape the other rules use — see {@see Placeholder}.
+ */
+final class HostRule implements RedactionRuleInterface
+{
+    private const BLANKED_HOST = 'redacted';
+
+    private const PATH = 'request.url';
+
+    private ?SecretSource $source;
+
+    private string $placeholder;
+
+    /**
+     * @param string|callable(): (string|null)|callable(array<string,mixed>): (string|null)|false|null $source a literal replacement host, a callable that resolves
+     *                                                                                                         one, or null to redact to a fixed placeholder instead
+     */
+    public function __construct($source = null)
+    {
+        $this->placeholder = Placeholder::forHost();
+        $this->source = null === $source ? null : new SecretSource($this->placeholder, $source);
+    }
+
+    public function scope(): string
+    {
+        return Scope::REQUEST;
+    }
+
+    public function isReversible(): bool
+    {
+        return null !== $this->source;
+    }
+
+    public function affectedMatchers(): array
+    {
+        // Note: 'url' is deliberately not reported here — RequestMatcher::matchUrl() only
+        // compares the URL path (PHP_URL_PATH), never the host, so this rule cannot invalidate
+        // it. 'headers' is reported instead of 'url': this rule keeps the Host header in sync
+        // with the URL's host component, and RequestMatcher::matchHeaders() does a strict
+        // whole-array comparison that a rewritten Host header would fail without a source.
+        return $this->isReversible() ? [] : ['host', 'headers'];
+    }
+
+    public function redact(array $recording): array
+    {
+        $source = $this->source;
+
+        if (null === $source) {
+            return $this->rewriteHost(
+                $recording,
+                static fn (): string => self::BLANKED_HOST,
+                static fn (): string => self::BLANKED_HOST
+            );
+        }
+
+        return $this->rewriteHost(
+            $recording,
+            function ($currentHost) use ($source, $recording): string {
+                // Resolving the secret here without using it is the point: a cassette redacted
+                // against a source that cannot be resolved could never be restored, and that
+                // failure belongs at record time rather than at the next replay, when the original
+                // value is long gone.
+                $source->resolve($recording);
+
+                Placeholder::assertAbsent($this->placeholder, $currentHost, self::PATH);
+
+                return $this->placeholder;
+            },
+            fn ($value, string $previousHost): string => $this->swapHostInHeaderValue($value, $previousHost, $this->placeholder)
+        );
+    }
+
+    public function restore(array $recording): array
+    {
+        $source = $this->source;
+
+        if (null === $source) {
+            return $recording;
+        }
+
+        return $this->rewriteHost(
+            $recording,
+            static fn (): string => $source->resolve($recording),
+            fn ($value, string $previousHost): string => $this->swapHostInHeaderValue($value, $previousHost, $source->resolve($recording))
+        );
+    }
+
+    /**
+     * Rewrites the host in `request.url` and mirrors it into the request's `Host` header.
+     *
+     * A no-op if the URL is missing or unparseable — there is no host to redact in either case.
+     *
+     * @param array<string,mixed>             $recording
+     * @param \Closure(string): string        $resolveHost receives the host currently in the URL, returns its replacement
+     * @param \Closure(mixed, string): string $headerValue receives the Host header's current value and the host being replaced
+     *
+     * @return array<string,mixed>
+     */
+    private function rewriteHost(array $recording, \Closure $resolveHost, \Closure $headerValue): array
+    {
+        $url = $recording['request']['url'] ?? null;
+
+        if (!\is_string($url) || '' === $url) {
+            return $recording;
+        }
+
+        $parts = UrlParts::parse($url);
+
+        if (null === $parts) {
+            return $recording;
+        }
+
+        $previousHost = (string) ($parts['host'] ?? '');
+        $parts['host'] = $resolveHost($previousHost);
+        $recording['request']['url'] = UrlParts::toUrl($parts);
+
+        foreach (RecordingPath::resolvePaths($recording, [], ['Host']) as $segments) {
+            if (Scope::REQUEST !== $segments[0]) {
+                continue;
+            }
+
+            $recording = RecordingPath::replace(
+                $recording,
+                $segments,
+                static fn ($value): string => $headerValue($value, $previousHost)
+            );
+        }
+
+        return $recording;
+    }
+
+    /**
+     * Swaps the host out of the `Host` header's value, leaving everything else it carries in place.
+     *
+     * The host is located case-insensitively, because hostnames are case-insensitive per RFC 3986
+     * and a client is free to send `api.example.com` for a URL written as `API.Example.com`. A
+     * byte-exact search would miss that value, leaving only the wholesale overwrite below — which
+     * throws away whatever else the header carried, typically the port, so the `headers` matcher
+     * then fails on replay even though nothing leaked. The host itself comes back in the
+     * replacement's casing rather than the header's own, which the header cannot preserve: a single
+     * source stands for both locations, and the casing the header used is not on the cassette.
+     *
+     * A value that does not name the host at all is still overwritten wholesale, so the real host
+     * cannot survive in it either way.
+     *
+     * @param mixed $value the Host header's current value
+     */
+    private function swapHostInHeaderValue($value, string $previousHost, string $host): string
+    {
+        if (!\is_string($value) || '' === $previousHost) {
+            return $host;
+        }
+
+        $occurrences = 0;
+        $swapped = str_ireplace($previousHost, $host, $value, $occurrences);
+
+        return 0 === $occurrences ? $host : $swapped;
+    }
+}

--- a/src/VCR/Storage/Redaction/Rule/PostFieldRule.php
+++ b/src/VCR/Storage/Redaction/Rule/PostFieldRule.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction\Rule;
+
+use VCR\Storage\RecordingPath;
+use VCR\Storage\Redaction\Placeholder;
+use VCR\Storage\Redaction\RedactionRuleInterface;
+use VCR\Storage\Redaction\Scope;
+use VCR\Storage\Redaction\SecretSource;
+
+/**
+ * Redacts a single key inside `request.post_fields`.
+ *
+ * Post fields only ever exist on the request side, so this rule is always request-scoped. With a
+ * replacement source, the source *is* the real field value: `redact()` writes a placeholder in its
+ * place so the cassette never carries it, and `restore()` resolves the source again and writes it
+ * back before the request matchers run, so the `post_fields` matcher keeps comparing the real value
+ * against the real value a live request sends.
+ *
+ * Without a source, the field's value is blanked to an empty string rather than the key being
+ * removed — `RecordingPath` has no key-deletion primitive. Unlike a response header, a post field is
+ * never handed back to application code during replay (it only ever feeds request matching), so this
+ * does not change replay-observable behaviour the way a blanked response header does.
+ */
+final class PostFieldRule implements RedactionRuleInterface
+{
+    private string $fieldName;
+
+    private ?SecretSource $source;
+
+    private string $placeholder;
+
+    /**
+     * @param string|callable(): (string|null)|callable(array<string,mixed>): (string|null)|false|null $source a literal replacement value, a callable that resolves
+     *                                                                                                         one, or null to blank the field instead
+     */
+    public function __construct(string $fieldName, $source = null)
+    {
+        $this->fieldName = $fieldName;
+        $this->placeholder = Placeholder::forPostField($fieldName);
+        $this->source = null === $source ? null : new SecretSource($this->placeholder, $source);
+    }
+
+    public function scope(): string
+    {
+        return Scope::REQUEST;
+    }
+
+    public function isReversible(): bool
+    {
+        return null !== $this->source;
+    }
+
+    public function affectedMatchers(): array
+    {
+        return $this->isReversible() ? [] : ['post_fields'];
+    }
+
+    public function redact(array $recording): array
+    {
+        $source = $this->source;
+
+        if (!$this->hasField($recording)) {
+            return $recording;
+        }
+
+        if (null === $source) {
+            return $this->writeField($recording, '');
+        }
+
+        // Resolving the secret here without using it is the point: a cassette redacted against a
+        // source that cannot be resolved could never be restored, and that failure belongs at
+        // record time rather than at the next replay, when the original value is long gone.
+        $source->resolve($recording);
+
+        Placeholder::assertAbsent(
+            $this->placeholder,
+            RecordingPath::get($recording, $this->segments()),
+            implode('.', $this->segments())
+        );
+
+        return $this->writeField($recording, $this->placeholder);
+    }
+
+    public function restore(array $recording): array
+    {
+        $source = $this->source;
+
+        if (null === $source || !$this->hasField($recording)) {
+            return $recording;
+        }
+
+        return $this->writeField($recording, $source->resolve($recording));
+    }
+
+    /**
+     * @param array<string,mixed> $recording
+     */
+    private function hasField(array $recording): bool
+    {
+        $postFields = $recording['request']['post_fields'] ?? null;
+
+        return \is_array($postFields) && \array_key_exists($this->fieldName, $postFields);
+    }
+
+    /**
+     * @param array<string,mixed> $recording
+     *
+     * @return array<string,mixed>
+     */
+    private function writeField(array $recording, string $value): array
+    {
+        return RecordingPath::replace($recording, $this->segments(), static fn (): string => $value);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function segments(): array
+    {
+        return ['request', 'post_fields', $this->fieldName];
+    }
+}

--- a/src/VCR/Storage/Redaction/Rule/PostFieldsCallbackRule.php
+++ b/src/VCR/Storage/Redaction/Rule/PostFieldsCallbackRule.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction\Rule;
+
+use VCR\Storage\RecordingPath;
+use VCR\Storage\Redaction\RedactionRuleInterface;
+use VCR\Storage\Redaction\Scope;
+
+/**
+ * Rewrites the whole `request.post_fields` array through an arbitrary user-supplied callback.
+ *
+ * This is the escape hatch for redaction needs the field- and value-targeted rules cannot
+ * express: the callback receives the current post fields verbatim and returns their replacement.
+ * Post fields only ever exist on the request side, so this rule is always request-scoped. Because
+ * the transformation is arbitrary, it is irreversible by nature: there is no way to recover the
+ * original post fields from the redacted ones.
+ *
+ * Chaining several callbacks over the same post fields is not this class's responsibility.
+ * Registering multiple `PostFieldsCallbackRule` instances already produces that behaviour, since
+ * `RedactionRules` applies each rule's `redact()` in registration order and each one sees the post
+ * fields the previous rule already rewrote.
+ */
+final class PostFieldsCallbackRule implements RedactionRuleInterface
+{
+    /**
+     * @var callable(array<string,mixed>): array<string,mixed>
+     */
+    private $callback;
+
+    /**
+     * @param callable(array<string,mixed>): array<string,mixed> $callback receives the current post fields, returns their replacement
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    public function scope(): string
+    {
+        return Scope::REQUEST;
+    }
+
+    public function isReversible(): bool
+    {
+        return false;
+    }
+
+    public function affectedMatchers(): array
+    {
+        return ['post_fields'];
+    }
+
+    public function redact(array $recording): array
+    {
+        return RecordingPath::replace(
+            $recording,
+            ['request', 'post_fields'],
+            fn (mixed $postFields): array => ($this->callback)(\is_array($postFields) ? $postFields : [])
+        );
+    }
+
+    /**
+     * No-op: the callback's transformation is arbitrary and cannot be inverted, so the original
+     * post fields are gone for good once redact() has run.
+     *
+     * @param array<string,mixed> $recording
+     *
+     * @return array<string,mixed>
+     */
+    public function restore(array $recording): array
+    {
+        return $recording;
+    }
+}

--- a/src/VCR/Storage/Redaction/Rule/QueryParameterRule.php
+++ b/src/VCR/Storage/Redaction/Rule/QueryParameterRule.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction\Rule;
+
+use VCR\Storage\Redaction\Placeholder;
+use VCR\Storage\Redaction\RedactionRuleInterface;
+use VCR\Storage\Redaction\Scope;
+use VCR\Storage\Redaction\SecretSource;
+use VCR\Storage\Redaction\UrlParts;
+
+/**
+ * Redacts a single named parameter out of the query string carried in `request.url`.
+ *
+ * There is no query setter on `Request` — the URL string is the only carrier of the query string — so
+ * this rule takes the URL apart with `parse_url()`, rewrites the named parameter within the raw query
+ * string, and puts the URL back together, leaving every other parameter byte-identical (see
+ * {@see UrlParts::rewriteQueryParameter()} for why that is done on the raw segments rather than
+ * through `parse_str()`). Query strings only ever exist in the request, so this rule is always
+ * request-scoped.
+ *
+ * With a replacement source, the source *is* the real parameter value: `redact()` writes a
+ * placeholder in its place so the cassette never carries it, and `restore()` resolves the source
+ * again and writes it back before the request matchers run, so the `query_string` matcher keeps
+ * comparing the real value against the real value a live request sends.
+ *
+ * The source is written into the query string exactly as it resolves, with no percent-encoding
+ * applied — supply it in the form the HTTP client actually puts on the wire (`'a%20b'` if the
+ * client encodes the space, `'a b'` if it does not). Encoding it here instead would mean picking
+ * one convention for every client: `RequestMatcher::matchQueryString()` compares the raw query
+ * string byte-for-byte, and `urlencode()` escaping an `@` or writing a space as `+` is enough to
+ * fail that comparison against a client that does neither. This is the same contract
+ * {@see ValueSubstitutionRule} places on its secret, and the reason both rules can promise a
+ * byte-identical round trip at all.
+ *
+ * The placeholder goes in unencoded for the same reason it can: `<<REDACTED:QUERY_PARAMETER:name>>`
+ * carries no `&`, `=` or `#`, so `parse_url()` still hands back the query string whole, and the
+ * placeholder is never located by parsing it out — `restore()` rewrites the same named segment
+ * this rule wrote, so the value never travels through a URL parser outside these two methods.
+ *
+ * Without a source, the parameter's value is blanked to an empty string rather than the parameter
+ * being removed from the query string — this keeps the URL structurally valid and does not risk the
+ * unparseable-URL failure mode `HostRule` avoids by using a placeholder instead of an empty host.
+ */
+final class QueryParameterRule implements RedactionRuleInterface
+{
+    private const PATH = 'request.url';
+
+    private string $parameterName;
+
+    private ?SecretSource $source;
+
+    private string $placeholder;
+
+    /**
+     * @param string|callable(): (string|null)|callable(array<string,mixed>): (string|null)|false|null $source a literal replacement value, a callable that resolves
+     *                                                                                                         one, or null to blank the parameter instead
+     */
+    public function __construct(string $parameterName, $source = null)
+    {
+        $this->parameterName = $parameterName;
+        $this->placeholder = Placeholder::forQueryParameter($parameterName);
+        $this->source = null === $source ? null : new SecretSource($this->placeholder, $source);
+    }
+
+    public function scope(): string
+    {
+        return Scope::REQUEST;
+    }
+
+    public function isReversible(): bool
+    {
+        return null !== $this->source;
+    }
+
+    public function affectedMatchers(): array
+    {
+        // Note: the query string is compared by the 'query_string' matcher
+        // (RequestMatcher::matchQueryString()), not 'url' — RequestMatcher::matchUrl() only
+        // compares the URL path (PHP_URL_PATH), so it is never affected by this rule.
+        return $this->isReversible() ? [] : ['query_string'];
+    }
+
+    public function redact(array $recording): array
+    {
+        $source = $this->source;
+
+        if (null === $source) {
+            return $this->rewriteParameter($recording, static fn (): string => '');
+        }
+
+        return $this->rewriteParameter($recording, function (string $value) use ($source, $recording): string {
+            // Resolving the secret here without using it is the point: a cassette redacted against
+            // a source that cannot be resolved could never be restored, and that failure belongs at
+            // record time rather than at the next replay, when the original value is long gone.
+            $source->resolve($recording);
+
+            Placeholder::assertAbsent($this->placeholder, $value, self::PATH);
+
+            return $this->placeholder;
+        });
+    }
+
+    public function restore(array $recording): array
+    {
+        $source = $this->source;
+
+        if (null === $source) {
+            return $recording;
+        }
+
+        return $this->rewriteParameter($recording, static fn (): string => $source->resolve($recording));
+    }
+
+    /**
+     * Rewrites the named query parameter, leaving the rest of the URL exactly as it was.
+     *
+     * A no-op if the URL is missing, unparseable, carries no query string, or does not carry the
+     * named parameter — in none of those cases is there anything for this rule to redact.
+     *
+     * @param array<string,mixed>      $recording
+     * @param \Closure(string): string $replacement receives the parameter's current, decoded value
+     *
+     * @return array<string,mixed>
+     */
+    private function rewriteParameter(array $recording, \Closure $replacement): array
+    {
+        $url = $recording['request']['url'] ?? null;
+
+        if (!\is_string($url) || '' === $url) {
+            return $recording;
+        }
+
+        $parts = UrlParts::parse($url);
+
+        if (null === $parts || !isset($parts['query'])) {
+            return $recording;
+        }
+
+        $query = UrlParts::rewriteQueryParameter((string) $parts['query'], $this->parameterName, $replacement);
+
+        if (null === $query) {
+            return $recording;
+        }
+
+        $parts['query'] = $query;
+        $recording['request']['url'] = UrlParts::toUrl($parts);
+
+        return $recording;
+    }
+}

--- a/src/VCR/Storage/Redaction/Rule/ValueSubstitutionRule.php
+++ b/src/VCR/Storage/Redaction/Rule/ValueSubstitutionRule.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction\Rule;
+
+use VCR\Storage\Redaction\InvalidRedactionRuleException;
+use VCR\Storage\Redaction\PlaceholderCollisionException;
+use VCR\Storage\Redaction\RedactionRuleInterface;
+use VCR\Storage\Redaction\Scope;
+use VCR\Storage\Redaction\SecretSource;
+
+/**
+ * Replaces every occurrence of a secret value with a placeholder, anywhere in the recording.
+ *
+ * Unlike path-based rules, this rule does not target a fixed set of fields: it walks the whole
+ * recording and rewrites every string leaf it finds, at any depth. That is the underlying
+ * implementation `filterSensitiveData()` composes into a `ValueSubstitutionRule` per configured
+ * secret. Because the substitution is a literal, reversible string swap, it never invalidates a
+ * request matcher.
+ *
+ * The secret itself is never stored: {@see SecretSource} resolves it on demand from either a
+ * literal string or a callable, so it can be looked up from an environment variable, a secrets
+ * manager, or derived from the recording being processed.
+ */
+final class ValueSubstitutionRule implements RedactionRuleInterface
+{
+    private string $placeholder;
+
+    private SecretSource $source;
+
+    /**
+     * @param string                                                                                   $placeholder the literal text that replaces the secret in the recording
+     * @param string|callable(): (string|null)|callable(array<string,mixed>): (string|null)|false|null $source      a literal secret value, or a callable that resolves one; a plain
+     *                                                                                                              string is always treated as the literal secret, never invoked, so
+     *                                                                                                              there is no ambiguity with PHP's "string as callable name" convention.
+     *                                                                                                              `false`/`null`, as `getenv()` returns for an unset variable, are
+     *                                                                                                              accepted and surface as a `MissingSecretException` when the secret
+     *                                                                                                              is actually needed
+     *
+     * @throws InvalidRedactionRuleException if the placeholder is empty, or the source is neither a
+     *                                       string nor a callable
+     */
+    public function __construct(string $placeholder, $source)
+    {
+        if ('' === $placeholder) {
+            throw InvalidRedactionRuleException::emptyPlaceholder();
+        }
+
+        $this->placeholder = $placeholder;
+        $this->source = new SecretSource($placeholder, $source);
+    }
+
+    public function scope(): string
+    {
+        return Scope::BOTH;
+    }
+
+    public function isReversible(): bool
+    {
+        return true;
+    }
+
+    public function affectedMatchers(): array
+    {
+        return [];
+    }
+
+    public function redact(array $recording): array
+    {
+        $secret = $this->source->resolve($recording);
+        $collisionPath = $this->findFirstOccurrence($recording, $this->placeholder);
+
+        if (null !== $collisionPath) {
+            throw PlaceholderCollisionException::forPlaceholder($this->placeholder, $collisionPath);
+        }
+
+        return $this->replaceInRecording($recording, $secret, $this->placeholder);
+    }
+
+    public function restore(array $recording): array
+    {
+        $secret = $this->source->resolve($recording);
+
+        return $this->replaceInRecording($recording, $this->placeholder, $secret);
+    }
+
+    /**
+     * Finds the dotted path of the first string leaf containing $needle, or null if none do.
+     *
+     * @param array<string,mixed> $recording
+     */
+    private function findFirstOccurrence(array $recording, string $needle, string $path = ''): ?string
+    {
+        foreach ($recording as $key => $value) {
+            $currentPath = '' === $path ? (string) $key : $path.'.'.$key;
+
+            if (\is_string($value) && str_contains($value, $needle)) {
+                return $currentPath;
+            }
+
+            if (\is_array($value)) {
+                $found = $this->findFirstOccurrence($value, $needle, $currentPath);
+
+                if (null !== $found) {
+                    return $found;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Replaces every occurrence of $search with $replace in every string leaf of the recording,
+     * recursing into nested maps (e.g. headers) and lists (e.g. post_files) alike.
+     *
+     * @param array<string,mixed> $recording
+     *
+     * @return array<string,mixed>
+     */
+    private function replaceInRecording(array $recording, string $search, string $replace): array
+    {
+        foreach ($recording as $key => $value) {
+            if (\is_string($value)) {
+                $recording[$key] = str_replace($search, $replace, $value);
+            } elseif (\is_array($value)) {
+                $recording[$key] = $this->replaceInRecording($value, $search, $replace);
+            }
+        }
+
+        return $recording;
+    }
+}

--- a/src/VCR/Storage/Redaction/Scope.php
+++ b/src/VCR/Storage/Redaction/Scope.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction;
+
+/**
+ * The side(s) of a recorded HTTP interaction a redaction rule applies to.
+ *
+ * Kept as class constants rather than a native enum so the codebase stays compatible with the
+ * PHP 8.0 floor this project supports. Because a plain string cannot enforce its own domain,
+ * {@see self::assertValid()} is what keeps a typo from silently turning a rule into a no-op.
+ */
+final class Scope
+{
+    public const REQUEST = 'request';
+    public const RESPONSE = 'response';
+    public const BOTH = 'both';
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Whether a rule declaring $scope acts on $side.
+     *
+     * @param string $scope the scope a rule declares, one of this class' three constants
+     * @param string $side  the side being considered, `Scope::REQUEST` or `Scope::RESPONSE` — also
+     *                      the name of the container a recording keeps that side under
+     */
+    public static function includes(string $scope, string $side): bool
+    {
+        return self::BOTH === $scope || $scope === $side;
+    }
+
+    /**
+     * Rejects a scope string that is not one of this class' three constants.
+     *
+     * @phpstan-assert self::REQUEST|self::RESPONSE|self::BOTH $scope
+     *
+     * @throws InvalidRedactionRuleException if $scope is not a recognised scope
+     */
+    public static function assertValid(string $scope): void
+    {
+        if (!\in_array($scope, [self::REQUEST, self::RESPONSE, self::BOTH], true)) {
+            throw InvalidRedactionRuleException::unsupportedScope($scope);
+        }
+    }
+}

--- a/src/VCR/Storage/Redaction/SecretSource.php
+++ b/src/VCR/Storage/Redaction/SecretSource.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction;
+
+/**
+ * Where a reversible redaction rule gets the real secret from, on demand.
+ *
+ * The secret itself is never stored on the rule: it is resolved every time it is needed, from
+ * either a literal string or a callable, so it can be looked up from an environment variable, a
+ * secrets manager, or derived from the recording being processed. A plain string is always the
+ * literal secret and is never invoked, so there is no ambiguity with PHP's "string as callable
+ * name" convention.
+ *
+ * This is a boundary: it takes whatever a caller hands over and decides there and then whether it
+ * can ever produce a secret. `null` and `false` are accepted rather than rejected, because
+ * `getenv()` returns `false` and `$_SERVER['X'] ?? null` returns `null` for an unset variable, and
+ * a test suite running without the secret configured should fail with a `MissingSecretException`
+ * naming the placeholder instead of a `TypeError` from deep inside this class. Anything else — an
+ * int, an array that is not callable, an object without `__invoke()` — is a configuration mistake
+ * and is rejected right where it was configured.
+ */
+final class SecretSource
+{
+    /**
+     * @var string|callable|null the normalised source, with the "not configured" values collapsed into null
+     */
+    private $source;
+
+    /**
+     * Whether the callable source wants the recording passed to it, decided once at construction
+     * time via reflection rather than on every resolve().
+     *
+     * What matters is the *required* parameter count: this keeps both `callable(): ?string` and
+     * `callable(array $recording): ?string` sources working without forcing every caller to declare
+     * an unused parameter. A no-arg-in-practice callable with an unrelated optional parameter, e.g.
+     * `function (string $x = 'foo'): ?string`, must still be called with zero arguments; counting
+     * all parameters would pass it a `$recording` array where it expects a `string` and blow up
+     * with a `TypeError`.
+     */
+    private bool $recordingAware = false;
+
+    private string $placeholder;
+
+    /**
+     * @param string $placeholder the placeholder this secret is swapped with, named in the exception raised when the secret cannot be resolved
+     * @param mixed  $source      a literal secret value, or a callable that resolves one; `null`/`false` stand for "not configured"
+     *
+     * @throws InvalidRedactionRuleException if $source is neither a string nor a callable, and not
+     *                                       one of the `null`/`false` "not configured" values
+     */
+    public function __construct(string $placeholder, $source)
+    {
+        $this->placeholder = $placeholder;
+
+        if (\is_string($source)) {
+            $this->source = $source;
+
+            return;
+        }
+
+        if (null === $source || false === $source) {
+            $this->source = null;
+
+            return;
+        }
+
+        if (!\is_callable($source)) {
+            throw InvalidRedactionRuleException::unsupportedSecretSource($placeholder, get_debug_type($source));
+        }
+
+        $this->source = $source;
+        $this->recordingAware = (new \ReflectionFunction(\Closure::fromCallable($source)))->getNumberOfRequiredParameters() > 0;
+    }
+
+    /**
+     * Resolves the secret, evaluating a callable source against the given recording if needed.
+     *
+     * @param array<string,mixed> $recording the recording a recording-aware source is resolved against
+     *
+     * @throws MissingSecretException if the source resolves to anything other than a non-empty string
+     */
+    public function resolve(array $recording): string
+    {
+        $secret = $this->evaluate($recording);
+
+        if (!\is_string($secret) || '' === $secret) {
+            throw MissingSecretException::forPlaceholder($this->placeholder);
+        }
+
+        return $secret;
+    }
+
+    /**
+     * @param array<string,mixed> $recording
+     */
+    private function evaluate(array $recording): mixed
+    {
+        $source = $this->source;
+
+        if (!\is_callable($source) || \is_string($source)) {
+            return $source;
+        }
+
+        return $this->recordingAware ? $source($recording) : $source();
+    }
+}

--- a/src/VCR/Storage/Redaction/UrlParts.php
+++ b/src/VCR/Storage/Redaction/UrlParts.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Storage\Redaction;
+
+/**
+ * Takes a URL apart into `parse_url()` components and puts it back together again.
+ *
+ * `parse_url()` has no counterpart in PHP's standard library, so a rule that rewrites one component
+ * of `request.url` — the host, a single query parameter — has to reassemble the rest by hand. Doing
+ * that in one place keeps `HostRule` and `QueryParameterRule` from drifting apart on which
+ * components they preserve.
+ */
+final class UrlParts
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Splits a URL into its components.
+     *
+     * @param string $url the URL to split
+     *
+     * @return array<string,int|string>|null the components found, or null if the URL is unparseable
+     */
+    public static function parse(string $url): ?array
+    {
+        $parts = parse_url($url);
+
+        return false === $parts ? null : $parts;
+    }
+
+    /**
+     * Rewrites one named parameter inside a raw query string, leaving every other one byte-identical.
+     *
+     * Deliberately not built on `parse_str()`/`http_build_query()`: `parse_str()` mangles keys the
+     * way PHP mangles variable names, turning a dot or a space into an underscore. Round-tripping a
+     * query string through that pair rewrites parameters this rule never targeted (`client.secret`
+     * comes back as `client_secret`), which breaks the `query_string` matcher on replay, and makes a
+     * parameter whose own name carries a dot impossible to find — so its value would silently stay
+     * on the cassette in plaintext. Working on the raw segments avoids both.
+     *
+     * Every occurrence of the parameter is rewritten, not just the last one, so a repeated
+     * parameter cannot leave one copy of the secret behind.
+     *
+     * The string the replacement returns is written into the query string **verbatim**, with no
+     * percent-encoding applied to it. There is no encoding convention every HTTP client follows
+     * identically — `urlencode()` escapes `@` and writes a space as `+`, `rawurlencode()` writes
+     * `%20`, and a given client may leave either untouched — so re-encoding the value here cannot
+     * reproduce byte-for-byte what a live request will carry, and `RequestMatcher::matchQueryString()`
+     * compares the raw query string byte-for-byte. Writing the value exactly as given puts that
+     * choice where the knowledge is, with the caller, the same contract
+     * {@see Rule\ValueSubstitutionRule} has always had for its secret.
+     *
+     * Reading is deliberately not symmetric: the parameter's name and its current value are both
+     * compared *decoded*, so a percent-encoded name is still found and a percent-encoded secret is
+     * still recognised by the collision guard.
+     *
+     * @param string                   $query       the raw query string, without the leading "?"
+     * @param string                   $name        the parameter to rewrite, compared decoded
+     * @param \Closure(string): string $replacement receives the parameter's current, decoded value,
+     *                                              and returns the replacement to write verbatim
+     *
+     * @return string|null the rewritten query string, or null if the parameter does not occur in it
+     */
+    public static function rewriteQueryParameter(string $query, string $name, \Closure $replacement): ?string
+    {
+        $segments = explode('&', $query);
+        $found = false;
+
+        foreach ($segments as $index => $segment) {
+            $separator = strpos($segment, '=');
+            $rawName = false === $separator ? $segment : substr($segment, 0, $separator);
+
+            if (urldecode($rawName) !== $name) {
+                continue;
+            }
+
+            $currentValue = false === $separator ? '' : urldecode(substr($segment, $separator + 1));
+            $segments[$index] = $rawName.'='.$replacement($currentValue);
+            $found = true;
+        }
+
+        return $found ? implode('&', $segments) : null;
+    }
+
+    /**
+     * Reassembles a URL from the components `parse_url()` produced, preserving every one of them.
+     *
+     * @param array<string,int|string> $parts the components to reassemble, as returned by {@see self::parse()}
+     */
+    public static function toUrl(array $parts): string
+    {
+        $url = '';
+
+        if (isset($parts['scheme'])) {
+            $url .= $parts['scheme'].'://';
+        }
+
+        if (isset($parts['user'])) {
+            $url .= $parts['user'];
+            if (isset($parts['pass'])) {
+                $url .= ':'.$parts['pass'];
+            }
+            $url .= '@';
+        }
+
+        $url .= $parts['host'] ?? '';
+
+        if (isset($parts['port'])) {
+            $url .= ':'.$parts['port'];
+        }
+
+        $url .= $parts['path'] ?? '';
+
+        if (isset($parts['query']) && '' !== $parts['query']) {
+            $url .= '?'.$parts['query'];
+        }
+
+        if (isset($parts['fragment'])) {
+            $url .= '#'.$parts['fragment'];
+        }
+
+        return $url;
+    }
+}

--- a/tests/Integration/Storage/RedactingStorageIntegrationTest.php
+++ b/tests/Integration/Storage/RedactingStorageIntegrationTest.php
@@ -1,0 +1,596 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Integration\Storage;
+
+use org\bovigo\vfs\vfsStream;
+use Symfony\Component\Yaml\Yaml as SymfonyYaml;
+use VCR\LibraryHooks\StreamWrapperHook;
+use VCR\Storage\EncryptedStorageFactory;
+use VCR\Storage\Encryption\EncryptionKey;
+use VCR\Storage\RedactingStorageFactory;
+use VCR\Storage\Redaction\MissingSecretException;
+use VCR\Storage\Redaction\RedactionRules;
+use VCR\Storage\Redaction\Scope;
+use VCR\Storage\YamlStorageFactory;
+use VCR\Tests\Integration\AbstractHttpServerIntegrationTestCase;
+use VCR\VCR;
+
+final class RedactingStorageIntegrationTest extends AbstractHttpServerIntegrationTestCase
+{
+    private const SECRET = 'hunter2-do-not-commit';
+
+    /**
+     * @param array<string,string> $headers
+     */
+    private function getWithHeaders(string $url, array $headers = []): int
+    {
+        $headerLines = '';
+        foreach ($headers as $name => $value) {
+            $headerLines .= $name.': '.$value."\r\n";
+        }
+
+        $context = stream_context_create([
+            'http' => ['method' => 'GET', 'header' => $headerLines, 'ignore_errors' => true],
+        ]);
+
+        return $this->performAndReadStatus($url, $context);
+    }
+
+    /**
+     * @param array<string,string> $headers
+     */
+    private function postWithHeaders(string $url, string $body, array $headers = []): int
+    {
+        $headerLines = "Content-Type: application/x-www-form-urlencoded\r\n";
+        foreach ($headers as $name => $value) {
+            $headerLines .= $name.': '.$value."\r\n";
+        }
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'header' => $headerLines,
+                'content' => $body,
+                'ignore_errors' => true,
+            ],
+        ]);
+
+        return $this->performAndReadStatus($url, $context);
+    }
+
+    /**
+     * @param array<string,string> $headers
+     */
+    private function curlPost(string $url, string $body, array $headers = [], bool $captureRequestHeaders = false): int
+    {
+        $ch = curl_init($url);
+        curl_setopt($ch, \CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, \CURLOPT_POST, true);
+        curl_setopt($ch, \CURLOPT_POSTFIELDS, $body);
+
+        if ([] !== $headers) {
+            $headerLines = [];
+            foreach ($headers as $name => $value) {
+                $headerLines[] = $name.': '.$value;
+            }
+            curl_setopt($ch, \CURLOPT_HTTPHEADER, $headerLines);
+        }
+
+        if ($captureRequestHeaders) {
+            curl_setopt($ch, \CURLINFO_HEADER_OUT, true);
+        }
+
+        curl_exec($ch);
+        $statusCode = (int) curl_getinfo($ch, \CURLINFO_HTTP_CODE);
+
+        // curl_close() is a documented no-op since PHP 8.0 and deprecated on PHP 8.5, so it is
+        // deliberately omitted here.
+        return $statusCode;
+    }
+
+    /**
+     * @param array<string,mixed> $fields
+     */
+    private function curlPostFields(string $url, array $fields): int
+    {
+        $ch = curl_init($url);
+        curl_setopt($ch, \CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, \CURLOPT_POST, true);
+        curl_setopt($ch, \CURLOPT_POSTFIELDS, $fields);
+        curl_exec($ch);
+
+        return (int) curl_getinfo($ch, \CURLINFO_HTTP_CODE);
+    }
+
+    /**
+     * @param resource $context
+     */
+    private function performAndReadStatus(string $url, $context): int
+    {
+        $stream = fopen($url, 'r', false, $context);
+
+        if (false === $stream) {
+            throw new \RuntimeException(\sprintf('Unable to open a stream to "%s".', $url));
+        }
+
+        // StreamWrapperHook::streamGetMetaData() reports the real response header lines whether
+        // the stream was served by VCR's own wrapper (replay) or PHP's native http wrapper
+        // (recording, since library hooks are disabled around the real outbound request).
+        $meta = StreamWrapperHook::streamGetMetaData($stream);
+        fclose($stream);
+
+        /** @var string[] $responseHeaders */
+        $responseHeaders = \is_array($meta['wrapper_data'] ?? null) ? $meta['wrapper_data'] : [];
+
+        return $this->statusFromResponseHeaders($responseHeaders);
+    }
+
+    /**
+     * @param string[] $responseHeaders
+     */
+    private function statusFromResponseHeaders(array $responseHeaders): int
+    {
+        if (!isset($responseHeaders[0]) || !preg_match('#^HTTP/\S+\s+(\d{3})#', $responseHeaders[0], $matches)) {
+            throw new \RuntimeException('Unable to determine the HTTP status code from the response headers.');
+        }
+
+        return (int) $matches[1];
+    }
+
+    private function cassettePath(string $cassette): string
+    {
+        return vfsStream::url('testDir').'/'.$cassette;
+    }
+
+    private function cassetteContents(string $cassette): string
+    {
+        return (string) file_get_contents($this->cassettePath($cassette));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function firstRecording(string $cassette): array
+    {
+        $parsed = SymfonyYaml::parse($this->cassetteContents($cassette));
+
+        return \is_array($parsed[0] ?? null) ? $parsed[0] : [];
+    }
+
+    /**
+     * The core proof of the feature (Verification #1): a real secret goes through
+     * `filterSensitiveData()`, never touches the disk, and replay still succeeds with every
+     * default request matcher enabled — reversible redaction must not force narrower matching.
+     */
+    public function testFilterSensitiveDataHidesSecretAndReplaysWithAllDefaultMatchersEnabled(): void
+    {
+        $rules = RedactionRules::create()->filterSensitiveData('<<AUTH_TOKEN>>', self::SECRET);
+
+        VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules));
+
+        $this->recordAndReplay(
+            'redact-core-proof',
+            fn (): int => $this->postWithHeaders(self::$baseUrl.'/post', 'ping=pong', ['Authorization' => 'Bearer '.self::SECRET])
+        );
+
+        $raw = $this->cassetteContents('redact-core-proof');
+
+        $this->assertStringNotContainsString(self::SECRET, $raw, 'The secret must never hit the disk.');
+        $this->assertStringContainsString('<<AUTH_TOKEN>>', $raw);
+        // The test server echoes request headers back into the response body, so a passing
+        // assertion above already proves both request and response coverage; this pins it down
+        // explicitly against the parsed structure instead of relying on incidental byte layout.
+        $recording = $this->firstRecording('redact-core-proof');
+        $this->assertStringContainsString('<<AUTH_TOKEN>>', $recording['request']['headers']['Authorization']);
+        $this->assertStringContainsString('<<AUTH_TOKEN>>', $recording['response']['body']);
+    }
+
+    /**
+     * Verification #2: CURLINFO_HEADER_OUT captures the raw outgoing request headers into
+     * response.curl_info.request_header — a leak channel every naive redaction approach misses.
+     * filterSensitiveData() walks the whole recording, so it must cover this path too.
+     */
+    public function testCurlInfoHeaderOutSecretIsRedactedEverywhereInCassette(): void
+    {
+        $rules = RedactionRules::create()->filterSensitiveData('<<AUTH_TOKEN>>', self::SECRET);
+
+        VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules));
+
+        $this->recordAndReplay(
+            'redact-curl-header-out',
+            fn (): int => $this->curlPost(self::$baseUrl.'/post', 'ping=pong', ['Authorization' => 'Bearer '.self::SECRET], true)
+        );
+
+        $raw = $this->cassetteContents('redact-curl-header-out');
+        $this->assertStringNotContainsString(self::SECRET, $raw, 'The secret must be absent from the entire cassette file.');
+
+        $recording = $this->firstRecording('redact-curl-header-out');
+        $requestHeaderOut = $recording['response']['curl_info']['request_header'] ?? null;
+        $this->assertIsString($requestHeaderOut, 'CURLINFO_HEADER_OUT must have been captured.');
+        $this->assertStringContainsString('<<AUTH_TOKEN>>', $requestHeaderOut, 'The captured outgoing headers must be redacted, not skipped.');
+    }
+
+    /**
+     * PR #344 checklist: "Declare the secret as a callback resolved at runtime".
+     */
+    public function testCallableSecretSourceRoundTripsWithoutArguments(): void
+    {
+        $secret = self::SECRET;
+        $rules = RedactionRules::create()->filterSensitiveData('<<AUTH_TOKEN>>', static fn (): string => $secret);
+
+        VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules));
+
+        $this->recordAndReplay(
+            'redact-callable-secret',
+            fn (): int => $this->postWithHeaders(self::$baseUrl.'/post', 'ping=pong', ['Authorization' => 'Bearer '.$secret])
+        );
+
+        $raw = $this->cassetteContents('redact-callable-secret');
+        $this->assertStringNotContainsString($secret, $raw);
+        $this->assertStringContainsString('<<AUTH_TOKEN>>', $raw);
+    }
+
+    /**
+     * PR #344 checklist: "Callback receives the request/response so the secret can be derived
+     * from them" — evaluated against the pre-redaction recording on write.
+     */
+    public function testRecordingAwareCallableSecretIsDerivedFromThePreRedactionRecording(): void
+    {
+        $rules = RedactionRules::create()->filterSensitiveData(
+            '<<DERIVED_TOKEN>>',
+            static fn (array $recording): string => 'derived-'.$recording['request']['method']
+        );
+
+        VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules));
+
+        $derivedSecret = 'derived-POST';
+
+        $this->recordAndReplay(
+            'redact-recording-aware-secret',
+            fn (): int => $this->postWithHeaders(self::$baseUrl.'/post', 'ping=pong', ['X-Derived-Secret' => $derivedSecret])
+        );
+
+        $raw = $this->cassetteContents('redact-recording-aware-secret');
+        $this->assertStringNotContainsString($derivedSecret, $raw);
+        $this->assertStringContainsString('<<DERIVED_TOKEN>>', $raw);
+    }
+
+    /**
+     * PR #344 checklist: "Introspect the configured redactions" — safeRequestMatchers() and
+     * invalidatedRequestMatchers() are pure functions over the registered rules.
+     */
+    public function testRedactionRulesExposeSafeAndInvalidatedRequestMatchers(): void
+    {
+        $rules = RedactionRules::create()
+            ->allowIrreversibleRequestRedaction()
+            ->header('X-Nonce', null, Scope::REQUEST)
+            ->queryParameter('nonce');
+
+        $this->assertSame(['headers', 'query_string'], $rules->invalidatedRequestMatchers());
+        $this->assertSame(
+            ['method', 'url', 'host', 'body', 'post_fields', 'soap_operation'],
+            $rules->safeRequestMatchers()
+        );
+        $this->assertCount(2, $rules->rules());
+    }
+
+    /**
+     * Verification #5 (falsy secret): the plan explicitly rejected "silently skipped" in favour
+     * of MissingSecretException, end to end through RedactingStorageFactory.
+     */
+    public function testFalsySecretSourceRaisesMissingSecretExceptionThroughTheFactory(): void
+    {
+        $rules = RedactionRules::create()->filterSensitiveData('<<MISSING_TOKEN>>', static fn (): ?string => null);
+
+        VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules));
+
+        $this->expectException(MissingSecretException::class);
+
+        VCR::turnOn();
+        VCR::insertCassette('redact-falsy-secret');
+        $this->postWithHeaders(self::$baseUrl.'/post', 'ping=pong');
+    }
+
+    /**
+     * Verification #5 (shared secret): two placeholders sharing the same secret must not throw
+     * or corrupt the recording — pins the "ordered pair list, not a flipped hash" decision.
+     */
+    public function testTwoPlaceholdersSharingTheSameSecretBothRoundTrip(): void
+    {
+        $rules = RedactionRules::create()
+            ->filterSensitiveData('<<TOKEN_A>>', self::SECRET)
+            ->filterSensitiveData('<<TOKEN_B>>', self::SECRET);
+
+        VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules));
+
+        $this->recordAndReplay(
+            'redact-shared-secret',
+            fn (): int => $this->postWithHeaders(self::$baseUrl.'/post', 'ping=pong', ['Authorization' => 'Bearer '.self::SECRET])
+        );
+
+        $raw = $this->cassetteContents('redact-shared-secret');
+        $this->assertStringNotContainsString(self::SECRET, $raw);
+    }
+
+    /**
+     * Verification #6: redact-then-encrypt, the documented composition order.
+     */
+    public function testStackingRedactionOverEncryptionHidesSecretInCiphertextCassette(): void
+    {
+        if (!\extension_loaded('sodium')) {
+            $this->markTestSkipped('The encrypted storage requires ext-sodium, which is not loaded.');
+        }
+
+        $key = EncryptionKey::fromBinary(str_repeat("\x5a", \SODIUM_CRYPTO_KDF_KEYBYTES));
+        $rules = RedactionRules::create()->filterSensitiveData('<<AUTH_TOKEN>>', self::SECRET);
+
+        VCR::configure()->setStorageFactory(
+            RedactingStorageFactory::withRules(EncryptedStorageFactory::withKey(new YamlStorageFactory(), $key), $rules)
+        );
+
+        $this->recordAndReplay(
+            'redact-then-encrypt',
+            fn (): int => $this->postWithHeaders(self::$baseUrl.'/post', 'ping=pong', ['Authorization' => 'Bearer '.self::SECRET])
+        );
+
+        $raw = $this->cassetteContents('redact-then-encrypt');
+        $this->assertStringNotContainsString(self::SECRET, $raw);
+        $this->assertStringContainsString('vcr:enc:v1:', $raw);
+    }
+
+    /**
+     * External sanitizer checklist: "Ignore query fields" (valueless form, under the irreversible
+     * opt-in). The query value legitimately differs between the record and replay calls; the
+     * feature's promise is that wiring up safeRequestMatchers() keeps replay working anyway.
+     *
+     * QueryParameterRule targets request.url specifically, not the whole recording — unlike
+     * filterSensitiveData(), it makes no claim about response.curl_info.url (curl's own
+     * CURLINFO_EFFECTIVE_URL echo of the real request URL, unrelated to this rule), so the
+     * assertion below is scoped to the field the rule actually owns.
+     */
+    public function testQueryParameterIgnoredWithoutSourceUsingSafeRequestMatchers(): void
+    {
+        $rules = RedactionRules::create()->allowIrreversibleRequestRedaction()->queryParameter('nonce');
+
+        VCR::configure()
+            ->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules))
+            ->enableRequestMatchers($rules->safeRequestMatchers());
+
+        $callNumber = 0;
+        $this->recordAndReplay(
+            'redact-query-ignored',
+            function () use (&$callNumber): int {
+                ++$callNumber;
+
+                return $this->getWithHeaders(self::$baseUrl.'/get?nonce=call-'.$callNumber);
+            }
+        );
+
+        $recording = $this->firstRecording('redact-query-ignored');
+        $this->assertStringNotContainsString('call-1', $recording['request']['url'], 'The query parameter must be blanked in the recorded request URL.');
+        $this->assertStringContainsString('nonce=', $recording['request']['url']);
+    }
+
+    /**
+     * External sanitizer checklist: "Ignore request headers" (reversible form). Both the record
+     * and the replay call send the *real* secret, exactly as a live HTTP client always would: what
+     * lands on disk is the placeholder, and restoration puts the real value back before the
+     * matchers run, so replay matches with every default matcher — `headers` included — still
+     * enabled. Nothing here is hand-tuned to make the two sides agree.
+     *
+     * header() targets the header location specifically, not the whole recording — the test server
+     * used here echoes every request header back into the response body, which HeaderRule never
+     * touches (only filterSensitiveData() walks the whole recording), so the secret-absence
+     * assertion is scoped to the recorded request, the part the rule actually owns.
+     */
+    public function testHeaderWithSourceConcealsSecretAndStillMatchesOnReplay(): void
+    {
+        $rules = RedactionRules::create()->header('X-Signature', self::SECRET, Scope::REQUEST);
+
+        VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules));
+
+        $this->recordAndReplay(
+            'redact-header-source',
+            fn (): int => $this->postWithHeaders(self::$baseUrl.'/post', 'ping=pong', ['X-Signature' => self::SECRET])
+        );
+
+        $recording = $this->firstRecording('redact-header-source');
+
+        $this->assertSame(
+            '<<REDACTED:HEADER:x-signature>>',
+            $recording['request']['headers']['X-Signature'],
+            'The recorded header must carry the placeholder, never the real signature.'
+        );
+        $this->assertStringNotContainsString(
+            self::SECRET,
+            (string) json_encode($recording['request']),
+            'The secret must be absent from the recorded request on disk.'
+        );
+    }
+
+    /**
+     * The same proof for host(), the only built-in rule that invalidates more than one matcher when
+     * it is irreversible: given the real host as its source it invalidates none, rewriting both
+     * request.url and the Host header on the way out and putting both back on the way in.
+     */
+    public function testHostWithSourceConcealsTheRealHostAndStillMatchesOnReplay(): void
+    {
+        $realHost = (string) parse_url(self::$baseUrl, \PHP_URL_HOST);
+        $rules = RedactionRules::create()->host($realHost);
+
+        $this->assertSame([], $rules->invalidatedRequestMatchers());
+
+        VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules));
+
+        $this->recordAndReplay('redact-host-source', fn (): int => $this->getWithHeaders(self::$baseUrl.'/get'));
+
+        $recording = $this->firstRecording('redact-host-source');
+        $port = (string) parse_url(self::$baseUrl, \PHP_URL_PORT);
+
+        $this->assertStringContainsString('redacted-host.invalid', $recording['request']['url']);
+        $this->assertStringNotContainsString($realHost, $recording['request']['url']);
+        $this->assertSame('redacted-host.invalid:'.$port, $recording['request']['headers']['Host'] ?? null);
+    }
+
+    /**
+     * External sanitizer checklist: "Ignore all headers ('*')" and "Ignore response headers
+     * (incl. '*')" — allHeaders() is response-scoped here, which is always legal unconditionally
+     * since responses are never matched against.
+     */
+    public function testAllHeadersWildcardBlanksEveryResponseHeaderValue(): void
+    {
+        $rules = RedactionRules::create()->allHeaders(Scope::RESPONSE);
+
+        VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules));
+
+        $this->recordAndReplay('redact-all-response-headers', fn (): int => $this->getWithHeaders(self::$baseUrl.'/get'));
+
+        $recording = $this->firstRecording('redact-all-response-headers');
+        $this->assertNotEmpty($recording['response']['headers'], 'The response must have carried at least one header to blank.');
+        foreach ($recording['response']['headers'] as $value) {
+            $this->assertSame('', $value);
+        }
+    }
+
+    /**
+     * External sanitizer checklist: "Ignore hostname" — host() rewrites the host consistently in
+     * both request.url and the Host header (valueless form, under the irreversible opt-in, since
+     * the live test server's real host cannot be substituted for another reachable one here).
+     */
+    public function testHostRedactedConsistentlyInUrlAndHostHeader(): void
+    {
+        $rules = RedactionRules::create()->allowIrreversibleRequestRedaction()->host();
+
+        VCR::configure()
+            ->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules))
+            ->enableRequestMatchers($rules->safeRequestMatchers());
+
+        $this->recordAndReplay('redact-host', fn (): int => $this->getWithHeaders(self::$baseUrl.'/get'));
+
+        $recording = $this->firstRecording('redact-host');
+        $realHost = (string) parse_url(self::$baseUrl, \PHP_URL_HOST).':'.parse_url(self::$baseUrl, \PHP_URL_PORT);
+
+        $this->assertStringNotContainsString($realHost, $recording['request']['url']);
+        $this->assertStringContainsString('redacted', $recording['request']['url']);
+        $this->assertSame('redacted', $recording['request']['headers']['Host'] ?? null);
+    }
+
+    /**
+     * External sanitizer checklist: "Request body scrubbers (chained callbacks)" — multiple
+     * body() calls chain in registration order, each seeing the previous rule's output.
+     */
+    public function testChainedBodyScrubbersApplyInRegistrationOrder(): void
+    {
+        $rules = RedactionRules::create()
+            ->allowIrreversibleRequestRedaction()
+            ->body(static fn (string $body): string => str_replace('secret', 'MASKED', $body), Scope::REQUEST)
+            ->body(static fn (string $body): string => strtoupper($body), Scope::REQUEST);
+
+        VCR::configure()
+            ->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules))
+            ->enableRequestMatchers($rules->safeRequestMatchers());
+
+        $this->recordAndReplay(
+            'redact-chained-body',
+            fn (): int => $this->postWithHeaders(self::$baseUrl.'/post', 'greeting=hello-secret-world')
+        );
+
+        $recording = $this->firstRecording('redact-chained-body');
+        $this->assertSame('GREETING=HELLO-MASKED-WORLD', $recording['request']['body']);
+    }
+
+    /**
+     * External sanitizer checklist: "Response body scrubbers" — always legal unconditionally,
+     * since the response is never matched against; no opt-in or matcher narrowing required.
+     */
+    public function testResponseBodyScrubberRedactsWithoutInvalidatingMatchers(): void
+    {
+        $rules = RedactionRules::create()->body(static fn (string $body): string => 'scrubbed', Scope::RESPONSE);
+
+        VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules));
+
+        $this->recordAndReplay('redact-response-body', fn (): int => $this->getWithHeaders(self::$baseUrl.'/get'));
+
+        $recording = $this->firstRecording('redact-response-body');
+        $this->assertSame('scrubbed', $recording['response']['body']);
+    }
+
+    /**
+     * External sanitizer checklist: "Post field scrubbers (callback over the array)" chained via
+     * multiple postFields() calls, plus postField() for a single key — both request-scoped and
+     * irreversible by nature.
+     */
+    public function testChainedPostFieldScrubbersAndSinglePostFieldRule(): void
+    {
+        $rules = RedactionRules::create()
+            ->allowIrreversibleRequestRedaction()
+            ->postFields(static function (array $fields): array {
+                if (isset($fields['card'])) {
+                    $fields['card'] = 'MASKED-CARD';
+                }
+
+                return $fields;
+            })
+            ->postFields(static function (array $fields): array {
+                $fields['scrubbed_by'] = 'chain';
+
+                return $fields;
+            })
+            ->postField('password');
+
+        VCR::configure()
+            ->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules))
+            ->enableRequestMatchers($rules->safeRequestMatchers());
+
+        $this->recordAndReplay(
+            'redact-post-fields',
+            fn (): int => $this->curlPostFields(self::$baseUrl.'/post', ['card' => '4111111111111111', 'password' => self::SECRET, 'other' => 'keep-me'])
+        );
+
+        $recording = $this->firstRecording('redact-post-fields');
+        $postFields = $recording['request']['post_fields'];
+
+        $this->assertSame('MASKED-CARD', $postFields['card']);
+        $this->assertSame('chain', $postFields['scrubbed_by']);
+        $this->assertSame('', $postFields['password']);
+        $this->assertSame('keep-me', $postFields['other']);
+    }
+
+    /**
+     * External sanitizer checklist: "Case-insensitive header matching" — same convention as
+     * EncryptionPolicy's header handling.
+     */
+    public function testHeaderRuleMatchesResponseHeaderNamesCaseInsensitively(): void
+    {
+        $rules = RedactionRules::create()->header('content-type', null, Scope::RESPONSE);
+
+        VCR::configure()->setStorageFactory(RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules));
+
+        $this->recordAndReplay('redact-case-insensitive-header', fn (): int => $this->getWithHeaders(self::$baseUrl.'/get'));
+
+        $recording = $this->firstRecording('redact-case-insensitive-header');
+        $this->assertSame('', $recording['response']['headers']['Content-Type'] ?? null);
+    }
+
+    /**
+     * Verification #7: the storage-factory reset happens via inheritance
+     * (AbstractIntegrationTestCase::setUp() resets to `new YamlStorageFactory()` before every
+     * test). This proves no RedactingStorageFactory configured by an earlier test in this class
+     * leaks into a test that never configures one itself.
+     */
+    public function testDefaultStorageFactoryIsNotLeakedFromPreviousRedactionTests(): void
+    {
+        $this->recordAndReplay(
+            'redact-no-leak',
+            fn (): int => $this->postWithHeaders(self::$baseUrl.'/post', 'ping=pong', ['Authorization' => 'Bearer '.self::SECRET])
+        );
+
+        // No redaction rules were configured for this test, so the plain YamlStorageFactory that
+        // AbstractIntegrationTestCase::setUp() resets to on every test must have been used — the
+        // secret is expected to be in plaintext.
+        $raw = $this->cassetteContents('redact-no-leak');
+        $this->assertStringContainsString(self::SECRET, $raw);
+    }
+}

--- a/tests/Unit/Storage/PurgeableRedactingStorageTest.php
+++ b/tests/Unit/Storage/PurgeableRedactingStorageTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\PurgeableRedactingStorage;
+use VCR\Storage\Redaction\RedactionRules;
+use VCR\Storage\Yaml;
+
+final class PurgeableRedactingStorageTest extends TestCase
+{
+    private Yaml $inner;
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        $this->inner = new Yaml(vfsStream::url('testDir').'/', 'redacted_purgeable_test');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(int $index = 0): array
+    {
+        return [
+            'request' => [
+                'method' => 'POST',
+                'url' => 'https://api.example.com/login',
+                'headers' => ['Authorization' => 'Bearer secret'],
+                'body' => 'hunter2',
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+                'body' => 'welcome',
+            ],
+            'index' => $index,
+        ];
+    }
+
+    public function testPurgeClearsTheInnerStorage(): void
+    {
+        $storage = new PurgeableRedactingStorage($this->inner, RedactionRules::create());
+        $storage->storeRecording($this->recording());
+
+        $storage->purge();
+        $storage->rewind();
+
+        $this->assertFalse($storage->valid());
+    }
+}

--- a/tests/Unit/Storage/RecordingPathTest.php
+++ b/tests/Unit/Storage/RecordingPathTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\RecordingPath;
+
+final class RecordingPathTest extends TestCase
+{
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(): array
+    {
+        return [
+            'request' => [
+                'method' => 'POST',
+                'url' => 'https://api.example.com/login',
+                'headers' => [
+                    'Host' => 'api.example.com',
+                    'authorization' => 'Bearer secret',
+                    'X-Trace-Id' => 'abc-123',
+                ],
+                'body' => '{"password":"hunter2"}',
+                'post_fields' => ['user' => 'alice', 'password' => 'hunter2'],
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+                'headers' => ['Set-Cookie' => 'session=abc', 'Content-Type' => 'application/json'],
+                'body' => 'welcome',
+            ],
+            'index' => 0,
+        ];
+    }
+
+    public function testResolvePathsSplitsDottedFieldPaths(): void
+    {
+        $paths = RecordingPath::resolvePaths($this->recording(), ['request.body', 'response.body'], []);
+
+        $this->assertSame([['request', 'body'], ['response', 'body']], $paths);
+    }
+
+    public function testResolvePathsMatchesHeaderNamesCaseInsensitively(): void
+    {
+        $paths = RecordingPath::resolvePaths($this->recording(), [], ['AUTHORIZATION']);
+
+        $this->assertSame([['request', 'headers', 'authorization']], $paths);
+    }
+
+    public function testResolvePathsMatchesHeadersInBothContainers(): void
+    {
+        $paths = RecordingPath::resolvePaths($this->recording(), [], ['authorization', 'set-cookie']);
+
+        $this->assertSame(
+            [['request', 'headers', 'authorization'], ['response', 'headers', 'Set-Cookie']],
+            $paths
+        );
+    }
+
+    public function testResolvePathsKeepsHeaderNamesContainingDotsAsOneSegment(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['headers']['X.Api.Secret'] = 'top-secret';
+
+        $paths = RecordingPath::resolvePaths($recording, [], ['X.Api.Secret']);
+
+        $this->assertSame([['request', 'headers', 'X.Api.Secret']], $paths);
+    }
+
+    public function testResolvePathsIgnoresNonArrayHeaders(): void
+    {
+        $recording = ['request' => ['headers' => 'not-an-array'], 'index' => 0];
+
+        $paths = RecordingPath::resolvePaths($recording, [], ['authorization']);
+
+        $this->assertSame([], $paths);
+    }
+
+    public function testResolvePathsReturnsEmptyArrayForEmptyInputs(): void
+    {
+        $paths = RecordingPath::resolvePaths($this->recording(), [], []);
+
+        $this->assertSame([], $paths);
+    }
+
+    public function testReplaceTransformsTheValueAtTheSegmentPath(): void
+    {
+        $recording = $this->recording();
+
+        $replaced = RecordingPath::replace($recording, ['request', 'body'], static fn ($value) => strtoupper((string) $value));
+
+        $this->assertSame('{"PASSWORD":"HUNTER2"}', $replaced['request']['body']);
+    }
+
+    public function testReplaceLeavesTheRecordingUnchangedWhenASegmentIsMissing(): void
+    {
+        $recording = ['request' => ['method' => 'GET'], 'index' => 0];
+
+        $replaced = RecordingPath::replace($recording, ['request', 'body'], static fn ($value) => 'never-called');
+
+        $this->assertSame($recording, $replaced);
+    }
+
+    public function testReplaceLeavesTheRecordingUnchangedWhenTheContainerIsMissing(): void
+    {
+        $recording = ['index' => 0];
+
+        $replaced = RecordingPath::replace($recording, ['request', 'body'], static fn ($value) => 'never-called');
+
+        $this->assertSame($recording, $replaced);
+    }
+
+    public function testReplaceSupportsOpaqueHeaderNameSegmentsContainingDots(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['headers']['X.Api.Secret'] = 'top-secret';
+
+        $replaced = RecordingPath::replace(
+            $recording,
+            ['request', 'headers', 'X.Api.Secret'],
+            static fn ($value) => strtoupper((string) $value)
+        );
+
+        $this->assertSame('TOP-SECRET', $replaced['request']['headers']['X.Api.Secret']);
+    }
+
+    public function testGetReadsTheValueAtTheSegmentPath(): void
+    {
+        $value = RecordingPath::get($this->recording(), ['request', 'body']);
+
+        $this->assertSame('{"password":"hunter2"}', $value);
+    }
+
+    public function testGetReadsNestedArrayValues(): void
+    {
+        $value = RecordingPath::get($this->recording(), ['response', 'status', 'code']);
+
+        $this->assertSame(200, $value);
+    }
+
+    public function testGetReturnsNullWhenASegmentIsMissing(): void
+    {
+        $value = RecordingPath::get(['request' => ['method' => 'GET']], ['request', 'body']);
+
+        $this->assertNull($value);
+    }
+
+    public function testGetReturnsNullWhenTheContainerIsMissing(): void
+    {
+        $value = RecordingPath::get(['index' => 0], ['request', 'body']);
+
+        $this->assertNull($value);
+    }
+
+    public function testGetSupportsOpaqueHeaderNameSegmentsContainingDots(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['headers']['X.Api.Secret'] = 'top-secret';
+
+        $value = RecordingPath::get($recording, ['request', 'headers', 'X.Api.Secret']);
+
+        $this->assertSame('top-secret', $value);
+    }
+}

--- a/tests/Unit/Storage/RedactingStorageFactoryTest.php
+++ b/tests/Unit/Storage/RedactingStorageFactoryTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\PurgeableRedactingStorage;
+use VCR\Storage\RedactingStorage;
+use VCR\Storage\RedactingStorageFactory;
+use VCR\Storage\Redaction\RedactionRules;
+use VCR\Storage\StorageFactoryInterface;
+use VCR\Storage\StorageInterface;
+use VCR\Storage\YamlStorageFactory;
+
+final class RedactingStorageFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+    }
+
+    public function testWithRulesDelegatesTheGivenRulesToTheCreatedStorage(): void
+    {
+        $rules = RedactionRules::create()->header('Authorization', 'redacted');
+        $factory = RedactingStorageFactory::withRules(new YamlStorageFactory(), $rules);
+
+        $storage = $factory->create(vfsStream::url('testDir').'/', 'rules-cassette');
+
+        $recording = ['request' => ['headers' => ['Authorization' => 'Bearer secret-token']]];
+        $storage->storeRecording($recording);
+        $storage->rewind();
+        $storage->valid();
+
+        $current = $storage->current();
+        $this->assertSame('redacted', $current['request']['headers']['Authorization'] ?? null);
+    }
+
+    public function testWithDefaultsCoversExactlyTheThreeStandardSensitiveResponseHeaders(): void
+    {
+        $factory = RedactingStorageFactory::withDefaults(new YamlStorageFactory());
+
+        $storage = $factory->create(vfsStream::url('testDir').'/', 'defaults-cassette');
+
+        $recording = [
+            'response' => [
+                'headers' => [
+                    'Set-Cookie' => 'session=abc123',
+                    'WWW-Authenticate' => 'Basic realm="example"',
+                    'Proxy-Authenticate' => 'Basic realm="proxy"',
+                    'Content-Type' => 'application/json',
+                ],
+            ],
+        ];
+        $storage->storeRecording($recording);
+        $storage->rewind();
+        $storage->valid();
+
+        $current = $storage->current();
+        $this->assertSame('', $current['response']['headers']['Set-Cookie'] ?? null);
+        $this->assertSame('', $current['response']['headers']['WWW-Authenticate'] ?? null);
+        $this->assertSame('', $current['response']['headers']['Proxy-Authenticate'] ?? null);
+        $this->assertSame('application/json', $current['response']['headers']['Content-Type'] ?? null);
+    }
+
+    public function testWrapsAPurgeableStorageInThePurgeableVariant(): void
+    {
+        $factory = RedactingStorageFactory::withDefaults(new YamlStorageFactory());
+
+        $storage = $factory->create(vfsStream::url('testDir').'/', 'yaml-cassette');
+
+        $this->assertInstanceOf(PurgeableRedactingStorage::class, $storage);
+    }
+
+    public function testWrapsANonPurgeableStorageInThePlainVariant(): void
+    {
+        $factory = RedactingStorageFactory::withDefaults(new NonPurgeableStorageFactoryStub());
+
+        $storage = $factory->create(vfsStream::url('testDir').'/', 'non-purgeable-cassette');
+
+        $this->assertInstanceOf(RedactingStorage::class, $storage);
+        $this->assertNotInstanceOf(PurgeableRedactingStorage::class, $storage);
+    }
+
+    public function testEachCassetteGetsItsOwnStorage(): void
+    {
+        $factory = RedactingStorageFactory::withDefaults(new YamlStorageFactory());
+
+        $first = $factory->create(vfsStream::url('testDir').'/', 'first-cassette');
+        $second = $factory->create(vfsStream::url('testDir').'/', 'second-cassette');
+
+        $this->assertNotSame($first, $second);
+    }
+}
+
+final class NonPurgeableStorageFactoryStub implements StorageFactoryInterface
+{
+    public function create(string $cassettePath, string $cassetteName): StorageInterface
+    {
+        return new NonPurgeableStorageStub();
+    }
+}
+
+final class NonPurgeableStorageStub implements StorageInterface
+{
+    /**
+     * @var array<string,mixed>|null
+     */
+    private $recording;
+
+    public function storeRecording(array $recording): void
+    {
+        $this->recording = $recording;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function current(): ?array
+    {
+        return $this->recording;
+    }
+
+    public function next(): void
+    {
+    }
+
+    public function key(): int
+    {
+        return 0;
+    }
+
+    public function rewind(): void
+    {
+    }
+
+    public function valid(): bool
+    {
+        return null !== $this->recording;
+    }
+
+    public function isNew(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Unit/Storage/RedactingStorageTest.php
+++ b/tests/Unit/Storage/RedactingStorageTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\RedactingStorage;
+use VCR\Storage\Redaction\RedactionRules;
+use VCR\Storage\Redaction\Rule\ValueSubstitutionRule;
+use VCR\Storage\Redaction\Scope;
+use VCR\Storage\Yaml;
+
+final class RedactingStorageTest extends TestCase
+{
+    private Yaml $inner;
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('testDir');
+        $this->inner = new Yaml(vfsStream::url('testDir').'/', 'redacted_test');
+    }
+
+    private function storage(RedactionRules $rules): RedactingStorage
+    {
+        return new RedactingStorage($this->inner, $rules);
+    }
+
+    private function rawCassette(): string
+    {
+        return (string) file_get_contents(vfsStream::url('testDir').'/redacted_test');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(int $index = 0): array
+    {
+        return [
+            'request' => [
+                'method' => 'POST',
+                'url' => 'https://api.example.com/login',
+                'headers' => ['Authorization' => 'Bearer secret'],
+                'body' => 'hunter2',
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+                'headers' => ['Set-Cookie' => 'session=abc123'],
+                'body' => 'welcome',
+            ],
+            'index' => $index,
+        ];
+    }
+
+    public function testWritesRedactedRecordingToTheInnerStorage(): void
+    {
+        $rules = RedactionRules::create()->filterSensitiveData('REDACTED', 'hunter2');
+
+        $this->storage($rules)->storeRecording($this->recording());
+
+        $raw = $this->rawCassette();
+
+        $this->assertStringNotContainsString('hunter2', $raw);
+        $this->assertStringContainsString('REDACTED', $raw);
+    }
+
+    public function testUrlAndMethodStayReadableOnDisk(): void
+    {
+        $rules = RedactionRules::create()->filterSensitiveData('REDACTED', 'hunter2');
+
+        $this->storage($rules)->storeRecording($this->recording());
+
+        $raw = $this->rawCassette();
+
+        $this->assertStringContainsString('https://api.example.com/login', $raw);
+        $this->assertStringContainsString('POST', $raw);
+    }
+
+    public function testRestoresOnRead(): void
+    {
+        $rules = RedactionRules::create()->filterSensitiveData('REDACTED', 'hunter2');
+        $storage = $this->storage($rules);
+        $storage->storeRecording($this->recording());
+
+        $storage->rewind();
+        $storage->valid();
+
+        $this->assertSame($this->recording(), $storage->current());
+    }
+
+    public function testIrreversibleResponseHeaderIsNotRestored(): void
+    {
+        $rules = RedactionRules::create()->allHeaders(Scope::RESPONSE);
+        $storage = $this->storage($rules);
+        $storage->storeRecording($this->recording());
+
+        $storage->rewind();
+        $storage->valid();
+
+        $current = $storage->current();
+        $this->assertIsArray($current);
+        $this->assertSame('', $current['response']['headers']['Set-Cookie']);
+    }
+
+    public function testReverseOrderRestorationMattersForChainedRules(): void
+    {
+        $rules = RedactionRules::create()
+            ->add(new ValueSubstitutionRule('bar', 'foo'))
+            ->add(new ValueSubstitutionRule('baz', 'bar'));
+
+        $recording = $this->recording();
+        $recording['request']['body'] = 'foo';
+
+        $storage = $this->storage($rules);
+        $storage->storeRecording($recording);
+
+        $raw = $this->rawCassette();
+        $this->assertStringContainsString('baz', $raw);
+
+        $storage->rewind();
+        $storage->valid();
+
+        $current = $storage->current();
+        $this->assertIsArray($current);
+        $this->assertSame('foo', $current['request']['body']);
+    }
+
+    public function testIteratingSeveralRecordingsReturnsThemInOrder(): void
+    {
+        $rules = RedactionRules::create()->filterSensitiveData('REDACTED', 'hunter2');
+        $storage = $this->storage($rules);
+        $storage->storeRecording($this->recording(0));
+        $storage->storeRecording($this->recording(1));
+
+        $collected = [];
+        foreach ($storage as $recording) {
+            $collected[] = $recording;
+        }
+
+        $this->assertSame([$this->recording(0), $this->recording(1)], $collected);
+    }
+
+    public function testDelegatesKeyToTheInnerStorage(): void
+    {
+        $storage = $this->storage(RedactionRules::create());
+        $storage->storeRecording($this->recording());
+
+        $storage->rewind();
+        $storage->next();
+
+        $this->assertSame($this->inner->key(), $storage->key());
+    }
+
+    public function testIsNewIsDelegated(): void
+    {
+        $this->assertSame($this->inner->isNew(), $this->storage(RedactionRules::create())->isNew());
+    }
+
+    public function testPlainVariantIsNotPurgeable(): void
+    {
+        $this->assertNotInstanceOf(\VCR\Storage\PurgeableStorageInterface::class, $this->storage(RedactionRules::create()));
+    }
+}

--- a/tests/Unit/Storage/Redaction/InvalidRedactionRuleExceptionTest.php
+++ b/tests/Unit/Storage/Redaction/InvalidRedactionRuleExceptionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Redaction\InvalidRedactionRuleException;
+
+final class InvalidRedactionRuleExceptionTest extends TestCase
+{
+    public function testEmptyPlaceholderExplainsWhyAnEmptyPlaceholderIsUseless(): void
+    {
+        $exception = InvalidRedactionRuleException::emptyPlaceholder();
+
+        $this->assertStringContainsString('must not be empty', $exception->getMessage());
+    }
+
+    public function testUnsupportedSecretSourceNamesThePlaceholderAndTheGivenType(): void
+    {
+        $exception = InvalidRedactionRuleException::unsupportedSecretSource('{{API_KEY}}', 'int');
+
+        $this->assertStringContainsString('{{API_KEY}}', $exception->getMessage());
+        $this->assertStringContainsString('int', $exception->getMessage());
+    }
+
+    public function testWildcardHeaderWithSourceNamesTheWildcardAndTheWayOut(): void
+    {
+        $exception = InvalidRedactionRuleException::wildcardHeaderWithSource('*');
+
+        $this->assertStringContainsString('"*"', $exception->getMessage());
+        $this->assertStringContainsString('Name the header', $exception->getMessage());
+    }
+
+    public function testUnsupportedScopeNamesTheRejectedScopeAndTheAcceptedOnes(): void
+    {
+        $exception = InvalidRedactionRuleException::unsupportedScope('requset');
+
+        $this->assertStringContainsString('requset', $exception->getMessage());
+        $this->assertStringContainsString('request', $exception->getMessage());
+        $this->assertStringContainsString('response', $exception->getMessage());
+        $this->assertStringContainsString('both', $exception->getMessage());
+    }
+}

--- a/tests/Unit/Storage/Redaction/MissingReplacementExceptionTest.php
+++ b/tests/Unit/Storage/Redaction/MissingReplacementExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Redaction\MissingReplacementException;
+
+final class MissingReplacementExceptionTest extends TestCase
+{
+    public function testForRuleNamesTheOffendingRule(): void
+    {
+        $exception = MissingReplacementException::forRule('redact password field');
+
+        $this->assertStringContainsString('redact password field', $exception->getMessage());
+    }
+
+    public function testForRuleStatesTheTwoWaysOut(): void
+    {
+        $message = MissingReplacementException::forRule('redact password field')->getMessage();
+
+        $this->assertStringContainsString('replacement', $message);
+        $this->assertStringContainsString('allowIrreversibleRequestRedaction()', $message);
+    }
+}

--- a/tests/Unit/Storage/Redaction/MissingSecretExceptionTest.php
+++ b/tests/Unit/Storage/Redaction/MissingSecretExceptionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Redaction\MissingSecretException;
+
+final class MissingSecretExceptionTest extends TestCase
+{
+    public function testForPlaceholderNamesThePlaceholder(): void
+    {
+        $exception = MissingSecretException::forPlaceholder('{{API_KEY}}');
+
+        $this->assertStringContainsString('{{API_KEY}}', $exception->getMessage());
+    }
+}

--- a/tests/Unit/Storage/Redaction/PlaceholderCollisionExceptionTest.php
+++ b/tests/Unit/Storage/Redaction/PlaceholderCollisionExceptionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Redaction\PlaceholderCollisionException;
+
+final class PlaceholderCollisionExceptionTest extends TestCase
+{
+    public function testForPlaceholderNamesBothThePlaceholderAndThePath(): void
+    {
+        $exception = PlaceholderCollisionException::forPlaceholder('{{API_KEY}}', 'request.body');
+
+        $this->assertStringContainsString('{{API_KEY}}', $exception->getMessage());
+        $this->assertStringContainsString('request.body', $exception->getMessage());
+    }
+}

--- a/tests/Unit/Storage/Redaction/RedactionRulesTest.php
+++ b/tests/Unit/Storage/Redaction/RedactionRulesTest.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Configuration;
+use VCR\Request;
+use VCR\Storage\Redaction\MissingReplacementException;
+use VCR\Storage\Redaction\RedactionRuleInterface;
+use VCR\Storage\Redaction\RedactionRules;
+use VCR\Storage\Redaction\Rule\HeaderRule;
+use VCR\Storage\Redaction\Rule\HostRule;
+use VCR\Storage\Redaction\Rule\PostFieldRule;
+use VCR\Storage\Redaction\Rule\QueryParameterRule;
+use VCR\Storage\Redaction\Rule\ValueSubstitutionRule;
+use VCR\Storage\Redaction\Scope;
+
+final class RedactionRulesTest extends TestCase
+{
+    /**
+     * @return list<string>
+     */
+    private function defaultMatchers(): array
+    {
+        return ['method', 'url', 'host', 'headers', 'body', 'post_fields', 'query_string', 'soap_operation'];
+    }
+
+    public function testHeaderWithNoSourceAndNoOptInThrowsMissingReplacementException(): void
+    {
+        $this->expectException(MissingReplacementException::class);
+
+        RedactionRules::create()->header('Authorization');
+    }
+
+    public function testHeaderWithNoSourceSucceedsAfterAllowIrreversibleRequestRedaction(): void
+    {
+        $rules = RedactionRules::create()
+            ->allowIrreversibleRequestRedaction()
+            ->header('Authorization');
+
+        $this->assertCount(1, $rules->rules());
+    }
+
+    public function testResponseOnlyIrreversibleHeaderNeverThrowsRegardlessOfOptIn(): void
+    {
+        $rules = RedactionRules::create()->header('Set-Cookie', null, Scope::RESPONSE);
+
+        $this->assertCount(1, $rules->rules());
+    }
+
+    public function testResponseOnlyIrreversibleHeaderNeverThrowsEvenAfterOptIn(): void
+    {
+        $rules = RedactionRules::create()
+            ->allowIrreversibleRequestRedaction()
+            ->header('Set-Cookie', null, Scope::RESPONSE);
+
+        $this->assertCount(1, $rules->rules());
+    }
+
+    public function testSafeAndInvalidatedRequestMatchersPartitionTheFullDefaultSet(): void
+    {
+        $rules = RedactionRules::create()
+            ->allowIrreversibleRequestRedaction()
+            ->header('Authorization')
+            ->queryParameter('token');
+
+        $safe = $rules->safeRequestMatchers();
+        $invalidated = $rules->invalidatedRequestMatchers();
+
+        $this->assertSame(['headers', 'query_string'], $invalidated);
+        $this->assertSame(
+            array_values(array_diff($this->defaultMatchers(), $invalidated)),
+            $safe
+        );
+        $union = array_unique(array_merge($safe, $invalidated));
+        sort($union);
+        $expected = $this->defaultMatchers();
+        sort($expected);
+        $this->assertSame($expected, $union);
+        $this->assertSame([], array_intersect($safe, $invalidated));
+    }
+
+    public function testZeroIrreversibleRulesLeavesFullDefaultSetSafe(): void
+    {
+        $rules = RedactionRules::create()
+            ->filterSensitiveData('REDACTED', 'secret-value')
+            ->header('Authorization', 'Bearer secret-token');
+
+        $this->assertSame([], $rules->invalidatedRequestMatchers());
+        $this->assertSame($this->defaultMatchers(), $rules->safeRequestMatchers());
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function hostRecording(): array
+    {
+        return [
+            'request' => [
+                'method' => 'GET',
+                'url' => 'https://api.example.com:8443/status?ping=1',
+                'headers' => ['Host' => 'api.example.com:8443'],
+            ],
+            'response' => ['status' => ['code' => 200, 'message' => 'OK']],
+            'index' => 0,
+        ];
+    }
+
+    /**
+     * Runs the recording through every rule the way RedactingStorage does, then compares the result
+     * against a live request built from the untouched recording, using the very matcher callbacks
+     * Configuration hands to Cassette::playback().
+     *
+     * @param list<string> $matchers
+     */
+    private function matchesThroughRealMatchers(RedactionRules $rules, array $matchers): bool
+    {
+        $recording = $this->hostRecording();
+        $onDisk = $recording;
+
+        foreach ($rules->rules() as $rule) {
+            $onDisk = $rule->redact($onDisk);
+        }
+
+        $replayed = $onDisk;
+        foreach (array_reverse($rules->rules()) as $rule) {
+            $replayed = $rule->restore($replayed);
+        }
+
+        $configuration = new Configuration();
+        $configuration->enableRequestMatchers($matchers);
+
+        return Request::fromArray($replayed['request'])
+            ->matches(Request::fromArray($recording['request']), $configuration->getRequestMatchers());
+    }
+
+    /**
+     * HostRule is the only built-in that invalidates more than one matcher, which makes it the case
+     * where an inaccurate affectedMatchers() does the most damage. Asserting the list is not enough
+     * — the review that caught this twice was fooled by exactly that — so this drives the reported
+     * lists through the real matcher callbacks: everything safeRequestMatchers() keeps must actually
+     * still match, and the full default set must not.
+     */
+    public function testAnIrreversibleMultiKeyRuleLeavesExactlyTheMatchersItKeepsWorking(): void
+    {
+        $rules = RedactionRules::create()->allowIrreversibleRequestRedaction()->host();
+
+        $this->assertSame(['host', 'headers'], $rules->invalidatedRequestMatchers());
+        $this->assertSame(
+            ['method', 'url', 'body', 'post_fields', 'query_string', 'soap_operation'],
+            $rules->safeRequestMatchers()
+        );
+
+        $this->assertFalse(
+            $this->matchesThroughRealMatchers($rules, $this->defaultMatchers()),
+            'Sanity check: the full default set must break, otherwise the rule under-reports nothing.'
+        );
+        $this->assertTrue(
+            $this->matchesThroughRealMatchers($rules, $rules->safeRequestMatchers()),
+            'Every matcher safeRequestMatchers() keeps must still match the redacted recording.'
+        );
+    }
+
+    /**
+     * The same rule given a source reports no invalidated matchers at all — and this time the full
+     * default set really does still match, because restore() puts the real host back.
+     */
+    public function testTheSameMultiKeyRuleGivenASourceKeepsEveryDefaultMatcherWorking(): void
+    {
+        $rules = RedactionRules::create()->host('api.example.com');
+
+        $this->assertSame([], $rules->invalidatedRequestMatchers());
+        $this->assertSame($this->defaultMatchers(), $rules->safeRequestMatchers());
+        $this->assertTrue($this->matchesThroughRealMatchers($rules, $this->defaultMatchers()));
+    }
+
+    public function testRulesReturnsRulesInRegistrationOrder(): void
+    {
+        $first = new ValueSubstitutionRule('FIRST', 'secret-one');
+        $second = new HeaderRule('Authorization', 'replacement-token');
+        $third = new QueryParameterRule('token', 'replacement-query-token');
+
+        $rules = RedactionRules::create()
+            ->add($first)
+            ->add($second)
+            ->add($third);
+
+        $this->assertSame([$first, $second, $third], $rules->rules());
+    }
+
+    /**
+     * A stand-in for a caller-written rule, so the tests around add()'s reversibility contract can
+     * vary the three things that contract actually reads — scope, reversibility and the matchers
+     * the rule invalidates — without repeating the interface five times.
+     *
+     * @param Scope::REQUEST|Scope::RESPONSE|Scope::BOTH $scope
+     * @param list<string>                               $matchers what the rule claims to invalidate
+     */
+    private function customRule(string $scope, array $matchers = [], bool $reversible = false): RedactionRuleInterface
+    {
+        return new class($scope, $matchers, $reversible) implements RedactionRuleInterface {
+            /**
+             * @param Scope::REQUEST|Scope::RESPONSE|Scope::BOTH $ruleScope
+             * @param list<string>                               $matchers
+             */
+            public function __construct(
+                private string $ruleScope,
+                private array $matchers,
+                private bool $reversible
+            ) {
+            }
+
+            public function scope(): string
+            {
+                return $this->ruleScope;
+            }
+
+            public function isReversible(): bool
+            {
+                return $this->reversible;
+            }
+
+            public function affectedMatchers(): array
+            {
+                return $this->matchers;
+            }
+
+            public function redact(array $recording): array
+            {
+                return $recording;
+            }
+
+            public function restore(array $recording): array
+            {
+                return $recording;
+            }
+        };
+    }
+
+    public function testAddRejectsACustomIrreversibleRequestScopedRuleWithoutOptIn(): void
+    {
+        $this->expectException(MissingReplacementException::class);
+
+        RedactionRules::create()->add($this->customRule(Scope::REQUEST, ['body']));
+    }
+
+    public function testAddAllowsACustomIrreversibleRequestScopedRuleAfterOptIn(): void
+    {
+        $rules = RedactionRules::create()
+            ->allowIrreversibleRequestRedaction()
+            ->add($this->customRule(Scope::REQUEST, ['body']));
+
+        $this->assertCount(1, $rules->rules());
+        $this->assertSame(['body'], $rules->invalidatedRequestMatchers());
+    }
+
+    public function testAddRejectsACustomIrreversibleBothScopedRuleWithoutOptIn(): void
+    {
+        $this->expectException(MissingReplacementException::class);
+
+        RedactionRules::create()->add($this->customRule(Scope::BOTH, ['body']));
+    }
+
+    public function testAddNeverRejectsACustomIrreversibleResponseScopedRule(): void
+    {
+        $rules = RedactionRules::create()->add($this->customRule(Scope::RESPONSE));
+
+        $this->assertCount(1, $rules->rules());
+    }
+
+    public function testAddNeverRejectsAReversibleRequestScopedRuleWithoutOptIn(): void
+    {
+        $rules = RedactionRules::create()->add($this->customRule(Scope::REQUEST, [], true));
+
+        $this->assertCount(1, $rules->rules());
+    }
+
+    public function testFilterSensitiveDataAddsAValueSubstitutionRule(): void
+    {
+        $rules = RedactionRules::create()->filterSensitiveData('REDACTED', 'secret-value');
+
+        $this->assertInstanceOf(ValueSubstitutionRule::class, $rules->rules()[0]);
+    }
+
+    public function testAllHeadersAddsTheWildcardHeaderRule(): void
+    {
+        $rules = RedactionRules::create()->allHeaders(Scope::RESPONSE);
+
+        $this->assertInstanceOf(HeaderRule::class, $rules->rules()[0]);
+        $this->assertSame(Scope::RESPONSE, $rules->rules()[0]->scope());
+    }
+
+    public function testQueryParameterAddsAQueryParameterRule(): void
+    {
+        $rules = RedactionRules::create()->queryParameter('token', 'replacement-query-token');
+
+        $this->assertInstanceOf(QueryParameterRule::class, $rules->rules()[0]);
+    }
+
+    public function testPostFieldAddsAPostFieldRule(): void
+    {
+        $rules = RedactionRules::create()->postField('password', 'replacement-password');
+
+        $this->assertInstanceOf(PostFieldRule::class, $rules->rules()[0]);
+    }
+
+    public function testHostAddsAHostRule(): void
+    {
+        $rules = RedactionRules::create()->host('replacement-host');
+
+        $this->assertInstanceOf(HostRule::class, $rules->rules()[0]);
+    }
+
+    public function testBodyAllowsMultipleCallsAddingARuleEach(): void
+    {
+        $rules = RedactionRules::create()
+            ->allowIrreversibleRequestRedaction()
+            ->body(static fn (string $body): string => $body, Scope::REQUEST)
+            ->body(static fn (string $body): string => $body, Scope::RESPONSE);
+
+        $this->assertCount(2, $rules->rules());
+    }
+
+    public function testPostFieldsAllowsMultipleCallsAddingARuleEach(): void
+    {
+        $rules = RedactionRules::create()
+            ->allowIrreversibleRequestRedaction()
+            ->postFields(static fn (array $postFields): array => $postFields)
+            ->postFields(static fn (array $postFields): array => $postFields);
+
+        $this->assertCount(2, $rules->rules());
+    }
+}

--- a/tests/Unit/Storage/Redaction/Rule/BodyCallbackRuleTest.php
+++ b/tests/Unit/Storage/Redaction/Rule/BodyCallbackRuleTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction\Rule;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Redaction\InvalidRedactionRuleException;
+use VCR\Storage\Redaction\Rule\BodyCallbackRule;
+use VCR\Storage\Redaction\Scope;
+
+final class BodyCallbackRuleTest extends TestCase
+{
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(): array
+    {
+        return [
+            'request' => [
+                'method' => 'POST',
+                'url' => 'https://api.example.com/login',
+                'headers' => [],
+                'body' => '{"user":"alice"}',
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+                'body' => '{"token":"abc-123"}',
+            ],
+            'index' => 0,
+        ];
+    }
+
+    public function testRedactAppliesTheCallbackToTheRequestBodyOnlyWhenScopedToRequest(): void
+    {
+        $rule = new BodyCallbackRule(static fn (string $body): string => strtoupper($body), Scope::REQUEST);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame('{"USER":"ALICE"}', $redacted['request']['body']);
+        $this->assertSame('{"token":"abc-123"}', $redacted['response']['body']);
+    }
+
+    public function testRedactAppliesTheCallbackToTheResponseBodyOnlyWhenScopedToResponse(): void
+    {
+        $rule = new BodyCallbackRule(static fn (string $body): string => strtoupper($body), Scope::RESPONSE);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame('{"user":"alice"}', $redacted['request']['body']);
+        $this->assertSame('{"TOKEN":"ABC-123"}', $redacted['response']['body']);
+    }
+
+    public function testRedactAppliesTheCallbackToBothBodiesWhenScopedToBoth(): void
+    {
+        $rule = new BodyCallbackRule(static fn (string $body): string => strtoupper($body), Scope::BOTH);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame('{"USER":"ALICE"}', $redacted['request']['body']);
+        $this->assertSame('{"TOKEN":"ABC-123"}', $redacted['response']['body']);
+    }
+
+    public function testRedactIsANoOpWhenTheScopedBodyIsMissing(): void
+    {
+        $recording = $this->recording();
+        unset($recording['request']['body']);
+        $rule = new BodyCallbackRule(static fn (string $body): string => strtoupper($body), Scope::REQUEST);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertSame($recording, $redacted);
+    }
+
+    public function testRestoreIsANoOpAndDoesNotInvokeTheCallback(): void
+    {
+        $recording = $this->recording();
+        $rule = new BodyCallbackRule(function (string $body): string {
+            $this->fail('restore() must not invoke the callback.');
+        }, Scope::BOTH);
+
+        $restored = $rule->restore($recording);
+
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testConstructionRejectsAScopeThatIsNotOneOfTheThreeKnownOnes(): void
+    {
+        $this->expectException(InvalidRedactionRuleException::class);
+
+        new BodyCallbackRule(static fn (string $body): string => $body, 'requset');
+    }
+
+    public function testScopeReturnsTheConfiguredScope(): void
+    {
+        $rule = new BodyCallbackRule(static fn (string $body): string => $body, Scope::RESPONSE);
+
+        $this->assertSame(Scope::RESPONSE, $rule->scope());
+    }
+
+    public function testIsReversibleIsAlwaysFalse(): void
+    {
+        $rule = new BodyCallbackRule(static fn (string $body): string => $body, Scope::BOTH);
+
+        $this->assertFalse($rule->isReversible());
+    }
+
+    public function testAffectedMatchersIsBodyWhenScopeIsRequest(): void
+    {
+        $rule = new BodyCallbackRule(static fn (string $body): string => $body, Scope::REQUEST);
+
+        $this->assertSame(['body'], $rule->affectedMatchers());
+    }
+
+    public function testAffectedMatchersIsBodyWhenScopeIsBoth(): void
+    {
+        $rule = new BodyCallbackRule(static fn (string $body): string => $body, Scope::BOTH);
+
+        $this->assertSame(['body'], $rule->affectedMatchers());
+    }
+
+    public function testAffectedMatchersIsEmptyWhenScopeIsResponse(): void
+    {
+        $rule = new BodyCallbackRule(static fn (string $body): string => $body, Scope::RESPONSE);
+
+        $this->assertSame([], $rule->affectedMatchers());
+    }
+}

--- a/tests/Unit/Storage/Redaction/Rule/HeaderRuleTest.php
+++ b/tests/Unit/Storage/Redaction/Rule/HeaderRuleTest.php
@@ -1,0 +1,344 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction\Rule;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Request;
+use VCR\RequestMatcher;
+use VCR\Storage\Redaction\InvalidRedactionRuleException;
+use VCR\Storage\Redaction\MissingSecretException;
+use VCR\Storage\Redaction\PlaceholderCollisionException;
+use VCR\Storage\Redaction\Rule\HeaderRule;
+use VCR\Storage\Redaction\Scope;
+
+final class HeaderRuleTest extends TestCase
+{
+    /**
+     * Pinned as a literal rather than read back from Placeholder: the format ends up in committed
+     * cassettes, so a change to it is a change to what users see on disk and has to be deliberate.
+     */
+    private const AUTHORIZATION_PLACEHOLDER = '<<REDACTED:HEADER:authorization>>';
+
+    private const SECRET = 'Bearer super-secret-token';
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(): array
+    {
+        return [
+            'request' => [
+                'method' => 'POST',
+                'url' => 'https://api.example.com/login',
+                'headers' => [
+                    'Authorization' => self::SECRET,
+                    'X-Trace-Id' => 'abc-123',
+                ],
+                'body' => '{}',
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+                'headers' => [
+                    'Set-Cookie' => 'session=secret-session',
+                    'Content-Type' => 'application/json',
+                ],
+                'body' => 'welcome',
+            ],
+            'index' => 0,
+        ];
+    }
+
+    public function testRedactWritesThePlaceholderRatherThanTheSecretItself(): void
+    {
+        $rule = new HeaderRule('Authorization', self::SECRET, Scope::REQUEST);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame(self::AUTHORIZATION_PLACEHOLDER, $redacted['request']['headers']['Authorization']);
+    }
+
+    public function testThePlaceholderIsDerivedFromTheHeaderNameSoReRecordingIsByteIdentical(): void
+    {
+        $rule = new HeaderRule('Authorization', self::SECRET, Scope::REQUEST);
+
+        $first = $rule->redact($this->recording());
+        $second = $rule->redact($this->recording());
+
+        $this->assertSame($first, $second);
+        $this->assertSame(
+            self::AUTHORIZATION_PLACEHOLDER,
+            (new HeaderRule('Authorization', 'a different secret', Scope::REQUEST))->redact($this->recording())['request']['headers']['Authorization'],
+            'The placeholder must depend on the header name only, never on the secret.'
+        );
+    }
+
+    public function testRedactMatchesTheHeaderNameCaseInsensitively(): void
+    {
+        $rule = new HeaderRule('AUTHORIZATION', self::SECRET, Scope::REQUEST);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame(self::AUTHORIZATION_PLACEHOLDER, $redacted['request']['headers']['Authorization']);
+    }
+
+    public function testRedactWithBothScopeAffectsRequestAndResponseHeadersOfTheSameName(): void
+    {
+        $recording = $this->recording();
+        $recording['response']['headers']['Authorization'] = 'Bearer other-secret';
+        $rule = new HeaderRule('Authorization', self::SECRET);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertSame(self::AUTHORIZATION_PLACEHOLDER, $redacted['request']['headers']['Authorization']);
+        $this->assertSame(self::AUTHORIZATION_PLACEHOLDER, $redacted['response']['headers']['Authorization']);
+    }
+
+    public function testRestoreWritesTheRealSecretBackIntoTheRequestHeader(): void
+    {
+        $rule = new HeaderRule('Authorization', self::SECRET, Scope::REQUEST);
+
+        $restored = $rule->restore($rule->redact($this->recording()));
+
+        $this->assertSame(self::SECRET, $restored['request']['headers']['Authorization']);
+    }
+
+    public function testRedactAndRestoreRoundTripBackToTheOriginalRecording(): void
+    {
+        $recording = $this->recording();
+        $rule = new HeaderRule('Authorization', self::SECRET, Scope::REQUEST);
+
+        $this->assertSame($recording, $rule->restore($rule->redact($recording)));
+    }
+
+    public function testRestoreWritesTheSecretBackOnEverySideTheScopeCovers(): void
+    {
+        $recording = $this->recording();
+        $recording['response']['headers']['Authorization'] = self::SECRET;
+        $rule = new HeaderRule('Authorization', self::SECRET);
+
+        $restored = $rule->restore($rule->redact($recording));
+
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testAResponseScopedHeaderIsRestoredToo(): void
+    {
+        $recording = $this->recording();
+        $rule = new HeaderRule('Set-Cookie', 'session=secret-session', Scope::RESPONSE);
+
+        $redacted = $rule->redact($recording);
+        $this->assertSame('<<REDACTED:HEADER:set-cookie>>', $redacted['response']['headers']['Set-Cookie']);
+
+        $this->assertSame($recording, $rule->restore($redacted));
+    }
+
+    public function testRestoreIsANoOpWithoutASource(): void
+    {
+        $recording = $this->recording();
+        $rule = new HeaderRule('Authorization', null, Scope::REQUEST);
+
+        $restored = $rule->restore($recording);
+
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testRestoreIsANoOpWhenTheHeaderIsNotInTheRecording(): void
+    {
+        $recording = $this->recording();
+        $rule = new HeaderRule('X-Absent', self::SECRET, Scope::REQUEST);
+
+        $this->assertSame($recording, $rule->restore($recording));
+    }
+
+    public function testRedactBlanksTheHeaderValueWithoutASource(): void
+    {
+        $rule = new HeaderRule('Set-Cookie', null, Scope::RESPONSE);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame('', $redacted['response']['headers']['Set-Cookie']);
+    }
+
+    public function testRedactThrowsMissingSecretExceptionWhenSourceResolvesToEmptyString(): void
+    {
+        $rule = new HeaderRule('Authorization', '', Scope::REQUEST);
+
+        $this->expectException(MissingSecretException::class);
+
+        $rule->redact($this->recording());
+    }
+
+    public function testRedactThrowsMissingSecretExceptionRatherThanWritingAnUnrestorableCassette(): void
+    {
+        $rule = new HeaderRule('Authorization', static fn (): ?string => null, Scope::REQUEST);
+
+        $this->expectException(MissingSecretException::class);
+        $this->expectExceptionMessage(self::AUTHORIZATION_PLACEHOLDER);
+
+        $rule->redact($this->recording());
+    }
+
+    public function testRedactThrowsPlaceholderCollisionExceptionWhenTheValueAlreadyCarriesThePlaceholder(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['headers']['Authorization'] = self::AUTHORIZATION_PLACEHOLDER;
+        $rule = new HeaderRule('Authorization', self::SECRET, Scope::REQUEST);
+
+        $this->expectException(PlaceholderCollisionException::class);
+        $this->expectExceptionMessage('request.headers.Authorization');
+
+        $rule->redact($recording);
+    }
+
+    /**
+     * The assertion that actually matters: what reaches the disk must not carry the secret, and
+     * what `RedactingStorage::current()` hands to `Cassette::playback()` must still satisfy the
+     * real `headers` matcher against a live request carrying the real secret. Asserting
+     * `affectedMatchers() === []` alone proved nothing — it is the rule's own claim about itself.
+     */
+    public function testTheRedactRestoreRoundTripSatisfiesTheRealHeadersMatcherAgainstALiveRequest(): void
+    {
+        $recording = $this->recording();
+        $rule = new HeaderRule('Authorization', self::SECRET, Scope::REQUEST);
+
+        $onDisk = $rule->redact($recording);
+        $this->assertStringNotContainsString(
+            'super-secret-token',
+            (string) json_encode($onDisk['request']),
+            'The recorded request must not carry the secret.'
+        );
+
+        $liveRequest = Request::fromArray($recording['request']);
+        $recordedRequest = Request::fromArray($onDisk['request']);
+        $this->assertFalse(
+            RequestMatcher::matchHeaders($recordedRequest, $liveRequest),
+            'Sanity check: without restore() the recorded request cannot match, or nothing was hidden.'
+        );
+
+        $replayedRequest = Request::fromArray($rule->restore($onDisk)['request']);
+        $this->assertTrue(
+            RequestMatcher::matchHeaders($replayedRequest, $liveRequest),
+            'After restore() the recorded request must match a live request carrying the real secret.'
+        );
+    }
+
+    public function testAllBuildsAWildcardRuleForTheGivenScope(): void
+    {
+        $rule = HeaderRule::all(Scope::REQUEST);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame('', $redacted['request']['headers']['Authorization']);
+        $this->assertSame('', $redacted['request']['headers']['X-Trace-Id']);
+        $this->assertSame('application/json', $redacted['response']['headers']['Content-Type']);
+    }
+
+    public function testAllScopedToBothRedactsHeadersOnEitherSide(): void
+    {
+        $rule = HeaderRule::all(Scope::BOTH);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame('', $redacted['request']['headers']['Authorization']);
+        $this->assertSame('', $redacted['request']['headers']['X-Trace-Id']);
+        $this->assertSame('', $redacted['response']['headers']['Set-Cookie']);
+        $this->assertSame('', $redacted['response']['headers']['Content-Type']);
+    }
+
+    public function testAllScopedToResponseLeavesRequestHeadersUntouched(): void
+    {
+        $rule = HeaderRule::all(Scope::RESPONSE);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame(self::SECRET, $redacted['request']['headers']['Authorization']);
+        $this->assertSame('', $redacted['response']['headers']['Set-Cookie']);
+        $this->assertSame('', $redacted['response']['headers']['Content-Type']);
+    }
+
+    public function testScopeReturnsTheConfiguredScope(): void
+    {
+        $rule = new HeaderRule('Authorization', null, Scope::RESPONSE);
+
+        $this->assertSame(Scope::RESPONSE, $rule->scope());
+    }
+
+    public function testConstructionRejectsAScopeThatIsNotOneOfTheThreeKnownOnes(): void
+    {
+        $this->expectException(InvalidRedactionRuleException::class);
+
+        new HeaderRule('Authorization', self::SECRET, 'requset');
+    }
+
+    /**
+     * `HeaderRule::all()` never passes a source, but the constructor is public and the wildcard is a
+     * documented header name — a source given alongside it would write that one value into every
+     * header in scope and restore it into all of them, corrupting a multi-header recording without
+     * a word of complaint.
+     */
+    public function testConstructionRejectsAReplacementSourceOnTheWildcardHeaderName(): void
+    {
+        $this->expectException(InvalidRedactionRuleException::class);
+        $this->expectExceptionMessage('cannot take a replacement source');
+
+        new HeaderRule('*', self::SECRET, Scope::REQUEST);
+    }
+
+    public function testTheWildcardHeaderNameIsStillAcceptedWithoutASource(): void
+    {
+        $rule = new HeaderRule('*', null, Scope::RESPONSE);
+
+        $this->assertSame(Scope::RESPONSE, $rule->scope());
+    }
+
+    public function testIsReversibleIsTrueWhenASourceIsGiven(): void
+    {
+        $rule = new HeaderRule('Authorization', self::SECRET, Scope::REQUEST);
+
+        $this->assertTrue($rule->isReversible());
+    }
+
+    public function testIsReversibleIsTrueWhenScopeIsResponseEvenWithoutASource(): void
+    {
+        $rule = new HeaderRule('Set-Cookie', null, Scope::RESPONSE);
+
+        $this->assertTrue($rule->isReversible());
+    }
+
+    public function testIsReversibleIsFalseForARequestSideHeaderWithoutASource(): void
+    {
+        $rule = new HeaderRule('Authorization', null, Scope::REQUEST);
+
+        $this->assertFalse($rule->isReversible());
+    }
+
+    public function testIsReversibleIsFalseWithBothScopeAndNoSource(): void
+    {
+        $rule = new HeaderRule('Authorization');
+
+        $this->assertFalse($rule->isReversible());
+    }
+
+    public function testAffectedMatchersIsEmptyWhenReversible(): void
+    {
+        $rule = new HeaderRule('Authorization', self::SECRET, Scope::REQUEST);
+
+        $this->assertSame([], $rule->affectedMatchers());
+    }
+
+    public function testAffectedMatchersIsHeadersWhenIrreversible(): void
+    {
+        $rule = new HeaderRule('Authorization', null, Scope::REQUEST);
+
+        $this->assertSame(['headers'], $rule->affectedMatchers());
+    }
+
+    public function testAffectedMatchersIsEmptyForAResponseSideHeaderWithoutASource(): void
+    {
+        $rule = new HeaderRule('Set-Cookie', null, Scope::RESPONSE);
+
+        $this->assertSame([], $rule->affectedMatchers());
+    }
+}

--- a/tests/Unit/Storage/Redaction/Rule/HostRuleTest.php
+++ b/tests/Unit/Storage/Redaction/Rule/HostRuleTest.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction\Rule;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Request;
+use VCR\RequestMatcher;
+use VCR\Storage\Redaction\MissingSecretException;
+use VCR\Storage\Redaction\PlaceholderCollisionException;
+use VCR\Storage\Redaction\Rule\HostRule;
+use VCR\Storage\Redaction\Rule\QueryParameterRule;
+use VCR\Storage\Redaction\Scope;
+
+final class HostRuleTest extends TestCase
+{
+    /**
+     * Pinned as a literal rather than read back from Placeholder: the format ends up in committed
+     * cassettes, so a change to it is a change to what users see on disk and has to be deliberate.
+     * Unlike the other rules' placeholders this one has to stay a valid hostname, since it is
+     * written into `request.url`.
+     */
+    private const HOST_PLACEHOLDER = 'redacted-host.invalid';
+
+    private const REAL_HOST = 'api.example.com';
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(): array
+    {
+        return [
+            'request' => [
+                'method' => 'GET',
+                'url' => 'https://api.example.com:8443/status?ping=1',
+                'headers' => ['Host' => 'api.example.com:8443', 'X-Trace-Id' => 'abc-123'],
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+            ],
+            'index' => 0,
+        ];
+    }
+
+    public function testRedactWritesThePlaceholderHostRatherThanTheRealOne(): void
+    {
+        $rule = new HostRule(self::REAL_HOST);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame('https://redacted-host.invalid:8443/status?ping=1', $redacted['request']['url']);
+        $this->assertSame('redacted-host.invalid:8443', $redacted['request']['headers']['Host']);
+        $this->assertStringNotContainsString(self::REAL_HOST, (string) json_encode($redacted['request']));
+    }
+
+    public function testThePlaceholderHostStaysParseableSoLaterRulesStillSeeAUsableUrl(): void
+    {
+        $rule = new HostRule(self::REAL_HOST);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame(self::HOST_PLACEHOLDER, parse_url($redacted['request']['url'], \PHP_URL_HOST));
+        $this->assertSame(8443, parse_url($redacted['request']['url'], \PHP_URL_PORT));
+    }
+
+    public function testRedactLeavesTheRestOfTheUrlUntouched(): void
+    {
+        $rule = new HostRule(self::REAL_HOST);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertStringContainsString(':8443', $redacted['request']['url']);
+        $this->assertStringContainsString('/status', $redacted['request']['url']);
+        $this->assertStringContainsString('?ping=1', $redacted['request']['url']);
+    }
+
+    public function testRedactIsANoOpOnTheHostHeaderWhenAbsent(): void
+    {
+        $recording = $this->recording();
+        unset($recording['request']['headers']['Host']);
+        $rule = new HostRule(self::REAL_HOST);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertArrayNotHasKey('Host', $redacted['request']['headers']);
+        $this->assertSame('https://redacted-host.invalid:8443/status?ping=1', $redacted['request']['url']);
+    }
+
+    public function testRedactMatchesTheHostHeaderNameCaseInsensitively(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['headers'] = ['host' => 'api.example.com'];
+        $rule = new HostRule(self::REAL_HOST);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertSame(self::HOST_PLACEHOLDER, $redacted['request']['headers']['host']);
+    }
+
+    public function testRestoreWritesTheRealHostBackIntoBothLocations(): void
+    {
+        $rule = new HostRule(self::REAL_HOST);
+
+        $restored = $rule->restore($rule->redact($this->recording()));
+
+        $this->assertSame('https://api.example.com:8443/status?ping=1', $restored['request']['url']);
+        $this->assertSame('api.example.com:8443', $restored['request']['headers']['Host']);
+    }
+
+    public function testRedactAndRestoreRoundTripBackToTheOriginalRecording(): void
+    {
+        $recording = $this->recording();
+        $rule = new HostRule(self::REAL_HOST);
+
+        $this->assertSame($recording, $rule->restore($rule->redact($recording)));
+    }
+
+    /**
+     * The URL and the `Host` header need not spell the host identically — hostnames are
+     * case-insensitive, and the header routinely carries a port the URL's host component does not.
+     * A byte-exact search missed such a header and fell through to a wholesale overwrite, which
+     * dropped the port and failed the `headers` matcher on replay.
+     */
+    public function testAHostHeaderThatSpellsTheHostDifferentlyKeepsItsPortThroughTheRoundTrip(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['url'] = 'https://API.Example.com:8443/status?ping=1';
+        $rule = new HostRule(self::REAL_HOST);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertSame('redacted-host.invalid:8443', $redacted['request']['headers']['Host']);
+        $this->assertStringNotContainsString('Example.com', (string) json_encode($redacted['request']));
+
+        $restored = $rule->restore($redacted);
+
+        $this->assertSame('api.example.com:8443', $restored['request']['headers']['Host']);
+    }
+
+    /**
+     * Same divergence, checked against the matcher it used to break: the live request carries the
+     * host the source names, and the recorded `Host` header has to come back equal to it.
+     */
+    public function testAHostHeaderThatSpellsTheHostDifferentlySatisfiesTheRealHeadersMatcher(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['url'] = 'https://API.Example.com:8443/status?ping=1';
+        $rule = new HostRule(self::REAL_HOST);
+
+        $liveRequest = Request::fromArray($recording['request']);
+        $replayedRequest = Request::fromArray($rule->restore($rule->redact($recording))['request']);
+
+        $this->assertTrue(RequestMatcher::matchHeaders($replayedRequest, $liveRequest));
+    }
+
+    public function testAHostHeaderCarryingAPortTheUrlDoesNotKeepsThatPort(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['url'] = 'https://api.example.com/status?ping=1';
+        $recording['request']['headers']['Host'] = 'api.example.com:8443';
+        $rule = new HostRule(self::REAL_HOST);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertSame('redacted-host.invalid:8443', $redacted['request']['headers']['Host']);
+        $this->assertSame($recording, $rule->restore($redacted));
+    }
+
+    public function testAHostHeaderThatDoesNotCarryTheHostIsOverwrittenWholesaleRatherThanLeftLeaking(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['headers']['Host'] = 'proxy.internal';
+        $rule = new HostRule(self::REAL_HOST);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertSame(self::HOST_PLACEHOLDER, $redacted['request']['headers']['Host']);
+    }
+
+    public function testRestoreIsANoOpWithoutASource(): void
+    {
+        $recording = $this->recording();
+        $rule = new HostRule();
+
+        $restored = $rule->restore($recording);
+
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testRedactReplacesTheHostWithAFixedPlaceholderWithoutASource(): void
+    {
+        $rule = new HostRule();
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame('https://redacted:8443/status?ping=1', $redacted['request']['url']);
+        $this->assertSame('redacted', $redacted['request']['headers']['Host']);
+    }
+
+    public function testRedactWithoutASourceProducesAUrlThatRequestFromArrayCanParse(): void
+    {
+        $recording = $this->recording();
+        unset($recording['request']['headers']['Host']);
+        $rule = new HostRule();
+
+        $redacted = $rule->redact($recording);
+
+        $request = Request::fromArray($redacted['request']);
+
+        $this->assertSame('redacted:8443', $request->getHost());
+    }
+
+    public function testComposesWithAnotherRuleAppliedAfterwardsOnTheSameUrl(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['url'] = 'https://api.example.com:8443/status?ping=1&token=secret';
+        $hostRule = new HostRule();
+        $queryRule = new QueryParameterRule('token', 'secret');
+
+        $afterHost = $hostRule->redact($recording);
+        $afterQuery = $queryRule->redact($afterHost);
+
+        $this->assertStringContainsString('token=<<REDACTED:QUERY_PARAMETER:token>>', $afterQuery['request']['url']);
+        $this->assertStringContainsString('redacted:8443', $afterQuery['request']['url']);
+    }
+
+    public function testTheReversiblePlaceholderAlsoLeavesALaterRuleAUsableUrl(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['url'] = 'https://api.example.com:8443/status?ping=1&token=secret';
+        $afterHost = (new HostRule(self::REAL_HOST))->redact($recording);
+
+        $afterQuery = (new QueryParameterRule('token', 'secret'))->redact($afterHost);
+
+        $this->assertStringContainsString('token=<<REDACTED:QUERY_PARAMETER:token>>', $afterQuery['request']['url']);
+        $this->assertStringContainsString('redacted-host.invalid:8443', $afterQuery['request']['url']);
+    }
+
+    public function testRedactThrowsMissingSecretExceptionWhenSourceResolvesToEmptyString(): void
+    {
+        $rule = new HostRule('');
+
+        $this->expectException(MissingSecretException::class);
+        $this->expectExceptionMessage(self::HOST_PLACEHOLDER);
+
+        $rule->redact($this->recording());
+    }
+
+    public function testRedactThrowsPlaceholderCollisionExceptionWhenTheUrlAlreadyCarriesThePlaceholder(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['url'] = 'https://redacted-host.invalid:8443/status?ping=1';
+        $rule = new HostRule(self::REAL_HOST);
+
+        $this->expectException(PlaceholderCollisionException::class);
+        $this->expectExceptionMessage('request.url');
+
+        $rule->redact($recording);
+    }
+
+    /**
+     * The rule rewrites two locations at once, so both matchers it would otherwise invalidate have
+     * to be satisfied again after restore() — including the port the Host header carries, which the
+     * rule does not own and must not lose.
+     */
+    public function testTheRedactRestoreRoundTripSatisfiesTheRealHostAndHeadersMatchersAgainstALiveRequest(): void
+    {
+        $recording = $this->recording();
+        $rule = new HostRule(self::REAL_HOST);
+
+        $onDisk = $rule->redact($recording);
+        $this->assertStringNotContainsString(self::REAL_HOST, (string) json_encode($onDisk['request']));
+
+        $liveRequest = Request::fromArray($recording['request']);
+        $recordedRequest = Request::fromArray($onDisk['request']);
+        $this->assertFalse(RequestMatcher::matchHost($recordedRequest, $liveRequest));
+        $this->assertFalse(RequestMatcher::matchHeaders($recordedRequest, $liveRequest));
+
+        $replayedRequest = Request::fromArray($rule->restore($onDisk)['request']);
+        $this->assertTrue(RequestMatcher::matchHost($replayedRequest, $liveRequest));
+        $this->assertTrue(RequestMatcher::matchHeaders($replayedRequest, $liveRequest));
+    }
+
+    public function testScopeIsAlwaysRequest(): void
+    {
+        $rule = new HostRule(self::REAL_HOST);
+
+        $this->assertSame(Scope::REQUEST, $rule->scope());
+    }
+
+    public function testIsReversibleIsTrueWhenASourceIsGiven(): void
+    {
+        $rule = new HostRule(self::REAL_HOST);
+
+        $this->assertTrue($rule->isReversible());
+    }
+
+    public function testIsReversibleIsFalseWithoutASource(): void
+    {
+        $rule = new HostRule();
+
+        $this->assertFalse($rule->isReversible());
+    }
+
+    public function testAffectedMatchersIsEmptyWhenReversible(): void
+    {
+        $rule = new HostRule(self::REAL_HOST);
+
+        $this->assertSame([], $rule->affectedMatchers());
+    }
+
+    public function testAffectedMatchersIsHostAndHeadersWhenIrreversible(): void
+    {
+        $rule = new HostRule();
+
+        $this->assertSame(['host', 'headers'], $rule->affectedMatchers());
+    }
+}

--- a/tests/Unit/Storage/Redaction/Rule/PostFieldRuleTest.php
+++ b/tests/Unit/Storage/Redaction/Rule/PostFieldRuleTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction\Rule;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Request;
+use VCR\RequestMatcher;
+use VCR\Storage\Redaction\MissingSecretException;
+use VCR\Storage\Redaction\PlaceholderCollisionException;
+use VCR\Storage\Redaction\Rule\PostFieldRule;
+use VCR\Storage\Redaction\Scope;
+
+final class PostFieldRuleTest extends TestCase
+{
+    /**
+     * Pinned as a literal rather than read back from Placeholder: the format ends up in committed
+     * cassettes, so a change to it is a change to what users see on disk and has to be deliberate.
+     */
+    private const PASSWORD_PLACEHOLDER = '<<REDACTED:POST_FIELD:password>>';
+
+    private const SECRET = 'hunter2';
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(): array
+    {
+        return [
+            'request' => [
+                'method' => 'POST',
+                'url' => 'https://api.example.com/login',
+                'headers' => [],
+                'post_fields' => ['user' => 'alice', 'password' => self::SECRET],
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+            ],
+            'index' => 0,
+        ];
+    }
+
+    public function testRedactWritesThePlaceholderRatherThanTheSecretItself(): void
+    {
+        $rule = new PostFieldRule('password', self::SECRET);
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame(self::PASSWORD_PLACEHOLDER, $redacted['request']['post_fields']['password']);
+        $this->assertSame('alice', $redacted['request']['post_fields']['user']);
+    }
+
+    public function testThePlaceholderIsDerivedFromTheFieldNameSoReRecordingIsByteIdentical(): void
+    {
+        $rule = new PostFieldRule('password', self::SECRET);
+
+        $this->assertSame($rule->redact($this->recording()), $rule->redact($this->recording()));
+    }
+
+    public function testRedactIsANoOpWhenTheFieldIsNotPresent(): void
+    {
+        $recording = $this->recording();
+        $rule = new PostFieldRule('missing-field', 'redacted');
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertSame($recording, $redacted);
+    }
+
+    public function testRestoreWritesTheRealSecretBackIntoTheField(): void
+    {
+        $rule = new PostFieldRule('password', self::SECRET);
+
+        $restored = $rule->restore($rule->redact($this->recording()));
+
+        $this->assertSame(self::SECRET, $restored['request']['post_fields']['password']);
+    }
+
+    public function testRedactAndRestoreRoundTripBackToTheOriginalRecording(): void
+    {
+        $recording = $this->recording();
+        $rule = new PostFieldRule('password', self::SECRET);
+
+        $this->assertSame($recording, $rule->restore($rule->redact($recording)));
+    }
+
+    public function testRestoreIsANoOpWithoutASource(): void
+    {
+        $recording = $this->recording();
+        $rule = new PostFieldRule('password');
+
+        $restored = $rule->restore($recording);
+
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testRestoreIsANoOpWhenTheFieldIsNotPresent(): void
+    {
+        $recording = $this->recording();
+        $rule = new PostFieldRule('missing-field', self::SECRET);
+
+        $this->assertSame($recording, $rule->restore($recording));
+    }
+
+    public function testRedactBlanksTheFieldValueWithoutASource(): void
+    {
+        $rule = new PostFieldRule('password');
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame('', $redacted['request']['post_fields']['password']);
+        $this->assertSame('alice', $redacted['request']['post_fields']['user']);
+    }
+
+    public function testRedactThrowsMissingSecretExceptionWhenSourceResolvesToEmptyString(): void
+    {
+        $rule = new PostFieldRule('password', '');
+
+        $this->expectException(MissingSecretException::class);
+        $this->expectExceptionMessage(self::PASSWORD_PLACEHOLDER);
+
+        $rule->redact($this->recording());
+    }
+
+    public function testRedactThrowsPlaceholderCollisionExceptionWhenTheValueAlreadyCarriesThePlaceholder(): void
+    {
+        $recording = $this->recording();
+        $recording['request']['post_fields']['password'] = self::PASSWORD_PLACEHOLDER;
+        $rule = new PostFieldRule('password', self::SECRET);
+
+        $this->expectException(PlaceholderCollisionException::class);
+        $this->expectExceptionMessage('request.post_fields.password');
+
+        $rule->redact($recording);
+    }
+
+    /**
+     * The secret must be gone from what reaches the disk, and back in place by the time the real
+     * `post_fields` matcher compares the recording against a live request.
+     */
+    public function testTheRedactRestoreRoundTripSatisfiesTheRealPostFieldsMatcherAgainstALiveRequest(): void
+    {
+        $recording = $this->recording();
+        $rule = new PostFieldRule('password', self::SECRET);
+
+        $onDisk = $rule->redact($recording);
+        $this->assertStringNotContainsString(self::SECRET, (string) json_encode($onDisk['request']));
+
+        $liveRequest = Request::fromArray($recording['request']);
+        $this->assertFalse(
+            RequestMatcher::matchPostFields(Request::fromArray($onDisk['request']), $liveRequest),
+            'Sanity check: without restore() the recorded request cannot match, or nothing was hidden.'
+        );
+
+        $this->assertTrue(
+            RequestMatcher::matchPostFields(Request::fromArray($rule->restore($onDisk)['request']), $liveRequest)
+        );
+    }
+
+    public function testScopeIsAlwaysRequest(): void
+    {
+        $rule = new PostFieldRule('password', self::SECRET);
+
+        $this->assertSame(Scope::REQUEST, $rule->scope());
+    }
+
+    public function testIsReversibleIsTrueWhenASourceIsGiven(): void
+    {
+        $rule = new PostFieldRule('password', self::SECRET);
+
+        $this->assertTrue($rule->isReversible());
+    }
+
+    public function testIsReversibleIsFalseWithoutASource(): void
+    {
+        $rule = new PostFieldRule('password');
+
+        $this->assertFalse($rule->isReversible());
+    }
+
+    public function testAffectedMatchersIsEmptyWhenReversible(): void
+    {
+        $rule = new PostFieldRule('password', self::SECRET);
+
+        $this->assertSame([], $rule->affectedMatchers());
+    }
+
+    public function testAffectedMatchersIsPostFieldsWhenIrreversible(): void
+    {
+        $rule = new PostFieldRule('password');
+
+        $this->assertSame(['post_fields'], $rule->affectedMatchers());
+    }
+}

--- a/tests/Unit/Storage/Redaction/Rule/PostFieldsCallbackRuleTest.php
+++ b/tests/Unit/Storage/Redaction/Rule/PostFieldsCallbackRuleTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction\Rule;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Redaction\Rule\PostFieldsCallbackRule;
+use VCR\Storage\Redaction\Scope;
+
+final class PostFieldsCallbackRuleTest extends TestCase
+{
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(): array
+    {
+        return [
+            'request' => [
+                'method' => 'POST',
+                'url' => 'https://api.example.com/login',
+                'headers' => [],
+                'body' => '{}',
+                'post_fields' => ['user' => 'alice', 'password' => 'hunter2'],
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+            ],
+            'index' => 0,
+        ];
+    }
+
+    public function testRedactAppliesTheCallbackToTheWholePostFieldsArray(): void
+    {
+        $rule = new PostFieldsCallbackRule(
+            static fn (array $postFields): array => array_map(static fn ($value) => strtoupper((string) $value), $postFields)
+        );
+
+        $redacted = $rule->redact($this->recording());
+
+        $this->assertSame(['user' => 'ALICE', 'password' => 'HUNTER2'], $redacted['request']['post_fields']);
+    }
+
+    public function testRedactLeavesTheRequestBodyAndOtherFieldsUntouched(): void
+    {
+        $recording = $this->recording();
+        $rule = new PostFieldsCallbackRule(static fn (array $postFields): array => []);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertSame($recording['request']['body'], $redacted['request']['body']);
+        $this->assertSame($recording['request']['method'], $redacted['request']['method']);
+        $this->assertSame($recording['response'], $redacted['response']);
+    }
+
+    public function testRedactIsANoOpWhenPostFieldsIsMissing(): void
+    {
+        $recording = $this->recording();
+        unset($recording['request']['post_fields']);
+        $rule = new PostFieldsCallbackRule(static fn (array $postFields): array => ['injected' => 'value']);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertSame($recording, $redacted);
+    }
+
+    public function testRestoreIsANoOpAndDoesNotInvokeTheCallback(): void
+    {
+        $recording = $this->recording();
+        $rule = new PostFieldsCallbackRule(function (array $postFields): array {
+            $this->fail('restore() must not invoke the callback.');
+        });
+
+        $restored = $rule->restore($recording);
+
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testScopeIsAlwaysRequest(): void
+    {
+        $rule = new PostFieldsCallbackRule(static fn (array $postFields): array => $postFields);
+
+        $this->assertSame(Scope::REQUEST, $rule->scope());
+    }
+
+    public function testIsReversibleIsAlwaysFalse(): void
+    {
+        $rule = new PostFieldsCallbackRule(static fn (array $postFields): array => $postFields);
+
+        $this->assertFalse($rule->isReversible());
+    }
+
+    public function testAffectedMatchersIsAlwaysPostFields(): void
+    {
+        $rule = new PostFieldsCallbackRule(static fn (array $postFields): array => $postFields);
+
+        $this->assertSame(['post_fields'], $rule->affectedMatchers());
+    }
+}

--- a/tests/Unit/Storage/Redaction/Rule/QueryParameterRuleTest.php
+++ b/tests/Unit/Storage/Redaction/Rule/QueryParameterRuleTest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction\Rule;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Request;
+use VCR\RequestMatcher;
+use VCR\Storage\Redaction\MissingSecretException;
+use VCR\Storage\Redaction\PlaceholderCollisionException;
+use VCR\Storage\Redaction\Rule\QueryParameterRule;
+use VCR\Storage\Redaction\Scope;
+
+final class QueryParameterRuleTest extends TestCase
+{
+    /**
+     * Pinned as a literal rather than read back from Placeholder: the format ends up in committed
+     * cassettes, so a change to it is a change to what users see on disk and has to be deliberate.
+     * It appears inside the URL exactly like this, unencoded.
+     */
+    private const TOKEN_PLACEHOLDER = '<<REDACTED:QUERY_PARAMETER:token>>';
+
+    private const SECRET = 'super-secret-token';
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(string $url): array
+    {
+        return [
+            'request' => [
+                'method' => 'GET',
+                'url' => $url,
+                'headers' => ['Host' => 'api.example.com'],
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+            ],
+            'index' => 0,
+        ];
+    }
+
+    public function testRedactWritesThePlaceholderRatherThanTheSecretItself(): void
+    {
+        $rule = new QueryParameterRule('token', self::SECRET);
+
+        $redacted = $rule->redact($this->recording('https://api.example.com/search?token='.self::SECRET.'&q=cats'));
+
+        $this->assertSame(
+            'https://api.example.com/search?token='.self::TOKEN_PLACEHOLDER.'&q=cats',
+            $redacted['request']['url']
+        );
+        $this->assertStringNotContainsString(self::SECRET, $redacted['request']['url']);
+    }
+
+    public function testThePlaceholderIsDerivedFromTheParameterNameSoReRecordingIsByteIdentical(): void
+    {
+        $rule = new QueryParameterRule('token', self::SECRET);
+        $recording = $this->recording('https://api.example.com/search?token='.self::SECRET);
+
+        $this->assertSame($rule->redact($recording), $rule->redact($recording));
+    }
+
+    public function testRedactLeavesOtherParametersAndTheRestOfTheUrlUntouched(): void
+    {
+        $rule = new QueryParameterRule('signature', 'abc123');
+        $original = 'https://api.example.com/orders/42?user=alice&signature=abc123&next=%2Fhome#section';
+
+        $redacted = $rule->redact($this->recording($original));
+
+        $url = $redacted['request']['url'];
+        $this->assertStringStartsWith('https://api.example.com/orders/42?', $url);
+        $this->assertStringContainsString('user=alice', $url);
+        $this->assertStringContainsString('signature=<<REDACTED:QUERY_PARAMETER:signature>>', $url);
+        $this->assertStringNotContainsString('abc123', $url);
+        $this->assertStringContainsString('next=%2Fhome', $url);
+        $this->assertStringEndsWith('#section', $url);
+    }
+
+    public function testRedactIsANoOpWhenTheParameterIsNotPresent(): void
+    {
+        $rule = new QueryParameterRule('token', self::SECRET);
+        $original = 'https://api.example.com/search?q=cats';
+
+        $redacted = $rule->redact($this->recording($original));
+
+        $this->assertSame($original, $redacted['request']['url']);
+    }
+
+    public function testRedactIsANoOpWhenTheUrlHasNoQueryString(): void
+    {
+        $rule = new QueryParameterRule('token', self::SECRET);
+        $original = 'https://api.example.com/search';
+
+        $redacted = $rule->redact($this->recording($original));
+
+        $this->assertSame($original, $redacted['request']['url']);
+    }
+
+    public function testRestoreWritesTheRealSecretBackIntoTheParameter(): void
+    {
+        $rule = new QueryParameterRule('token', self::SECRET);
+
+        $restored = $rule->restore($rule->redact($this->recording('https://api.example.com/search?token='.self::SECRET.'&q=cats')));
+
+        $this->assertSame(
+            'https://api.example.com/search?token=super-secret-token&q=cats',
+            $restored['request']['url']
+        );
+    }
+
+    public function testRedactAndRestoreRoundTripBackToTheOriginalRecording(): void
+    {
+        $recording = $this->recording('https://api.example.com/search?token='.self::SECRET.'&q=cats');
+        $rule = new QueryParameterRule('token', self::SECRET);
+
+        $this->assertSame($recording, $rule->restore($rule->redact($recording)));
+    }
+
+    public function testRestoreIsANoOpWithoutASource(): void
+    {
+        $recording = $this->recording('https://api.example.com/search?token=secret&q=cats');
+        $rule = new QueryParameterRule('token');
+
+        $restored = $rule->restore($recording);
+
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testRedactBlanksTheParameterValueWithoutASource(): void
+    {
+        $rule = new QueryParameterRule('token');
+
+        $redacted = $rule->redact($this->recording('https://api.example.com/search?token=secret&q=cats'));
+
+        $this->assertSame('https://api.example.com/search?token=&q=cats', $redacted['request']['url']);
+    }
+
+    public function testRedactThrowsMissingSecretExceptionWhenSourceResolvesToEmptyString(): void
+    {
+        $rule = new QueryParameterRule('token', '');
+
+        $this->expectException(MissingSecretException::class);
+        $this->expectExceptionMessage(self::TOKEN_PLACEHOLDER);
+
+        $rule->redact($this->recording('https://api.example.com/search?token=secret'));
+    }
+
+    public function testRedactThrowsPlaceholderCollisionExceptionWhenTheValueAlreadyCarriesThePlaceholder(): void
+    {
+        $rule = new QueryParameterRule('token', self::SECRET);
+        $url = 'https://api.example.com/search?token='.self::TOKEN_PLACEHOLDER;
+
+        $this->expectException(PlaceholderCollisionException::class);
+        $this->expectExceptionMessage('request.url');
+
+        $rule->redact($this->recording($url));
+    }
+
+    /**
+     * Values are written raw but read decoded, so a placeholder that reached the URL percent-encoded
+     * is still recognised rather than silently surviving restore() as the caller's own text.
+     */
+    public function testRedactThrowsPlaceholderCollisionExceptionForAPercentEncodedPlaceholderToo(): void
+    {
+        $rule = new QueryParameterRule('token', self::SECRET);
+        $url = 'https://api.example.com/search?token='.rawurlencode(self::TOKEN_PLACEHOLDER);
+
+        $this->expectException(PlaceholderCollisionException::class);
+        $this->expectExceptionMessage('request.url');
+
+        $rule->redact($this->recording($url));
+    }
+
+    /**
+     * The secret must be gone from what reaches the disk, and back in place by the time the real
+     * `query_string` matcher compares the recording against a live request.
+     */
+    public function testTheRedactRestoreRoundTripSatisfiesTheRealQueryStringMatcherAgainstALiveRequest(): void
+    {
+        $recording = $this->recording('https://api.example.com/search?token='.self::SECRET.'&q=cats');
+        $rule = new QueryParameterRule('token', self::SECRET);
+
+        $onDisk = $rule->redact($recording);
+        $this->assertStringNotContainsString(self::SECRET, (string) json_encode($onDisk['request']));
+
+        $liveRequest = Request::fromArray($recording['request']);
+        $this->assertFalse(
+            RequestMatcher::matchQueryString(Request::fromArray($onDisk['request']), $liveRequest),
+            'Sanity check: without restore() the recorded request cannot match, or nothing was hidden.'
+        );
+
+        $this->assertTrue(
+            RequestMatcher::matchQueryString(Request::fromArray($rule->restore($onDisk)['request']), $liveRequest)
+        );
+    }
+
+    /**
+     * Re-encoding the restored value used to break exactly these: `urlencode()` escapes an `@` and a
+     * `:`, `/` and `~`, and writes a space as `+`, none of which a client that sent the character
+     * literally will reproduce — and the `query_string` matcher compares the raw query string
+     * byte-for-byte. The value now goes back in exactly as it came out.
+     *
+     * @dataProvider awkwardSecretProvider
+     */
+    public function testARestoredValueMatchesTheRealQueryStringMatcherWhateverCharactersItCarries(string $secret): void
+    {
+        $recording = $this->recording('https://api.example.com/search?email='.$secret.'&q=1');
+        $rule = new QueryParameterRule('email', $secret);
+
+        $onDisk = $rule->redact($recording);
+        $this->assertStringNotContainsString($secret, $onDisk['request']['url']);
+
+        $liveRequest = Request::fromArray($recording['request']);
+        $replayedRequest = Request::fromArray($rule->restore($onDisk)['request']);
+
+        $this->assertSame($liveRequest->getQuery(), $replayedRequest->getQuery());
+        $this->assertTrue(RequestMatcher::matchQueryString($replayedRequest, $liveRequest));
+    }
+
+    /**
+     * @return array<string,string[]>
+     */
+    public static function awkwardSecretProvider(): array
+    {
+        return [
+            'at sign' => ['alice@example.com'],
+            'colon' => ['scheme:value'],
+            'slash' => ['a/b'],
+            'tilde' => ['~alice'],
+            'literal space' => ['two words'],
+            'already percent-encoded' => ['two%20words'],
+        ];
+    }
+
+    /**
+     * Round-tripping the query string through parse_str()/http_build_query() used to rewrite
+     * parameters this rule never targeted — `client.secret` came back as `client_secret` — which
+     * fails the query_string matcher on replay even though the rule reports invalidating nothing.
+     */
+    public function testRedactLeavesAParameterWhoseNameParseStrWouldMangleByteIdentical(): void
+    {
+        $recording = $this->recording('https://api.example.com/s?client.secret=abc&token='.self::SECRET.'&a[]=1');
+        $rule = new QueryParameterRule('token', self::SECRET);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertStringContainsString('client.secret=abc', $redacted['request']['url']);
+        $this->assertStringContainsString('a[]=1', $redacted['request']['url']);
+        $this->assertSame($recording, $rule->restore($redacted));
+    }
+
+    /**
+     * Same root cause seen from the other side: such a name could never be found, so its value
+     * stayed on the cassette in plaintext with no error to show for it.
+     */
+    public function testRedactFindsAParameterWhoseOwnNameParseStrWouldMangle(): void
+    {
+        $recording = $this->recording('https://api.example.com/s?client.secret='.self::SECRET);
+        $rule = new QueryParameterRule('client.secret', self::SECRET);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertStringNotContainsString(self::SECRET, $redacted['request']['url']);
+        $this->assertSame($recording, $rule->restore($redacted));
+    }
+
+    public function testRedactRewritesEveryOccurrenceOfARepeatedParameter(): void
+    {
+        $recording = $this->recording('https://api.example.com/s?token='.self::SECRET.'&q=cats&token='.self::SECRET);
+        $rule = new QueryParameterRule('token', self::SECRET);
+
+        $redacted = $rule->redact($recording);
+
+        $this->assertStringNotContainsString(self::SECRET, $redacted['request']['url']);
+        $this->assertSame(2, substr_count($redacted['request']['url'], self::TOKEN_PLACEHOLDER));
+    }
+
+    public function testScopeIsAlwaysRequest(): void
+    {
+        $rule = new QueryParameterRule('token', self::SECRET);
+
+        $this->assertSame(Scope::REQUEST, $rule->scope());
+    }
+
+    public function testIsReversibleIsTrueWhenASourceIsGiven(): void
+    {
+        $rule = new QueryParameterRule('token', self::SECRET);
+
+        $this->assertTrue($rule->isReversible());
+    }
+
+    public function testIsReversibleIsFalseWithoutASource(): void
+    {
+        $rule = new QueryParameterRule('token');
+
+        $this->assertFalse($rule->isReversible());
+    }
+
+    public function testAffectedMatchersIsEmptyWhenReversible(): void
+    {
+        $rule = new QueryParameterRule('token', self::SECRET);
+
+        $this->assertSame([], $rule->affectedMatchers());
+    }
+
+    public function testAffectedMatchersIsQueryStringWhenIrreversible(): void
+    {
+        $rule = new QueryParameterRule('token');
+
+        $this->assertSame(['query_string'], $rule->affectedMatchers());
+    }
+}

--- a/tests/Unit/Storage/Redaction/Rule/ValueSubstitutionRuleTest.php
+++ b/tests/Unit/Storage/Redaction/Rule/ValueSubstitutionRuleTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction\Rule;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Redaction\InvalidRedactionRuleException;
+use VCR\Storage\Redaction\MissingSecretException;
+use VCR\Storage\Redaction\PlaceholderCollisionException;
+use VCR\Storage\Redaction\Rule\ValueSubstitutionRule;
+use VCR\Storage\Redaction\Scope;
+
+final class ValueSubstitutionRuleTest extends TestCase
+{
+    private const SECRET = 'hunter2';
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(string $secret = self::SECRET): array
+    {
+        return [
+            'request' => [
+                'method' => 'POST',
+                'url' => 'https://api.example.com/login',
+                'headers' => ['Authorization' => 'Bearer '.$secret],
+                'body' => '{"password":"'.$secret.'"}',
+                'post_files' => [
+                    ['fieldName' => 'file', 'filename' => 'secret.txt', 'content' => 'token='.$secret],
+                ],
+                'post_fields' => ['password' => $secret],
+            ],
+            'response' => [
+                'status' => ['code' => 200, 'message' => 'OK'],
+                'headers' => ['Set-Cookie' => 'session='.$secret],
+                'body' => 'welcome '.$secret,
+                'curl_info' => ['request_header' => 'Authorization: Bearer '.$secret],
+            ],
+            'index' => 0,
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $recording
+     */
+    private function assertContainsPlaceholderEverywhere(array $recording, string $placeholder, string $secret): void
+    {
+        $this->assertStringNotContainsString($secret, $recording['request']['headers']['Authorization']);
+        $this->assertStringNotContainsString($secret, $recording['request']['body']);
+        $this->assertStringNotContainsString($secret, $recording['request']['post_files'][0]['content']);
+        $this->assertStringNotContainsString($secret, $recording['request']['post_fields']['password']);
+        $this->assertStringNotContainsString($secret, $recording['response']['headers']['Set-Cookie']);
+        $this->assertStringNotContainsString($secret, $recording['response']['body']);
+        $this->assertStringNotContainsString($secret, $recording['response']['curl_info']['request_header']);
+
+        $this->assertStringContainsString($placeholder, $recording['request']['headers']['Authorization']);
+        $this->assertStringContainsString($placeholder, $recording['request']['body']);
+        $this->assertStringContainsString($placeholder, $recording['request']['post_files'][0]['content']);
+        $this->assertSame($placeholder, $recording['request']['post_fields']['password']);
+        $this->assertStringContainsString($placeholder, $recording['response']['headers']['Set-Cookie']);
+        $this->assertStringContainsString($placeholder, $recording['response']['body']);
+        $this->assertStringContainsString($placeholder, $recording['response']['curl_info']['request_header']);
+    }
+
+    public function testLiteralSourceRoundTrips(): void
+    {
+        $recording = $this->recording();
+        $rule = new ValueSubstitutionRule('{{PASSWORD}}', self::SECRET);
+
+        $redacted = $rule->redact($recording);
+        $this->assertContainsPlaceholderEverywhere($redacted, '{{PASSWORD}}', self::SECRET);
+
+        $restored = $rule->restore($redacted);
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testNoArgumentCallableSourceRoundTrips(): void
+    {
+        $recording = $this->recording();
+        $rule = new ValueSubstitutionRule('{{PASSWORD}}', static fn (): string => ValueSubstitutionRuleTest::SECRET);
+
+        $redacted = $rule->redact($recording);
+        $this->assertContainsPlaceholderEverywhere($redacted, '{{PASSWORD}}', self::SECRET);
+
+        $restored = $rule->restore($redacted);
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testRecordingAwareCallableSourceRoundTrips(): void
+    {
+        $recording = $this->recording();
+        // The derived value (the status code, as a string) also appears verbatim as a string leaf
+        // elsewhere, so the round-trip actually exercises a substitution rather than being a no-op.
+        $recording['response']['headers']['X-Order-Status'] = 'status:200';
+        $rule = new ValueSubstitutionRule('{{ORDER_STATUS_CODE}}', static fn (array $recording): string => (string) $recording['response']['status']['code']);
+
+        $redacted = $rule->redact($recording);
+        $this->assertSame(200, $redacted['response']['status']['code']);
+        $this->assertStringNotContainsString('200', $redacted['response']['headers']['X-Order-Status']);
+        $this->assertSame('status:{{ORDER_STATUS_CODE}}', $redacted['response']['headers']['X-Order-Status']);
+
+        $restored = $rule->restore($redacted);
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testCallableSourceWithUnrelatedOptionalParameterIsTreatedAsNoArgument(): void
+    {
+        $recording = $this->recording();
+        $rule = new ValueSubstitutionRule(
+            '{{PASSWORD}}',
+            static fn (string $unrelated = self::SECRET): string => $unrelated
+        );
+
+        $redacted = $rule->redact($recording);
+        $this->assertContainsPlaceholderEverywhere($redacted, '{{PASSWORD}}', self::SECRET);
+
+        $restored = $rule->restore($redacted);
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testRedactThrowsMissingSecretExceptionWhenSourceResolvesToNull(): void
+    {
+        $rule = new ValueSubstitutionRule('{{PASSWORD}}', static fn (): ?string => null);
+
+        $this->expectException(MissingSecretException::class);
+
+        $rule->redact($this->recording());
+    }
+
+    public function testRestoreThrowsMissingSecretExceptionWhenSourceResolvesToNull(): void
+    {
+        $rule = new ValueSubstitutionRule('{{PASSWORD}}', static fn (): ?string => null);
+
+        $this->expectException(MissingSecretException::class);
+
+        $rule->restore($this->recording());
+    }
+
+    public function testRedactThrowsMissingSecretExceptionWhenSourceResolvesToEmptyString(): void
+    {
+        $rule = new ValueSubstitutionRule('{{PASSWORD}}', '');
+
+        $this->expectException(MissingSecretException::class);
+
+        $rule->redact($this->recording());
+    }
+
+    public function testRestoreThrowsMissingSecretExceptionWhenSourceResolvesToEmptyString(): void
+    {
+        $rule = new ValueSubstitutionRule('{{PASSWORD}}', '');
+
+        $this->expectException(MissingSecretException::class);
+
+        $rule->restore($this->recording());
+    }
+
+    public function testConstructionRejectsAnEmptyPlaceholder(): void
+    {
+        $this->expectException(InvalidRedactionRuleException::class);
+
+        new ValueSubstitutionRule('', self::SECRET);
+    }
+
+    /**
+     * `getenv()` returns false for an unset variable, which is exactly the documented
+     * `filterSensitiveData('<<AUTH_TOKEN>>', getenv('API_TOKEN'))` shape on a CI runner without the
+     * secret configured — it has to name the placeholder, not blow up with a TypeError.
+     */
+    public function testAnUnsetEnvironmentVariableSourceRaisesMissingSecretExceptionNotATypeError(): void
+    {
+        $rule = new ValueSubstitutionRule('{{PASSWORD}}', getenv('VCR_TEST_DEFINITELY_UNSET_VARIABLE'));
+
+        $this->expectException(MissingSecretException::class);
+        $this->expectExceptionMessage('{{PASSWORD}}');
+
+        $rule->redact($this->recording());
+    }
+
+    public function testRedactThrowsPlaceholderCollisionExceptionWhenPlaceholderAlreadyPresent(): void
+    {
+        $recording = $this->recording();
+        $recording['response']['body'] = 'welcome '.self::SECRET.' {{PASSWORD}}';
+        $rule = new ValueSubstitutionRule('{{PASSWORD}}', self::SECRET);
+
+        $this->expectException(PlaceholderCollisionException::class);
+        $this->expectExceptionMessage('{{PASSWORD}}');
+
+        $rule->redact($recording);
+    }
+
+    public function testTwoRulesSharingTheSameSecretWithDifferentPlaceholdersDoNotCorruptDataWhenChained(): void
+    {
+        $recording = $this->recording();
+        $ruleA = new ValueSubstitutionRule('{{SECRET_A}}', self::SECRET);
+        $ruleB = new ValueSubstitutionRule('{{SECRET_B}}', self::SECRET);
+
+        $redacted = $ruleB->redact($ruleA->redact($recording));
+
+        $this->assertStringNotContainsString(self::SECRET, $redacted['response']['body']);
+        $this->assertStringContainsString('{{SECRET_A}}', $redacted['response']['body']);
+        $this->assertStringNotContainsString('{{SECRET_B}}', $redacted['response']['body']);
+
+        $restored = $ruleA->restore($ruleB->restore($redacted));
+
+        $this->assertSame($recording, $restored);
+    }
+
+    public function testScopeIsBoth(): void
+    {
+        $rule = new ValueSubstitutionRule('{{PASSWORD}}', self::SECRET);
+
+        $this->assertSame(Scope::BOTH, $rule->scope());
+    }
+
+    public function testIsReversibleIsTrue(): void
+    {
+        $rule = new ValueSubstitutionRule('{{PASSWORD}}', self::SECRET);
+
+        $this->assertTrue($rule->isReversible());
+    }
+
+    public function testAffectedMatchersIsEmpty(): void
+    {
+        $rule = new ValueSubstitutionRule('{{PASSWORD}}', self::SECRET);
+
+        $this->assertSame([], $rule->affectedMatchers());
+    }
+}

--- a/tests/Unit/Storage/Redaction/ScopeTest.php
+++ b/tests/Unit/Storage/Redaction/ScopeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Redaction\InvalidRedactionRuleException;
+use VCR\Storage\Redaction\Scope;
+
+final class ScopeTest extends TestCase
+{
+    /**
+     * @dataProvider scopeProvider
+     */
+    public function testScopeHasTheExpectedValue(string $expectedValue, string $scope): void
+    {
+        $this->assertSame($expectedValue, $scope);
+    }
+
+    /** @return array<string, string[]> */
+    public static function scopeProvider(): array
+    {
+        return [
+            'request' => ['request', Scope::REQUEST],
+            'response' => ['response', Scope::RESPONSE],
+            'both' => ['both', Scope::BOTH],
+        ];
+    }
+
+    public function testAllScopesAreDistinctFromEachOther(): void
+    {
+        $this->assertSame(
+            [Scope::REQUEST, Scope::RESPONSE, Scope::BOTH],
+            array_unique([Scope::REQUEST, Scope::RESPONSE, Scope::BOTH])
+        );
+    }
+
+    /**
+     * @dataProvider inclusionProvider
+     */
+    public function testIncludesReportsWhetherAScopeCoversASide(bool $expected, string $scope, string $side): void
+    {
+        $this->assertSame($expected, Scope::includes($scope, $side));
+    }
+
+    /**
+     * @return array<string,array{0:bool,1:string,2:string}>
+     */
+    public static function inclusionProvider(): array
+    {
+        return [
+            'request covers request' => [true, Scope::REQUEST, Scope::REQUEST],
+            'request does not cover response' => [false, Scope::REQUEST, Scope::RESPONSE],
+            'response covers response' => [true, Scope::RESPONSE, Scope::RESPONSE],
+            'response does not cover request' => [false, Scope::RESPONSE, Scope::REQUEST],
+            'both covers request' => [true, Scope::BOTH, Scope::REQUEST],
+            'both covers response' => [true, Scope::BOTH, Scope::RESPONSE],
+        ];
+    }
+
+    /**
+     * @dataProvider validScopeProvider
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testAssertValidAcceptsEveryKnownScope(string $scope): void
+    {
+        Scope::assertValid($scope);
+    }
+
+    /**
+     * @return array<string,string[]>
+     */
+    public static function validScopeProvider(): array
+    {
+        return [
+            'request' => [Scope::REQUEST],
+            'response' => [Scope::RESPONSE],
+            'both' => [Scope::BOTH],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidScopeProvider
+     */
+    public function testAssertValidRejectsAnUnknownScopeInsteadOfSilentlyMakingTheRuleANoOp(string $scope): void
+    {
+        $this->expectException(InvalidRedactionRuleException::class);
+
+        Scope::assertValid($scope);
+    }
+
+    /**
+     * @return array<string,string[]>
+     */
+    public static function invalidScopeProvider(): array
+    {
+        return [
+            'typo' => ['requset'],
+            'empty' => [''],
+            'wrong case' => ['Request'],
+            'plural' => ['requests'],
+        ];
+    }
+}

--- a/tests/Unit/Storage/Redaction/SecretSourceTest.php
+++ b/tests/Unit/Storage/Redaction/SecretSourceTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Redaction\InvalidRedactionRuleException;
+use VCR\Storage\Redaction\MissingSecretException;
+use VCR\Storage\Redaction\SecretSource;
+
+final class SecretSourceTest extends TestCase
+{
+    private const PLACEHOLDER = '{{API_KEY}}';
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recording(): array
+    {
+        return [
+            'request' => ['method' => 'POST', 'url' => 'https://api.example.com/login'],
+            'response' => ['status' => ['code' => 200, 'message' => 'OK']],
+            'index' => 0,
+        ];
+    }
+
+    public function testALiteralStringIsTheSecret(): void
+    {
+        $source = new SecretSource(self::PLACEHOLDER, 'hunter2');
+
+        $this->assertSame('hunter2', $source->resolve($this->recording()));
+    }
+
+    public function testAStringThatHappensToNameAFunctionIsStillTakenLiterally(): void
+    {
+        $source = new SecretSource(self::PLACEHOLDER, 'strtoupper');
+
+        $this->assertSame('strtoupper', $source->resolve($this->recording()));
+    }
+
+    public function testANoArgumentCallableIsInvokedWithoutTheRecording(): void
+    {
+        $source = new SecretSource(self::PLACEHOLDER, static fn (): string => 'hunter2');
+
+        $this->assertSame('hunter2', $source->resolve($this->recording()));
+    }
+
+    public function testARecordingAwareCallableReceivesTheRecording(): void
+    {
+        $source = new SecretSource(self::PLACEHOLDER, static fn (array $recording): string => 'derived-'.$recording['request']['method']);
+
+        $this->assertSame('derived-POST', $source->resolve($this->recording()));
+    }
+
+    public function testACallableWithOnlyAnUnrelatedOptionalParameterIsTreatedAsNoArgument(): void
+    {
+        $source = new SecretSource(self::PLACEHOLDER, static fn (string $unrelated = 'hunter2'): string => $unrelated);
+
+        $this->assertSame('hunter2', $source->resolve($this->recording()));
+    }
+
+    public function testAnInvokableObjectIsAcceptedAsACallable(): void
+    {
+        $source = new SecretSource(self::PLACEHOLDER, new class {
+            public function __invoke(): string
+            {
+                return 'hunter2';
+            }
+        });
+
+        $this->assertSame('hunter2', $source->resolve($this->recording()));
+    }
+
+    public function testResolveThrowsMissingSecretExceptionForAnEmptyString(): void
+    {
+        $source = new SecretSource(self::PLACEHOLDER, '');
+
+        $this->expectException(MissingSecretException::class);
+        $this->expectExceptionMessage(self::PLACEHOLDER);
+
+        $source->resolve($this->recording());
+    }
+
+    public function testResolveThrowsMissingSecretExceptionForACallableReturningNull(): void
+    {
+        $source = new SecretSource(self::PLACEHOLDER, static fn (): ?string => null);
+
+        $this->expectException(MissingSecretException::class);
+
+        $source->resolve($this->recording());
+    }
+
+    /**
+     * `getenv()` returns false for an unset variable, so the documented
+     * `filterSensitiveData('<<AUTH_TOKEN>>', getenv('API_TOKEN'))` shape has to degrade into a
+     * MissingSecretException naming the placeholder rather than a raw TypeError.
+     */
+    public function testAFalseSourceResolvesToMissingSecretExceptionRatherThanATypeError(): void
+    {
+        $source = new SecretSource(self::PLACEHOLDER, getenv('VCR_TEST_DEFINITELY_UNSET_VARIABLE'));
+
+        $this->expectException(MissingSecretException::class);
+        $this->expectExceptionMessage(self::PLACEHOLDER);
+
+        $source->resolve($this->recording());
+    }
+
+    public function testANullSourceResolvesToMissingSecretException(): void
+    {
+        $source = new SecretSource(self::PLACEHOLDER, null);
+
+        $this->expectException(MissingSecretException::class);
+
+        $source->resolve($this->recording());
+    }
+
+    /**
+     * @dataProvider unsupportedSourceProvider
+     */
+    public function testConstructionRejectsASourceThatIsNeitherStringNorCallable(mixed $source, string $expectedType): void
+    {
+        $this->expectException(InvalidRedactionRuleException::class);
+        $this->expectExceptionMessage($expectedType);
+
+        new SecretSource(self::PLACEHOLDER, $source);
+    }
+
+    /**
+     * @return array<string,array{0:mixed,1:string}>
+     */
+    public static function unsupportedSourceProvider(): array
+    {
+        return [
+            'int' => [42, 'int'],
+            'true' => [true, 'bool'],
+            'float' => [1.5, 'float'],
+            'array' => [['not', 'callable'], 'array'],
+            'object' => [new \stdClass(), 'stdClass'],
+        ];
+    }
+}

--- a/tests/Unit/Storage/Redaction/UrlPartsTest.php
+++ b/tests/Unit/Storage/Redaction/UrlPartsTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VCR\Tests\Unit\Storage\Redaction;
+
+use PHPUnit\Framework\TestCase;
+use VCR\Storage\Redaction\UrlParts;
+
+final class UrlPartsTest extends TestCase
+{
+    /**
+     * @dataProvider roundTrippingUrlProvider
+     */
+    public function testEveryComponentSurvivesAParseAndRebuildRoundTrip(string $url): void
+    {
+        $parts = UrlParts::parse($url);
+
+        $this->assertNotNull($parts);
+        $this->assertSame($url, UrlParts::toUrl($parts));
+    }
+
+    /**
+     * @return array<string,string[]>
+     */
+    public static function roundTrippingUrlProvider(): array
+    {
+        return [
+            'plain' => ['https://api.example.com/status'],
+            'with port' => ['https://api.example.com:8443/status'],
+            'with query' => ['https://api.example.com/search?q=cats&page=2'],
+            'with fragment' => ['https://api.example.com/docs#section'],
+            'with credentials' => ['https://alice:hunter2@api.example.com/private'],
+            'with user only' => ['https://alice@api.example.com/private'],
+            'everything' => ['https://alice:hunter2@api.example.com:8443/orders/42?user=alice#top'],
+            'no path' => ['https://api.example.com'],
+        ];
+    }
+
+    public function testAnEmptyQueryComponentIsDroppedRatherThanLeavingADanglingQuestionMark(): void
+    {
+        $this->assertSame(
+            'https://api.example.com/search',
+            UrlParts::toUrl(['scheme' => 'https', 'host' => 'api.example.com', 'path' => '/search', 'query' => ''])
+        );
+    }
+
+    public function testRewriteQueryParameterLeavesEveryOtherParameterByteIdentical(): void
+    {
+        $query = UrlParts::rewriteQueryParameter(
+            'client.secret=abc&token=xyz&a[]=1&a[]=2&next=%2Fhome',
+            'token',
+            static fn (string $value): string => strtoupper($value)
+        );
+
+        $this->assertSame('client.secret=abc&token=XYZ&a[]=1&a[]=2&next=%2Fhome', $query);
+    }
+
+    public function testRewriteQueryParameterFindsANameThatParseStrWouldMangle(): void
+    {
+        $query = UrlParts::rewriteQueryParameter(
+            'client.secret=abc&token=xyz',
+            'client.secret',
+            static fn (): string => 'REDACTED'
+        );
+
+        $this->assertSame('client.secret=REDACTED&token=xyz', $query);
+    }
+
+    public function testRewriteQueryParameterRewritesEveryOccurrenceSoNoCopyOfTheSecretSurvives(): void
+    {
+        $query = UrlParts::rewriteQueryParameter(
+            'token=xyz&q=cats&token=xyz',
+            'token',
+            static fn (): string => 'REDACTED'
+        );
+
+        $this->assertSame('token=REDACTED&q=cats&token=REDACTED', $query);
+    }
+
+    public function testRewriteQueryParameterComparesTheNameDecoded(): void
+    {
+        $query = UrlParts::rewriteQueryParameter(
+            'api%20key=abc',
+            'api key',
+            static fn (): string => 'REDACTED'
+        );
+
+        $this->assertSame('api%20key=REDACTED', $query);
+    }
+
+    public function testRewriteQueryParameterPassesTheDecodedCurrentValueToTheReplacement(): void
+    {
+        $seen = null;
+
+        UrlParts::rewriteQueryParameter('token=a%20b', 'token', static function (string $value) use (&$seen): string {
+            $seen = $value;
+
+            return 'REDACTED';
+        });
+
+        $this->assertSame('a b', $seen);
+    }
+
+    public function testRewriteQueryParameterTreatsAValuelessParameterAsAnEmptyValue(): void
+    {
+        $query = UrlParts::rewriteQueryParameter('flag&q=cats', 'flag', static fn (string $value): string => 'was:'.$value);
+
+        $this->assertSame('flag=was:&q=cats', $query);
+    }
+
+    /**
+     * Re-encoding the replacement — with `urlencode()`, `rawurlencode()`, or anything else — cannot
+     * reproduce byte-for-byte what an arbitrary client puts on the wire, and the `query_string`
+     * matcher compares the raw query string. The replacement is therefore written verbatim.
+     */
+    public function testRewriteQueryParameterWritesTheReplacementVerbatimWithoutEncodingIt(): void
+    {
+        $query = UrlParts::rewriteQueryParameter(
+            'email=old&q=cats',
+            'email',
+            static fn (): string => 'alice@example.com two words ~a/b:c'
+        );
+
+        $this->assertSame('email=alice@example.com two words ~a/b:c&q=cats', $query);
+    }
+
+    public function testRewriteQueryParameterReturnsNullWhenTheParameterIsAbsent(): void
+    {
+        $this->assertNull(UrlParts::rewriteQueryParameter('q=cats', 'token', static fn (): string => 'REDACTED'));
+    }
+
+    public function testParseReturnsNullForAnUnparseableUrl(): void
+    {
+        $this->assertNull(UrlParts::parse('https://:8443/path'));
+    }
+}


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Feature
| Fixes            | Fix #503
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| Docs updated?    | yes
| License          | MIT

Adds a `RedactingStorage`/`RedactingStorageFactory` decorator that declaratively strips sensitive data from recorded cassettes on write and restores it on read, before `Cassette::playback()` applies the request matchers — so redaction no longer requires narrowing matchers to keep replay working. Mirrors the encrypted storage decorator (#502) architecturally: no changes to `Configuration`, `VCRFactory`, `Videorecorder`, `Cassette`, `Request` or `Response`.

```php
VCR::configure()->setStorageFactory(
    RedactingStorageFactory::withRules(
        new YamlStorageFactory(),
        RedactionRules::create()
            ->filterSensitiveData('<<API_TOKEN>>', getenv('API_TOKEN'))
            ->postField('password', getenv('TEST_PASSWORD'))
            ->header('Set-Cookie', Scope::RESPONSE)
    )
);
```

The secret appears nowhere on disk; replay succeeds with all eight default matchers enabled.

**Rule families:** value substitution (`filterSensitiveData()`, always reversible), name-scoped rules (`header()`, `allHeaders()`, `queryParameter()`, `postField()`, `host()`), callback rules (`body()`, `postFields()`, the escape hatch). A reversibility contract enforced in `RedactionRules::add()` refuses an irreversible request-side rule unless the caller opts in explicitly, and reports exactly which matchers it invalidates via `safeRequestMatchers()`/`invalidatedRequestMatchers()`. Both leak channels called out in the issue (`response.curl_info.request_header`, `request.post_files`) are covered and asserted in a dedicated integration test. Stacks with the encrypted storage backend (redact-then-encrypt).

`RedactionRuleInterface` is public API for custom rules; a new how-to page (`docs/howto/custom-redaction-rule.md`) covers all three extension levels (callback → custom rule class → own storage decorator).

Refs #503, #174, #352, #344. Closes #344 with a pointer to this implementation once merged (draft comment for that closure prepared separately).

Verified locally on the full Docker matrix (`workspace80`/`workspace85`, lowest and highest deps) before pushing — phpstan/cs/ec clean, zero new baseline entries; CI runs the same checks. Docs examples verified against a throwaway harness per the project's documentation gate.