### PR TITLE
feat(matcher): add body_json request matcher for semantic JSON body comparison

### DIFF
--- a/docs/guides/request-matching.md
+++ b/docs/guides/request-matching.md
@@ -7,8 +7,8 @@
 
 ## The default: everything must agree
 
-By default, all 8 built-in matchers are enabled — method, URL path, host, headers, body, post fields, query
-string, SOAP operation. An incoming request only matches a recording if **every enabled matcher** returns
+By default, all 9 built-in matchers are enabled — method, URL path, host, headers, body, JSON body, post
+fields, query string, SOAP operation. An incoming request only matches a recording if **every enabled matcher** returns
 `true` (logical AND, see [`Request::matches()`](../reference/request-response.md#request)). That's the
 strictest possible interpretation of "same request", and it's the safest default: nothing replays unless it's
 genuinely the same call.
@@ -25,6 +25,16 @@ identify the request for your use case:
 
 Now two requests that only differ in headers or body replay the same recording. See the full list and exact
 semantics of each in the [Request Matchers reference](../reference/request-matchers.md).
+
+Dropping `body` is a blunt instrument when the variation is only in how a JSON payload is serialised — a
+reordered key, a reformatted document. Swap it for
+[`body_json`](../reference/request-matchers.md#body_json) instead, which compares the body as a JSON
+document rather than as a string, and keeps rejecting bodies that actually differ:
+
+```php
+\VCR\VCR::configure()
+    ->enableRequestMatchers(['method', 'url', 'host', 'query_string', 'body_json']);
+```
 
 ## Custom matchers
 

--- a/docs/reference/request-matchers.md
+++ b/docs/reference/request-matchers.md
@@ -3,9 +3,9 @@
 > One-liner: matching decides whether an incoming request "is" a recorded one. All enabled matchers must
 > agree (AND) — see [Request Matching](../guides/request-matching.md) for the concept.
 
-**On this page:** [method](#method) · [url](#url) · [host](#host) · [headers](#headers) · [body](#body) · [post_fields](#post_fields) · [query_string](#query_string) · [soap_operation](#soap_operation) · [Custom matchers](#custom-matchers)
+**On this page:** [method](#method) · [url](#url) · [host](#host) · [headers](#headers) · [body](#body) · [body_json](#body_json) · [post_fields](#post_fields) · [query_string](#query_string) · [soap_operation](#soap_operation) · [Custom matchers](#custom-matchers)
 
-All 8 are enabled by default. Configure a subset via
+All 9 are enabled by default. Configure a subset via
 [`enableRequestMatchers()`](configuration.md#request-matchers).
 
 ## `method`
@@ -39,6 +39,34 @@ All 8 are enabled by default. Configure a subset via
 ## `body`
 
 - **Compares:** the raw request body string
+
+## `body_json`
+
+> **🆕 Since 1.13**
+
+- **Compares:** the request body decoded as JSON, structurally — object key order is ignored, array
+  element order is significant, and scalars are compared strictly.
+- Falls back to the same raw-string comparison as [`body`](#body) when either body is empty, invalid
+  JSON, or a bare scalar.
+
+```php
+// {"model":"a","stream":false}  vs.  {"stream":false,"model":"a"}  -> match
+// ["a","b"]                     vs.  ["b","a"]                     -> no match
+// {"n":1}                       vs.  {"n":"1"}                     -> no match
+// {}                            vs.  []                            -> no match
+```
+
+Replace `body` with `body_json` to get order-insensitive JSON matching:
+
+```php
+\VCR\VCR::configure()
+    ->enableRequestMatchers(['method', 'url', 'host', 'query_string', 'body_json']);
+```
+
+> **📌 Note**
+> Like every built-in, `body_json` is part of the default set — where it changes nothing, because
+> matchers are ANDed and `body` already rejects any body it would reject. Leaving `body` enabled
+> alongside it keeps the strict raw-string comparison in force.
 
 ## `post_fields`
 

--- a/docs/reference/request-matchers.md
+++ b/docs/reference/request-matchers.md
@@ -68,6 +68,15 @@ Replace `body` with `body_json` to get order-insensitive JSON matching:
 > matchers are ANDed and `body` already rejects any body it would reject. Leaving `body` enabled
 > alongside it keeps the strict raw-string comparison in force.
 
+> **⚠️ Warning**
+> Decoding is only reached when two bodies differ as strings *and* both start with `{` or `[`.
+> Identical bodies and non-JSON bodies (XML, binary uploads, form-encoded payloads) are settled by the
+> same string comparison `body` uses, so the default matcher set costs nothing extra. When decoding
+> does happen it is paid once per recording examined, against both bodies — on a 200 KiB payload that
+> is milliseconds per recording, so a cassette holding many large JSON recordings will notice.
+> Narrowing the enabled matchers so cheaper ones (`method`, `url`, `host`) reject non-candidates first
+> keeps that cost off the hot path.
+
 ## `post_fields`
 
 - **Compares:** `Request::getPostFields()` — parsed POST field array

--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -110,6 +110,10 @@ class Configuration
         'post_fields' => [RequestMatcher::class, 'matchPostFields'],
         'query_string' => [RequestMatcher::class, 'matchQueryString'],
         'soap_operation' => [RequestMatcher::class, 'matchSoapOperation'],
+        // Listed last on purpose: matchers are ANDed and evaluation short-circuits
+        // on the first failure, so `body` rejects a differing body before this
+        // matcher ever decodes it.
+        'body_json' => [RequestMatcher::class, 'matchBodyJson'],
     ];
 
     /**

--- a/src/VCR/RequestMatcher.php
+++ b/src/VCR/RequestMatcher.php
@@ -33,6 +33,22 @@ class RequestMatcher
         return $storedRequest->getBody() === $request->getBody();
     }
 
+    /**
+     * Compares request bodies as JSON documents instead of raw strings.
+     * Falls back to matchBody() when either body is not a JSON object or array.
+     */
+    public static function matchBodyJson(Request $storedRequest, Request $request): bool
+    {
+        $storedJson = self::decodeJsonBody($storedRequest->getBody());
+        $json = self::decodeJsonBody($request->getBody());
+
+        if (null === $storedJson || null === $json) {
+            return self::matchBody($storedRequest, $request);
+        }
+
+        return self::jsonValuesMatch($storedJson, $json);
+    }
+
     public static function matchPostFields(Request $storedRequest, Request $request): bool
     {
         return $storedRequest->getPostFields() === $request->getPostFields();
@@ -63,5 +79,89 @@ class RequestMatcher
         $operationStoredRequest = $matches[1];
 
         return $operationRequest === $operationStoredRequest;
+    }
+
+    /**
+     * Decodes a request body into a JSON object or array.
+     * Returns null when the body is empty, invalid JSON or a bare scalar.
+     *
+     * @return array<mixed>|\stdClass|null
+     */
+    private static function decodeJsonBody(?string $body): array|\stdClass|null
+    {
+        if (null === $body || '' === trim($body)) {
+            return null;
+        }
+
+        // Objects are decoded to stdClass on purpose: in associative mode
+        // '{"0":"a"}' and '["a"]' decode to the very same PHP value, which
+        // would make an object indistinguishable from an array.
+        // JSON_BIGINT_AS_STRING keeps integers beyond PHP_INT_MAX exact
+        // instead of letting two different integers collapse to one float.
+        $decoded = json_decode($body, false, 512, \JSON_BIGINT_AS_STRING);
+
+        if (\JSON_ERROR_NONE !== json_last_error()) {
+            return null;
+        }
+
+        // A bare scalar body has no ordering ambiguity, so the raw string
+        // comparison of matchBody() is both correct and cheaper.
+        if (!\is_array($decoded) && !$decoded instanceof \stdClass) {
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Compares two decoded JSON values: object key order is ignored,
+     * array element order is significant and scalars are compared strictly.
+     */
+    private static function jsonValuesMatch(mixed $storedValue, mixed $value): bool
+    {
+        if ($storedValue instanceof \stdClass || $value instanceof \stdClass) {
+            if (!$storedValue instanceof \stdClass || !$value instanceof \stdClass) {
+                return false;
+            }
+
+            $storedProperties = get_object_vars($storedValue);
+            $properties = get_object_vars($value);
+
+            if (\count($storedProperties) !== \count($properties)) {
+                return false;
+            }
+
+            foreach ($storedProperties as $key => $storedProperty) {
+                if (!\array_key_exists($key, $properties)) {
+                    return false;
+                }
+
+                if (!self::jsonValuesMatch($storedProperty, $properties[$key])) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        if (\is_array($storedValue) || \is_array($value)) {
+            if (!\is_array($storedValue) || !\is_array($value)) {
+                return false;
+            }
+
+            if (\count($storedValue) !== \count($value)) {
+                return false;
+            }
+
+            foreach ($storedValue as $index => $storedItem) {
+                if (!self::jsonValuesMatch($storedItem, $value[$index])) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return $storedValue === $value;
     }
 }

--- a/src/VCR/RequestMatcher.php
+++ b/src/VCR/RequestMatcher.php
@@ -39,8 +39,18 @@ class RequestMatcher
      */
     public static function matchBodyJson(Request $storedRequest, Request $request): bool
     {
-        $storedJson = self::decodeJsonBody($storedRequest->getBody());
-        $json = self::decodeJsonBody($request->getBody());
+        $storedBody = $storedRequest->getBody();
+        $body = $request->getBody();
+
+        // Identical bodies are semantically equal by definition. Checking this
+        // first keeps the default matcher set — where `body` has already proven
+        // the strings equal before this matcher runs — free of any decoding.
+        if ($storedBody === $body) {
+            return true;
+        }
+
+        $storedJson = self::decodeJsonBody($storedBody);
+        $json = self::decodeJsonBody($body);
 
         if (null === $storedJson || null === $json) {
             return self::matchBody($storedRequest, $request);
@@ -89,7 +99,21 @@ class RequestMatcher
      */
     private static function decodeJsonBody(?string $body): array|\stdClass|null
     {
-        if (null === $body || '' === trim($body)) {
+        if (null === $body) {
+            return null;
+        }
+
+        // Reject anything that cannot be a JSON object or array before paying for
+        // a decode. strspn() walks the leading whitespace without copying the
+        // body, which matters when it is a large upload: a multi-megabyte binary
+        // or XML body is dismissed on its first byte.
+        $offset = strspn($body, " \t\n\r\0\x0B");
+
+        if ($offset === \strlen($body)) {
+            return null;
+        }
+
+        if ('{' !== $body[$offset] && '[' !== $body[$offset]) {
             return null;
         }
 
@@ -104,8 +128,9 @@ class RequestMatcher
             return null;
         }
 
-        // A bare scalar body has no ordering ambiguity, so the raw string
-        // comparison of matchBody() is both correct and cheaper.
+        // The leading-character check above already guarantees this, but
+        // json_decode() is typed as mixed and the guard keeps the return type
+        // honest without trusting that guarantee.
         if (!\is_array($decoded) && !$decoded instanceof \stdClass) {
             return null;
         }

--- a/tests/Unit/CassetteTest.php
+++ b/tests/Unit/CassetteTest.php
@@ -47,6 +47,35 @@ final class CassetteTest extends TestCase
         $this->assertEquals($response->toArray(), $this->cassette->playback($request)?->toArray());
     }
 
+    public function testPlaybackWithBodyJsonMatcherIgnoresObjectKeyOrder(): void
+    {
+        $config = new Configuration();
+        $config->enableRequestMatchers(['method', 'url', 'host', 'query_string', 'body_json']);
+        $cassette = new Cassette('test', $config, new Yaml(vfsStream::url('test/'), 'body_json_test'));
+
+        $recordedRequest = new Request('POST', 'https://example.com/api');
+        $recordedRequest->setBody('{"model":"a","stream":false}');
+        $response = new Response('200', [], 'sometest');
+        $cassette->record($recordedRequest, $response);
+
+        $reorderedRequest = new Request('POST', 'https://example.com/api');
+        $reorderedRequest->setBody('{"stream":false,"model":"a"}');
+
+        $this->assertEquals(
+            $response->toArray(),
+            $cassette->playback($reorderedRequest)?->toArray(),
+            'A body with reordered object keys should replay'
+        );
+
+        $differentRequest = new Request('POST', 'https://example.com/api');
+        $differentRequest->setBody('{"model":"b","stream":false}');
+
+        $this->assertNull(
+            $cassette->playback($differentRequest),
+            'A body with a different value should not replay'
+        );
+    }
+
     public function testHasResponseNotFound(): void
     {
         $request = new Request('GET', 'https://example.com');

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -6,6 +6,7 @@ namespace VCR\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use VCR\Configuration;
+use VCR\Request;
 use VCR\Storage\BlackholeStorageFactory;
 use VCR\Storage\JsonStorageFactory;
 use VCR\Storage\StorageFactoryInterface;
@@ -85,6 +86,65 @@ final class ConfigurationTest extends TestCase
             ],
             $this->config->getRequestMatchers()
         );
+    }
+
+    public function testEnableBodyJsonRequestMatcher(): void
+    {
+        $this->config->enableRequestMatchers(['body_json']);
+        $this->assertEquals(
+            [
+                ['VCR\RequestMatcher', 'matchBodyJson'],
+            ],
+            $this->config->getRequestMatchers()
+        );
+    }
+
+    /**
+     * The `body_json` matcher joins the default matcher set, where it is ANDed with
+     * `body`. Because it can only ever accept what `body` already accepts, the
+     * default matching outcome must stay exactly as it was before it existed.
+     *
+     * @dataProvider defaultMatcherSetBodyProvider
+     */
+    public function testDefaultMatcherSetOutcomeIsUnchangedByBodyJson(?string $storedBody, ?string $body): void
+    {
+        $matchersWithoutBodyJson = [
+            'method', 'url', 'host', 'headers', 'body', 'post_fields', 'query_string', 'soap_operation',
+        ];
+
+        $storedRequest = new Request('POST', 'http://example.com', []);
+        $request = new Request('POST', 'http://example.com', []);
+
+        if (null !== $storedBody) {
+            $storedRequest->setBody($storedBody);
+        }
+
+        if (null !== $body) {
+            $request->setBody($body);
+        }
+
+        $withBodyJson = $storedRequest->matches($request, $this->config->getRequestMatchers());
+
+        $this->config->enableRequestMatchers($matchersWithoutBodyJson);
+        $withoutBodyJson = $storedRequest->matches($request, $this->config->getRequestMatchers());
+
+        $this->assertSame($withoutBodyJson, $withBodyJson);
+    }
+
+    /**
+     * @return array<string, array{0: string|null, 1: string|null}>
+     */
+    public static function defaultMatcherSetBodyProvider(): array
+    {
+        return [
+            'identical bodies' => ['{"a":1,"b":2}', '{"a":1,"b":2}'],
+            'reordered object keys' => ['{"a":1,"b":2}', '{"b":2,"a":1}'],
+            'reordered array elements' => ['["a","b"]', '["b","a"]'],
+            'different bodies' => ['{"a":1}', '{"a":2}'],
+            'invalid json' => ['{"a":1', '{"a":1'],
+            'non json bodies' => ['plain text', 'plain text'],
+            'absent bodies' => [null, null],
+        ];
     }
 
     public function testEnableRequestMatchersFailsWithNoExistingName(): void

--- a/tests/Unit/RequestMatcherTest.php
+++ b/tests/Unit/RequestMatcherTest.php
@@ -141,6 +141,91 @@ final class RequestMatcherTest extends TestCase
         $this->assertFalse(RequestMatcher::matchBody($first, $second), 'Bodies are different.');
     }
 
+    /**
+     * @dataProvider matchingJsonBodiesProvider
+     */
+    public function testMatchingBodyJsonMatches(?string $storedBody, ?string $body, string $message): void
+    {
+        $this->assertTrue(
+            RequestMatcher::matchBodyJson(
+                $this->createRequestWithBody($storedBody),
+                $this->createRequestWithBody($body)
+            ),
+            $message
+        );
+    }
+
+    /**
+     * @dataProvider nonMatchingJsonBodiesProvider
+     */
+    public function testMatchingBodyJsonDoesNotMatch(?string $storedBody, ?string $body, string $message): void
+    {
+        $this->assertFalse(
+            RequestMatcher::matchBodyJson(
+                $this->createRequestWithBody($storedBody),
+                $this->createRequestWithBody($body)
+            ),
+            $message
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string|null, 1: string|null, 2: string}>
+     */
+    public static function matchingJsonBodiesProvider(): array
+    {
+        return [
+            'identical bodies' => ['{"a":1,"b":2}', '{"a":1,"b":2}', 'Identical JSON bodies match'],
+            'reordered object keys' => ['{"a":1,"b":2}', '{"b":2,"a":1}', 'Object key order is ignored'],
+            'reformatted body' => ['{"a":1,"b":2}', "{\n  \"a\" : 1,\n  \"b\" : 2\n}", 'Formatting is ignored'],
+            'reordered nested object keys' => [
+                '{"o":{"x":1,"y":{"p":true,"q":null}}}',
+                '{"o":{"y":{"q":null,"p":true},"x":1}}',
+                'Object key order is ignored at any depth',
+            ],
+            'identical arrays' => ['["a","b"]', '["a","b"]', 'Arrays in the same order match'],
+            'empty objects' => ['{}', '{}', 'Empty objects match'],
+            'both bodies unset' => [null, null, 'Two absent bodies match'],
+            'both bodies empty' => ['', '', 'Two empty bodies match'],
+            'identical invalid json' => ['{"a":1', '{"a":1', 'Invalid JSON falls back to a string comparison'],
+            'identical whitespace only' => ['   ', '   ', 'A whitespace only body falls back to a string comparison'],
+            'identical non json bodies' => ['plain text', 'plain text', 'Non JSON bodies fall back to a string comparison'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{0: string|null, 1: string|null, 2: string}>
+     */
+    public static function nonMatchingJsonBodiesProvider(): array
+    {
+        return [
+            'reordered array elements' => ['["a","b"]', '["b","a"]', 'Array element order is significant'],
+            'reordered nested array elements' => [
+                '{"m":[{"r":"a"},{"r":"b"}]}',
+                '{"m":[{"r":"b"},{"r":"a"}]}',
+                'Array element order is significant at any depth',
+            ],
+            'integer against string' => ['{"a":1}', '{"a":"1"}', 'Scalar types are compared strictly'],
+            'integer against float' => ['{"a":1}', '{"a":1.0}', 'Integers and floats are different'],
+            'integer against boolean' => ['{"a":1}', '{"a":true}', 'Integers and booleans are different'],
+            'null against empty string' => ['{"a":null}', '{"a":""}', 'Null and an empty string are different'],
+            'object against array' => ['{}', '[]', 'An object is not an array'],
+            'numeric keys object against array' => ['{"0":"a"}', '["a"]', 'An object with numeric keys is not an array'],
+            'extra key' => ['{"a":1}', '{"a":1,"b":2}', 'An extra key is a mismatch'],
+            'missing key' => ['{"a":1,"b":2}', '{"a":1}', 'A missing key is a mismatch'],
+            'longer array' => ['["a"]', '["a","b"]', 'A different array length is a mismatch'],
+            'different invalid json' => ['not json', 'also not json', 'Invalid JSON falls back to a string comparison'],
+            'only one side is json' => ['{"a":1}', 'plain text', 'A JSON body does not match a non JSON body'],
+            'absent against empty object' => [null, '{}', 'An absent body does not match an empty object'],
+            'big integers beyond php int max' => [
+                '{"id":9223372036854775808}',
+                '{"id":9223372036854775809}',
+                'Integers beyond PHP_INT_MAX are compared exactly',
+            ],
+            'scalar bodies' => ['5', '5.0', 'Bare scalar bodies fall back to a string comparison'],
+        ];
+    }
+
     public function testMatchingSoapOperation(): void
     {
         $storedRequest = Request::fromArray([
@@ -173,5 +258,16 @@ final class RequestMatcherTest extends TestCase
             'body' => '{}',
         ]);
         $this->assertTrue(RequestMatcher::matchSoapOperation($storedRequest, $request), 'Operation is not SOAP message');
+    }
+
+    private function createRequestWithBody(?string $body): Request
+    {
+        $request = new Request('POST', 'http://example.com', []);
+
+        if (null !== $body) {
+            $request->setBody($body);
+        }
+
+        return $request;
     }
 }

--- a/tests/Unit/RequestMatcherTest.php
+++ b/tests/Unit/RequestMatcherTest.php
@@ -190,6 +190,12 @@ final class RequestMatcherTest extends TestCase
             'identical invalid json' => ['{"a":1', '{"a":1', 'Invalid JSON falls back to a string comparison'],
             'identical whitespace only' => ['   ', '   ', 'A whitespace only body falls back to a string comparison'],
             'identical non json bodies' => ['plain text', 'plain text', 'Non JSON bodies fall back to a string comparison'],
+            'identical bodies with leading whitespace' => [
+                "  \n{\"a\":1}",
+                "  \n{\"a\":1}",
+                'Identical bodies match without being decoded',
+            ],
+            'leading whitespace is ignored' => ["\n\t {\"a\":1,\"b\":2}", '{"b":2,"a":1}', 'Leading whitespace is ignored'],
         ];
     }
 
@@ -223,6 +229,8 @@ final class RequestMatcherTest extends TestCase
                 'Integers beyond PHP_INT_MAX are compared exactly',
             ],
             'scalar bodies' => ['5', '5.0', 'Bare scalar bodies fall back to a string comparison'],
+            'xml bodies' => ['<a><b/></a>', '<a><c/></a>', 'XML bodies fall back to a string comparison'],
+            'binary bodies' => ["\x00\x01\x02", "\x00\x01\x03", 'Binary bodies fall back to a string comparison'],
         ];
     }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Feature
| Fixes            | Fix #506
| BC break?        | no
| Deprecation?     | no
| New dependency?  | no
| Docs updated?    | yes
| License          | MIT

Adds a `body_json` request matcher that compares request bodies as JSON documents instead of raw strings.

`matchBody()` compares bytes, so replay depends on the *serialisation* of a JSON payload rather than on its
meaning. A reordered object key, a reformatted document or a switch between pretty-printed and minified JSON
all break replay for a request the server cannot tell apart. The failure is unhelpful in both record modes:
with `MODE_NONE` the test dies, with `MODE_NEW_EPISODES` a live HTTP call goes out and a near-duplicate
recording is appended. The usual workaround — dropping `body` from `enableRequestMatchers()` — throws away
body matching entirely, which is exactly the discrimination the user wanted.

```php
\VCR\VCR::configure()
    ->enableRequestMatchers(['method', 'url', 'host', 'query_string', 'body_json']);
```

```php
// {"model":"a","stream":false}  vs.  {"stream":false,"model":"a"}  -> match
// ["a","b"]                     vs.  ["b","a"]                     -> no match
// {"n":1}                       vs.  {"n":"1"}                     -> no match
// {}                            vs.  []                            -> no match
```

Object key order is ignored, array element order stays significant, scalars are compared strictly, and key
sets must be equal (it is not a subset matcher). When either body is empty, invalid JSON or a bare scalar it
falls back to the existing `matchBody()` string comparison.

### Implementation notes

Two decisions are worth flagging because the obvious alternatives are subtly wrong:

- Bodies are decoded to `stdClass` rather than in associative mode. `json_decode('{"0":"a"}', true)` and
  `json_decode('["a"]', true)` produce the very same PHP value, which would make an object
  indistinguishable from an array. `array_is_list()` would not have helped, and it needs PHP 8.1 anyway.
- `JSON_BIGINT_AS_STRING` is applied to both sides, so two different integers beyond `PHP_INT_MAX` cannot
  collapse to the same float and match by accident.

Both are covered by tests (`numeric keys object against array`, `big integers beyond php int max`).

### Does this change the default matcher set?

`body_json` is registered in `Configuration::$availableRequestMatchers`, so with the default configuration
(`enabledRequestMatchers === null`) it joins the enabled set. **The matching outcome is unchanged**, because
matchers are ANDed and `body_json` is strictly weaker than `body`:

- if `body` returns `true` the bodies are the identical string, therefore semantically equal, therefore
  `body_json` returns `true`;
- if `body` returns `false` the AND is already `false`.

So `body AND body_json ≡ body`. `testDefaultMatcherSetOutcomeIsUnchangedByBodyJson` asserts this rather than
leaving it as a claim: it runs the full default set against a table of body pairs and compares the result
with and without `body_json` enabled. The entry is also listed **last** in the array, so `body` short-circuits
before anything gets decoded on the failing path.

If you would rather the implicit "all" default stay literally untouched, the matcher can be held in a
separate list consulted only by `enableRequestMatchers()`/`addRequestMatcher()` name resolution — a ~10-line
`Configuration` change that leaves `RequestMatcher` as-is. Happy to switch if you prefer that.

### Backward compatibility

- Public API unchanged; one static method added to `VCR\RequestMatcher`.
- Default behaviour unchanged (asserted, see above).
- Cassette format untouched — this PR only affects matching. Cassettes recorded by any earlier version
  replay identically.
- No new dependency. `ext-json` is always available on PHP 8+ and `Storage\Json` already relies on it.
- PHP 8.0 compatible: only `json_decode`, `json_last_error`, `get_object_vars` and `strspn` are used.

### Docs

- `docs/reference/request-matchers.md` — new `body_json` entry with a `🆕 Since 1.13` callout, nav line and
  the "All 8" → "All 9" count.
- `docs/guides/request-matching.md` — the count, plus a pointer in *Narrowing what matters* explaining that
  swapping `body` for `body_json` is the targeted alternative to dropping body matching.

Both documented snippets are exercised by tests: the `enableRequestMatchers([...])` example and the
key-reordering behaviour are what `CassetteTest::testPlaybackWithBodyJsonMatcherIgnoresObjectKeyOrder`
records and replays through a real `Cassette` + `Yaml` storage.

### Test plan — what I actually ran

40 new cases: 31 in `RequestMatcherTest` across two data providers (reordered object keys, reformatting,
nesting, array order at depth, strict scalar typing, object-vs-array, numeric-key objects, extra/missing
keys, array length, invalid JSON, one-sided JSON, absent and empty bodies, whitespace-only and
leading-whitespace bodies, big integers, bare scalar bodies, XML and binary bodies), 1 in
`ConfigurationTest` for registration plus the 7-case default-set regression provider, and 1 in
`CassetteTest` covering record-then-replay end to end.

Docker matrix, run sequentially, each after its own `composer update`:

| Workspace | Deps | Result |
| --- | --- | --- |
| workspace80 | highest | 595 tests, OK |
| workspace80 | lowest | 595 tests, OK |
| workspace85 | highest | 595 tests, OK |
| workspace85 | lowest | 595 tests, OK |

`composer phpstan`, `composer cs` and `composer ec` on workspace80: all exit 0, no new baseline entries,
`cs-fix` reported 0 of 127 files to fix.

The matrix was re-run in full after the `perf` commit; the numbers above are from that run.

One thing to call out honestly: on workspace85 the run reports 31 PHPUnit deprecations against 28 on an
unmodified `master`. The 3 extra ones are my 3 new `@dataProvider` docblock annotations — I followed the
convention already used throughout `tests/`, so they will disappear with the suite-wide move to attributes
rather than needing anything special here. Say the word if you would prefer attributes in this PR.

Opened #506 with the problem statement and the design questions — happy for the discussion to happen there
rather than in this diff.
